### PR TITLE
[SL-UP] Dont use configRUN_FREERTOS_SECURE_ONLY for s3

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -204,8 +204,10 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 
 #define configENABLE_FPU 1
 #define configENABLE_MPU 0
+#ifndef _SILICON_LABS_32B_SERIES_3
 /* FreeRTOS Secure Side Only and TrustZone Security Extension */
 #define configRUN_FREERTOS_SECURE_ONLY 1
+#endif
 #define configENABLE_TRUSTZONE 0
 /* FreeRTOS MPU specific definitions. */
 #define configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS (0)


### PR DESCRIPTION
Not supported for series 3. at least for now
