### PR TITLE
[SL-TEMP]fix missing sl status for cmsis os2 common

### DIFF
--- a/examples/platform/silabs/MatterShell.cpp
+++ b/examples/platform/silabs/MatterShell.cpp
@@ -17,6 +17,7 @@
 
 #include "MatterShell.h"
 #include "sl_component_catalog.h"
+#include "sl_status.h"
 #include <ChipShellCollection.h>
 #include <cmsis_os2.h>
 #include <lib/core/CHIPCore.h>


### PR DESCRIPTION
Temp fix: add` include sl_status.h` because the following `sl_cmsis_os2_common.h` include sisdk header needs it and doesn't specify it