### PR TITLE
[SL-ONLY]First version of the script to parse git branches for our commits TAG…

### DIFF
--- a/scripts/tools/silabs/retrieve_sl_commits.py
+++ b/scripts/tools/silabs/retrieve_sl_commits.py
@@ -1,0 +1,68 @@
+#! /usr/bin/python3
+import subprocess
+import argparse
+from argparse import RawTextHelpFormatter
+
+def get_git_log(start_sha, end_sha, prefixes):
+    try:
+        # Run the git log command with output format <commit hash> -- <Title>
+        result = subprocess.run(
+            ['git', 'log', '--pretty=format:%H -- %s %s', f'{start_sha}..{end_sha}'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+            text=True
+        )
+       
+        # Split the result into lines
+        log_lines = result.stdout.split('\n')
+       
+        # Initialize a dictionary to hold commits by prefix
+        commits_by_prefix = {prefix: [] for prefix in prefixes}
+       
+        # Filter and group commits based on the prefixes
+        for line in log_lines:
+            for prefix in prefixes:
+                if prefix in line:
+                    commits_by_prefix[prefix].append(line)
+                    break
+       
+        return commits_by_prefix
+   
+    except subprocess.CalledProcessError as e:
+        print(f"Error running git log: {e}")
+        return {}
+
+def main():
+    parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter, description="""
+    This script will parse git logs for our silabs prefixes ([SL-UP], [SL-TEMP], [SL-ONLY] or [CSA-CP]) between the commit SHAs provided in parameters
+    on the current git branch.
+    It will then output, per prefix, the commit sha and commit Title in the following format)
+    [PREFIX] commits:
+    <full_commit_sha> -- <Commit_Title>
+    """,
+    epilog= """
+    Post result developer actions:
+       commits grouped under [SL-UP] shall be upstream the CSA master.
+       commits grouped under [SL-ONLY] shall be cherry-picked to matter_sdk main branch.
+       commits grouped under [SL-TEMP] must be revised. Are they still required, are they needed on main or for the next release. If they are, they need to be cherry-picked.
+       commits grouped under [CSA-PR] are purely informative. They already exist in CSA master and will automatically be brought to main or the new release branch through csa master merges.
+    """)
+    parser.add_argument('start_sha', type=str, help='The starting commit SHA')
+    parser.add_argument('end_sha', type=str, help='The ending commit SHA')
+
+    args = parser.parse_args()
+   
+    start_sha = args.start_sha
+    end_sha = args.end_sha
+    prefixes = ["[SL-UP]", "[SL-TEMP]", "[SL-ONLY]", "[CSA-CP]"]
+
+    commits_by_prefix = get_git_log(start_sha, end_sha, prefixes)
+    for prefix, commits in commits_by_prefix.items():
+        print(f"{prefix} commits:")
+        for commit in commits:
+            print(commit)
+        print()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…S/prefix

run `python3 retrieve_sl_commits.py -h` will provide the description on this script, how to use it and the expected actions relative to the results

**help**
```
usage: retrieve_sl_commits.py [-h] start_sha end_sha

    This script will parse git logs for our silabs prefixes ([SL-UP], [SL-TEMP], [SL-ONLY] or [CSA-CP]) between the commit SHAs provided in parameters
    on the current git branch.
    It will then output, per prefix, the commit sha and commit Title in the following format)
    [PREFIX] commits:
    <full_commit_sha> -- <Commit_Title>


positional arguments:
  start_sha   The starting commit SHA
  end_sha     The ending commit SHA

options:
  -h, --help  show this help message and exit

    Post result developer actions:
       commits grouped under [SL-UP] shall be upstream the CSA master.
       commits grouped under [SL-ONLY] shall be cherry-picked to matter_sdk main branch.
       commits grouped under [SL-TEMP] must be revised. Are they still required, are they needed on main or for the next release. If they are, they need to be cherry-picked.
       commits grouped under [CSA-PR] are purely informative. They already exist in CSA master and will automatically be brought to main or the new release branch through csa master merges.
```

Output example
```
[SL-UP] commits:
d22a2e2cb5b551d70dbafe4e33be4073badd0c20 -- [SL-UP] 917 static variable retention fix (#79) [SL-UP] 917 static variable retention fix (#79)
955ddd4c7ff01b24f53c568a3008558b85638540 -- [SL-UP] Split unique id and persistent unique (#78) [SL-UP] Split unique id and persistent unique (#78)
260f1edcaeb73decaee48fcd21b79f1529eea2a9 -- [SL-UP] Skip the OpenThread API call for WiFi builds (#76) [SL-UP] Skip the OpenThread API call for WiFi builds (#76)
c93e36f97be89160638bb7e36c72503d8103c066 -- [SL-UP] Resolve build error for 917NCP (#70) [SL-UP] Resolve build error for 917NCP (#70)

[SL-TEMP] commits:
fb3295c3eb21a837225108a3806c817550266645 -- [SL-TEMP]Add Matter+zigbee cmp logic On matter commissioning complete (#66) [SL-TEMP]Add Matter+zigbee cmp logic On matter commissioning complete (#66)
9101fb436b31ecd7a475235790810e6425cb70d3 -- [SL-TEMP] Add codeowners file to the release branch (#64) [SL-TEMP] Add codeowners file to the release branch (#64)

[SL-ONLY] commits:

[CSA-CP] commits:
934ac68b8d68ff1f7e38f7741a40ff748906488a -- [CSA-CP] Test event trigger slc support (#77) [CSA-CP] Test event trigger slc support (#77)
0bfd1972873b33615a8c179db4b2e4bbd70770d1 -- [CSA-CP][Silabs] Configure Light-Switch as a LIT ICD app (#36221) (#75) [CSA-CP][Silabs] Configure Light-Switch as a LIT ICD app (#36221) (#75)
e4ab2f842a306623d395265389bc0d8878fbcb97 -- [CSA-CP] Fix thermostat hang issue for SOC. (#73) [CSA-CP] Fix thermostat hang issue for SOC. (#73)
59328fcd6ff82b08a0a0706a78b5a7539f5430d1 -- [CSA-CP][ICD] Set MaximumCheckInBackOff to external and fix define guards for… (#72) [CSA-CP][ICD] Set MaximumCheckInBackOff to external and fix define guards for… (#72)
779fb67a0af8b8269d877ac3f63745242c53c37e -- [CSA-CP] Modify region code for module boards(brd4343a) (#69) [CSA-CP] Modify region code for module boards(brd4343a) (#69)
```