### PR TITLE
[SL-ONLY] Fix codeowners typo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default codeowners for the repository
-@SiliconLabsSoftware/matter-maintainer
+* @SiliconLabsSoftware/matter-reviewers
 
 #codeowners for the CODEOWNERS file
 /.github/CODEOWNERS @SiliconLabsSoftware/matter-admin


### PR DESCRIPTION
#### Description
To set default reviewers, you need a `*` add the start of the CODEOWNDERS file. When reading the documentation, that star was lost in all the comments `#` symbol.
