### PR TITLE
[SL-ONLY] Improve codeowners teams logic

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default codeowners for the repository
-* @SiliconLabsSoftware/matter-reviewers
+* @SiliconLabsSoftware/matter-watt-reviewers
 
 #codeowners for the CODEOWNERS file
 /.github/CODEOWNERS @SiliconLabsSoftware/matter-admin


### PR DESCRIPTION
#### Description
Instead of having a single reviewing team. I broke down the teams a nested teams.
matter-watt/reviewers and matter-wifi/reviewers. 

This will give us more flexibility when a futur update when we add the missing review rules.
