### PR TITLE
[SL-UP] Add BRD4338A support for Wiseconnect 3.4 in GN

### DIFF
--- a/examples/platform/silabs/ldscripts/SiWx917-common.ld
+++ b/examples/platform/silabs/ldscripts/SiWx917-common.ld
@@ -153,7 +153,7 @@ SECTIONS
     *sl_core_cortexm.c.o(.text*)
 
 		/* ipmu calibration data */
-		*(.common_ipmu_ram*)
+    *(.common_ipmu_ram*)
 
     . = ALIGN(4);
     /* preinit data */

--- a/examples/platform/silabs/ldscripts/SiWx917-common.ld
+++ b/examples/platform/silabs/ldscripts/SiWx917-common.ld
@@ -152,7 +152,7 @@ SECTIONS
     *sl_si91x_low_power_tickless_mode.c.o(.text*)
     *sl_core_cortexm.c.o(.text*)
 
-		/* ipmu calibration data */
+    /* ipmu calibration data */
     *(.common_ipmu_ram*)
 
     . = ALIGN(4);

--- a/examples/platform/silabs/ldscripts/SiWx917-common.ld
+++ b/examples/platform/silabs/ldscripts/SiWx917-common.ld
@@ -152,6 +152,9 @@ SECTIONS
     *sl_si91x_low_power_tickless_mode.c.o(.text*)
     *sl_core_cortexm.c.o(.text*)
 
+		/* ipmu calibration data */
+		*(.common_ipmu_ram*)
+
     . = ALIGN(4);
     /* preinit data */
     PROVIDE_HIDDEN (__preinit_array_start = .);

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -151,6 +151,7 @@ template("siwx917_sdk") {
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/inc",
 
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/power_manager/inc",
+      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/clock_manager/inc",
     ]
 
     if (sl_enable_rgb_led) {
@@ -617,11 +618,13 @@ template("siwx917_sdk") {
       "${efr32_sdk_root}/platform/common/src/sl_assert.c",
       "${efr32_sdk_root}/platform/common/src/sl_core_cortexm.c",
       "${efr32_sdk_root}/platform/common/src/sl_slist.c",
+      "${efr32_sdk_root}/platform/common/src/sl_string.c",
       "${efr32_sdk_root}/platform/common/src/sli_cmsis_os2_ext_task_register.c",
       "${efr32_sdk_root}/util/third_party/freertos/cmsis/Source/cmsis_os2.c",
       "${wifi_sdk_root}/components/protocol/wifi/si91x/sl_wifi.c",
 
       # wifi component
+      "${wifi_sdk_root}/components/protocol/wifi/src/sl_wifi_basic_credentials.c",
       "${wifi_sdk_root}/components/protocol/wifi/src/sl_wifi_callback_framework.c",
       "${wifi_sdk_root}/components/service/network_manager/src/sl_net.c",
 
@@ -629,8 +632,8 @@ template("siwx917_sdk") {
       "${wifi_sdk_root}/components/service/network_manager/src/sl_net_basic_certificate_store.c",
 
       # basic_network_manager component
-      "${wifi_sdk_root}/components/service/network_manager/src/sl_net_basic_credentials.c",
       "${wifi_sdk_root}/components/service/network_manager/src/sl_net_basic_profiles.c",
+      "${wifi_sdk_root}/components/service/network_manager/src/sl_net_credentials.c",
 
       # ble component
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/ble/src/rsi_ble_gap_apis.c",
@@ -653,19 +656,27 @@ template("siwx917_sdk") {
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/core/config/src/rsi_nvic_priorities_config.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/cmsis_driver/UDMA.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/cmsis_driver/USART.c",
+      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/aux_reference_volt_config.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/clock_update.c",
+      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_adc.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_crc.c",
+      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_dac.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_egpio.c",
+      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_opamp.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_spi.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_timers.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_udma.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_udma_wrapper.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_usart.c",
+      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_bod.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_ipmu.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_pll.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_power_save.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_temp_sensor.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_ulpss_clk.c",
+      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_adc.c",
+      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_bjt_temperature_sensor.c",
+      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_dma.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_driver_gpio.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_peripheral_drivers/src/sl_si91x_peripheral_gpio.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_ram.c",
@@ -678,10 +689,10 @@ template("siwx917_sdk") {
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/host_mcu/si91x/siwx917_soc_ncp_host.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/memory/malloc_buffers.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/sl_net/src/sl_net_rsi_utility.c",
+      "${wifi_sdk_root}/components/device/silabs/si91x/wireless/sl_net/src/sl_net_si91x_callback_framework.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/sl_net/src/sl_net_si91x_integration_handler.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/sl_net/src/sl_si91x_net_credentials.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/src/sl_rsi_utility.c",
-      "${wifi_sdk_root}/components/device/silabs/si91x/wireless/src/sl_si91x_callback_framework.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/src/sl_si91x_driver.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/threading/sli_si91x_multithreaded.c",
 
@@ -706,6 +717,8 @@ template("siwx917_sdk") {
       "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_ulp_timer_init.c",
       "${sdk_support_root}/matter/si91x/support/hal/rsi_hal_mcu_m4.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/button/src/sl_si91x_button.c",
+      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/clock_manager/src/sl_si91x_clock_manager.c",
+      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/clock_manager/src/sli_si91x_clock_manager.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/nvm3/src/sl_si91x_nvm3_hal_flash.c",
 
       # sl memory manager

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -76,7 +76,8 @@ if (silabs_board == "") {
 assert(silabs_board != "", "silabs_board must be specified")
 
 # Si917 WIFI board ----------
-if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A" || silabs_board == "BRD4343A") {
+if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A" ||
+    silabs_board == "BRD4343A") {
   if (silabs_board == "BRD2605A") {
     sl_enable_rgb_led = true
   }


### PR DESCRIPTION
#### Description
Adds support for wiseconnect 3.4.0 in the GN build system. PR doesn't bring support for all boards.
Only the BRD4338A was tested. 

