### PR TITLE
Add SiliconLabs codeowners files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default codeowners for the repository
+@SiliconLabsSoftware/matter-maintainer
+
+#codeowners for the CODEOWNERS file
+@SiliconLabsSoftware/matter-admin


### PR DESCRIPTION
#### Description
PR adds an initial version of the Codeowner files to the repository.
Since the CSA codeowners file is in the root, ours in the .github/ takes precedence. 

Github checks in the in the .github first then root and takes the first one it finds.

#### Tests
I'll be able to tests the codeowners automation once the PR is in to avoid adding temporary protections
