### PR TITLE
[SL-UP] Skip the OpenThread API call for WiFi builds

### DIFF
--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -413,7 +413,7 @@ static void UART_rx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, ui
 
 #ifdef ENABLE_CHIP_SHELL
     chip::NotifyShellProcess();
-#elif !defined(PW_RPC_ENABLED)
+#elif !defined(PW_RPC_ENABLED) && !defined(SL_WIFI)
     otSysEventSignalPending();
 #endif
 }


### PR DESCRIPTION
Build fails for thermostat-rs911x.slcp if the matter_shell component is excluded. To fix skip the OpenThread API call in uart.cpp in case of WiFi builds. 
Verified in a FULL CI build on the matter_extension repo. 
