### PR TITLE
[SL-UP] Updated return value when null is written as per spec

### DIFF
--- a/src/app/clusters/fan-control-server/fan-control-server.cpp
+++ b/src/app/clusters/fan-control-server/fan-control-server.cpp
@@ -198,7 +198,7 @@ MatterFanControlClusterServerPreAttributeChangedCallback(const ConcreteAttribute
                 }
                 else
                 {
-                    res = Status::WriteIgnored;
+                    res = Status::InvalidInState;
                 }
             }
             else
@@ -234,7 +234,7 @@ MatterFanControlClusterServerPreAttributeChangedCallback(const ConcreteAttribute
             }
             else
             {
-                res = Status::WriteIgnored;
+                res = Status::InvalidInState;
             }
         }
         else

--- a/src/app/tests/suites/TestFanControl.yaml
+++ b/src/app/tests/suites/TestFanControl.yaml
@@ -69,6 +69,8 @@ tests:
       attribute: "PercentSetting"
       arguments:
           value: null
+      response:
+          error: INVALID_IN_STATE
 
     - label: "Read back percent setting"
       command: "readAttribute"
@@ -105,6 +107,8 @@ tests:
       attribute: "SpeedSetting"
       arguments:
           value: null
+      response:
+          error: INVALID_IN_STATE
 
     - label: "Read back speed setting"
       command: "readAttribute"


### PR DESCRIPTION
This PR modifies the return value in the fan-cluster as per spec when NULL is written to percent-setting and speed-setting attributes. 

![image](https://github.com/user-attachments/assets/45181279-7a8b-49cd-bd2f-6905a54bd5fb)
