### PR TITLE
[CSA-CP]Provision SPAM

### DIFF
--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -17,7 +17,6 @@
 #include "AttestationKey.h"
 #include "ProvisionStorage.h"
 #include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <em_device.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
@@ -28,6 +27,7 @@
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/silabs/MigrationManager.h>
 #include <platform/silabs/SilabsConfig.h>
+#include <platform/silabs/platformAbstraction/SilabsPlatform.h>
 #include <silabs_creds.h>
 #ifndef NDEBUG
 #if defined(SL_MATTER_TEST_EVENT_TRIGGER_ENABLED) && (SL_MATTER_GN_BUILD == 0)
@@ -37,16 +37,7 @@
 #ifdef OTA_ENCRYPTION_ENABLE
 #include <platform/silabs/multi-ota/OtaTlvEncryptionKey.h>
 #endif // OTA_ENCRYPTION_ENABLE
-#ifdef SLI_SI91X_MCU_INTERFACE
-#include <sl_si91x_common_flash_intf.h>
-#else
-#ifdef _SILICON_LABS_32B_SERIES_2
-#include <em_msc.h>
-#elif defined(_SILICON_LABS_32B_SERIES_3)
-#include "sl_se_manager.h"
-#include "sl_se_manager_types.h"
-#include <sl_se_manager_extmem.h>
-#endif // _SILICON_LABS_32B_SERIES_2
+#ifndef SLI_SI91X_MCU_INTERFACE
 #include <psa/crypto.h>
 #endif
 
@@ -55,16 +46,6 @@ extern void setNvm3End(uint32_t addr);
 #elif !SL_MATTER_GN_BUILD
 #include <sl_matter_provision_config.h>
 #endif
-
-#if defined(_SILICON_LABS_32B_SERIES_3)
-// To remove any ambiguities regarding the Flash aliases, use the below macro to ignore the 8 MSB.
-#define FLASH_GENERIC_MASK 0x00FFFFFF
-#define GENERIC_ADDRESS(addr) ((addr) &FLASH_GENERIC_MASK)
-
-// Transforms any address into an address using the same alias as FLASH_BASE from the CMSIS.
-#define CMSIS_CONVERTED_ADDRESS(addr) (GENERIC_ADDRESS(addr) | FLASH_BASE)
-sl_se_command_context_t cmd_ctx;
-#endif // _SILICON_LABS_32B_SERIES_3
 
 extern uint8_t linker_nvm_end[];
 
@@ -86,42 +67,12 @@ size_t sCredentialsOffset     = 0;
 
 CHIP_ERROR ErasePage(uint32_t addr)
 {
-#ifdef SLI_SI91X_MCU_INTERFACE
-    rsi_flash_erase_sector((uint32_t *) addr);
-#elif defined(_SILICON_LABS_32B_SERIES_2)
-    MSC_ErasePage((uint32_t *) addr);
-#elif defined(_SILICON_LABS_32B_SERIES_3)
-    sl_status_t status;
-    uint32_t * data_start = NULL;
-    size_t data_size;
-
-    status = sl_se_data_region_get_location(&cmd_ctx, (void **) &data_start, &data_size);
-    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR(status));
-    VerifyOrReturnError(GENERIC_ADDRESS(addr) > GENERIC_ADDRESS((uint32_t) data_start), CHIP_ERROR_INVALID_ADDRESS);
-    status = sl_se_data_region_erase(&cmd_ctx, (void *) addr, 1); // Erase one page
-    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR(status));
-#endif
-    return CHIP_NO_ERROR;
+    return chip::DeviceLayer::Silabs::GetPlatform().FlashErasePage(addr);
 }
 
 CHIP_ERROR WritePage(uint32_t addr, const uint8_t * data, size_t size)
 {
-#ifdef SLI_SI91X_MCU_INTERFACE
-    rsi_flash_write((uint32_t *) addr, (unsigned char *) data, size);
-#elif defined(_SILICON_LABS_32B_SERIES_2)
-    MSC_WriteWord((uint32_t *) addr, data, size);
-#elif defined(_SILICON_LABS_32B_SERIES_3)
-    sl_status_t status;
-    uint32_t * data_start = NULL;
-    size_t data_size;
-
-    status = sl_se_data_region_get_location(&cmd_ctx, (void **) &data_start, &data_size);
-    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR(status));
-    VerifyOrReturnError(GENERIC_ADDRESS(addr) > GENERIC_ADDRESS((uint32_t) data_start), CHIP_ERROR_INVALID_ADDRESS);
-    status = sl_se_data_region_write(&cmd_ctx, (void *) addr, data, size);
-    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR(status));
-#endif
-    return CHIP_NO_ERROR;
+    return chip::DeviceLayer::Silabs::GetPlatform().FlashWritePage(addr, data, size);
 }
 
 size_t RoundNearest(size_t n, size_t multiple)
