### PR TITLE
[SL-UP] Change freertos include used to fix the macro not found

### DIFF
--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "SoftwareFaultReports.h"
-#include "FreeRTOS.h"
+#include "FreeRTOSConfig.h"
 #include "silabs_utils.h"
 #include <app/clusters/software-diagnostics-server/software-diagnostics-server.h>
 #include <app/util/attribute-storage.h>


### PR DESCRIPTION
Issue :
hitting 
`matter_sdk/examples/platform/silabs/SoftwareFaultReports.cpp:123:5: error: 'configASSERTNULL' was not declared in this scope; did you mean 'configASSERT'?` with sisdk 2024.12.0

the macro is defined in `FreeRTOSConfig.h `so use that include rather than 
`FreeRTOS.h`