### PR TITLE
[SL-UP] Resolve build error for 917NCP

### DIFF
--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -80,7 +80,7 @@ public:
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
 #if (SLI_SI91X_ENABLE_BLE || RSI_BLE_ENABLE)
-    static void HandleC3ReadRequest(SilabsBleWrapper::sl_wfx_msg_t * rsi_ble_read_req);
+    static void HandleC3ReadRequest(const SilabsBleWrapper::sl_wfx_msg_t & rsi_ble_read_req);
 #else
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
     static void HandleC3ReadRequest(volatile sl_bt_msg_t * evt);


### PR DESCRIPTION
This PR fixes build errors for 917ncp when additional data advertisement is enabled. This should be upstreamed to CSA master.

#36189 - This PR in CSA master refactored the BLE code. The change that is being pushed in this PR is missing in the CSA PR.

The build error is not seen in CSA as additional data advertisement is disabled by default. But in SLC, the additional data advertisement component is included for 917ncp, so faced the build error.