@@ -203,16 +154,8 @@ CHIP_ERROR Storage::Initialize(uint32_t flash_addr, uint32_t flash_size)
     {
 #ifndef SLI_SI91X_MCU_INTERFACE
         base_addr = (flash_addr + flash_size - FLASH_PAGE_SIZE);
-
-#ifdef _SILICON_LABS_32B_SERIES_2
-        MSC_Init();
-#elif defined(_SILICON_LABS_32B_SERIES_3)
-        sl_status_t status;
-        status = sl_se_init();
-        VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
-        status = sl_se_init_command_context(&cmd_ctx);
-#endif // _SILICON_LABS_32B_SERIES
 #endif // SLI_SI91X_MCU_INTERFACE
+        chip::DeviceLayer::Silabs::GetPlatform().FlashInit();
 #ifdef SL_PROVISION_GENERATOR
         setNvm3End(base_addr);
 #endif

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -15,12 +15,17 @@
  *    limitations under the License.
  */
 
+#include <em_device.h>
+#include <lib/support/CodeUtils.h>
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
-
 #if defined(_SILICON_LABS_32B_SERIES_2)
+#include "em_msc.h"
 #include "em_rmu.h"
-#else
+#elif defined(_SILICON_LABS_32B_SERIES_3)
 #include "sl_hal_emu.h"
+#include "sl_se_manager.h"
+#include "sl_se_manager_types.h"
+#include <sl_se_manager_extmem.h>
 #endif // _SILICON_LABS_32B_SERIES_2
 #include "sl_system_kernel.h"
 
@@ -65,6 +70,18 @@ extern "C" {
 #include "silabs_utils.h"
 #endif
 
+#if defined(_SILICON_LABS_32B_SERIES_3)
+// To remove any ambiguities regarding the Flash aliases, use the below macro to ignore the 8 MSB.
+#define FLASH_GENERIC_MASK 0x00FFFFFF
+#define GENERIC_ADDRESS(addr) ((addr) &FLASH_GENERIC_MASK)
+
+// Transforms any address into an address using the same alias as FLASH_BASE from the CMSIS.
+#define CMSIS_CONVERTED_ADDRESS(addr) (GENERIC_ADDRESS(addr) | FLASH_BASE)
+namespace {
+sl_se_command_context_t cmd_ctx;
+}
+#endif // _SILICON_LABS_32B_SERIES_3
+
 namespace chip {
 namespace DeviceLayer {
 namespace Silabs {
@@ -103,6 +120,56 @@ CHIP_ERROR SilabsPlatform::Init(void)
 
 #if SILABS_LOG_ENABLED
     silabsInitLog();
+#endif
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SilabsPlatform::FlashInit()
+{
+#if defined(_SILICON_LABS_32B_SERIES_2)
+    MSC_Init();
+#elif defined(_SILICON_LABS_32B_SERIES_3)
+    sl_status_t status;
+    status = sl_se_init();
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR(status));
+    status = sl_se_init_command_context(&cmd_ctx);
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR(status));
+#endif
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SilabsPlatform::FlashErasePage(uint32_t addr)
+{
+#if defined(_SILICON_LABS_32B_SERIES_2)
+    MSC_ErasePage((uint32_t *) addr);
+#elif defined(_SILICON_LABS_32B_SERIES_3)
+    sl_status_t status;
+    uint32_t * data_start = NULL;
+    size_t data_size;
+
+    status = sl_se_data_region_get_location(&cmd_ctx, (void **) &data_start, &data_size);
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR(status));
+    VerifyOrReturnError(GENERIC_ADDRESS(addr) > GENERIC_ADDRESS((uint32_t) data_start), CHIP_ERROR_INVALID_ADDRESS);
+    status = sl_se_data_region_erase(&cmd_ctx, (void *) addr, 1); // Erase one page
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR(status));
+#endif
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SilabsPlatform::FlashWritePage(uint32_t addr, const uint8_t * data, size_t size)
+{
+#if defined(_SILICON_LABS_32B_SERIES_2)
+    MSC_WriteWord((uint32_t *) addr, data, size);
+#elif defined(_SILICON_LABS_32B_SERIES_3)
+    sl_status_t status;
+    uint32_t * data_start = NULL;
+    size_t data_size;
+
+    status = sl_se_data_region_get_location(&cmd_ctx, (void **) &data_start, &data_size);
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR(status));
+    VerifyOrReturnError(GENERIC_ADDRESS(addr) > GENERIC_ADDRESS((uint32_t) data_start), CHIP_ERROR_INVALID_ADDRESS);
+    status = sl_se_data_region_write(&cmd_ctx, (void *) addr, data, size);
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR(status));
 #endif
     return CHIP_NO_ERROR;
 }

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -57,6 +57,10 @@ public:
 
     void StartScheduler(void) override;
 
+    CHIP_ERROR FlashInit() override;
+    CHIP_ERROR FlashErasePage(uint32_t addr) override;
+    CHIP_ERROR FlashWritePage(uint32_t addr, const uint8_t * data, size_t size) override;
+
 private:
     friend SilabsPlatform & GetPlatform(void);
 

--- a/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
@@ -51,6 +51,11 @@ public:
     virtual bool GetLedState(uint8_t led) { return 0; }
     virtual CHIP_ERROR ToggleLed(uint8_t led) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
+    // Flash
+    virtual CHIP_ERROR FlashInit() { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    virtual CHIP_ERROR FlashErasePage(uint32_t addr) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    virtual CHIP_ERROR FlashWritePage(uint32_t addr, const uint8_t * data, size_t size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
     // BLE Specific Method
 
 protected:

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -17,11 +17,13 @@
 
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
 #include <sl_si91x_button_pin_config.h>
+#include <sl_si91x_common_flash_intf.h>
 
 #include <FreeRTOS.h>
 #include <task.h>
 
 #include <app/icd/server/ICDServerConfig.h>
+#include <lib/support/CodeUtils.h>
 
 #include <lib/support/CodeUtils.h>
 #if SILABS_LOG_ENABLED
@@ -190,6 +192,23 @@ void sl_button_on_change(uint8_t btn, uint8_t btnAction)
 uint8_t SilabsPlatform::GetButtonState(uint8_t button)
 {
     return (button < SL_SI91x_BUTTON_COUNT) ? sButtonStates[button] : 0;
+}
+
+CHIP_ERROR SilabsPlatform::FlashInit()
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SilabsPlatform::FlashErasePage(uint32_t addr)
+{
+    rsi_flash_erase_sector((uint32_t *) addr);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SilabsPlatform::FlashWritePage(uint32_t addr, const uint8_t * data, size_t size)
+{
+    rsi_flash_write((uint32_t *) addr, (unsigned char *) data, size);
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Silabs


### PR DESCRIPTION
Make abstractions of the different platforms' flash APIs in our SPAM. Use this abstraction for our provision storage to align code in a single structure

-     Updated the GsdkSpam for series 3 now that provisioning relies on it
-     Updated provisioning to use Silabs Platform Abstraction Manager

