### PR TITLE
[SL-TEMP] Don't assert app on display enable fail

### DIFF
--- a/examples/platform/silabs/display/lcd.cpp
+++ b/examples/platform/silabs/display/lcd.cpp
@@ -45,7 +45,6 @@
 static uint8_t qrCode[qrcodegen_BUFFER_LEN_FOR_VERSION(QR_CODE_VERSION)];
 static uint8_t workBuffer[qrcodegen_BUFFER_LEN_FOR_VERSION(QR_CODE_VERSION)];
 #endif // QR_CODE_ENABLED
-
 CHIP_ERROR SilabsLCD::Init(uint8_t * name, bool initialState)
 {
     EMSTATUS status;
@@ -72,8 +71,8 @@ CHIP_ERROR SilabsLCD::Init(uint8_t * name, bool initialState)
     status = sl_board_enable_display();
     if (status != SL_STATUS_OK)
     {
+        // sl-temp: S3 display isn't working yet, don't crash app for this.
         SILABS_LOG("Board Display enable fail %d", status);
-        err = CHIP_ERROR_INTERNAL;
     }
 #endif
 


### PR DESCRIPTION
The LCD Display is not working on brd1019a yet. Do not crash the app if the display enable returns a failure. Log it and continue without the display.

