### PR TITLE
[SL-Only]Add Matter+zigbee cmp logic On matter commissioning complete

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -74,6 +74,13 @@
 #include <performance_test_commands.h>
 #endif // PERFORMANCE_TEST_ENABLED
 
+// SL-Only
+#include "sl_component_catalog.h"
+#ifdef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
+#include "ZigbeeCallbacks.h"
+#include "sl_cmp_config.h"
+#endif
+
 /**********************************************************
  * Defines and Constants
  *********************************************************/
@@ -873,6 +880,7 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
             AppTask::GetLCD().SetScreen(screen);
         }
 #endif // DISPLAY_ENABLED
+
         if ((event->ThreadConnectivityChange.Result == kConnectivity_Established) ||
             (event->InternetConnectivityChange.IPv6 == kConnectivity_Established))
         {
@@ -916,6 +924,15 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
             ChipLogError(AppServer, "wfx_power_save failed: 0x%lx", err);
         }
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER && RS911X_WIFI */
+// SL-Only
+#ifdef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
+#if defined(SL_MATTER_ZIGBEE_CMP)
+        uint8_t channel = otLinkGetChannel(DeviceLayer::ThreadStackMgrImpl().OTInstance());
+        Zigbee::RequestStart(channel);     // leave handle internally
+#elif defined(SL_MATTER_ZIGBEE_SEQUENTIAL) // Matter Zigbee sequential
+        Zigbee::RequestLeave();
+#endif                                     // SL_MATTER_ZIGBEE_CMP
+#endif                                     // SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
     }
     break;
     default:


### PR DESCRIPTION
Fixes [MATTER-4273](https://jira.silabs.com/browse/MATTER-4273)

Add a snippet of code that was missing from the older branch structure to handle the Zigbee network when matter commissioning completes.

