### PR TITLE
[SL-TEMP] Fix for access point power cycle rejoin issue with ecosystem

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -692,15 +692,10 @@ static sl_status_t wfx_rsi_do_join(void)
 
     // failure only happens when the firmware returns an error
     ChipLogError(DeviceLayer, "wfx_rsi_do_join: sl_wifi_connect failed: 0x%lx", static_cast<uint32_t>(status));
-    VerifyOrReturnError((wfx_rsi.join_retries <= MAX_JOIN_RETRIES_COUNT), status);
 
     wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED);
     ChipLogProgress(DeviceLayer, "wfx_rsi_do_join: retry attempt %d", wfx_rsi.join_retries);
     wfx_retry_connection(++wfx_rsi.join_retries);
-
-    WfxEvent_t event;
-    event.eventType = WFX_EVT_STA_START_JOIN;
-    WfxPostEvent(&event);
 
     return status;
 }


### PR DESCRIPTION
- The unnecessary join events have been removed. The join event is posted multiple times, causing issues with the ecosystem during AP power cycles. 
- The join retry limit has been removed. During the commissioning process, the MAX_JOIN_RETRIES_COUNT is set to 5, and this limit should be removed once commissioning is successful

Fixes https://jira.silabs.com/browse/MATTER-4297