### PR TITLE
[SL-ONLY] Add structure for the SleepManager class

### DIFF
--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -174,6 +174,10 @@ source_set("siwx917-common") {
     }
   }
 
+  if (chip_enable_icd_server) {
+    public_deps += [ "${silabs_common_plat_dir}/wifi/icd:sleep-manager" ]
+  }
+
   # DIC
   if (enable_dic) {
     public_deps +=

--- a/examples/platform/silabs/wifi/icd/BUILD.gn
+++ b/examples/platform/silabs/wifi/icd/BUILD.gn
@@ -1,0 +1,37 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+config("sleep-manager-config") {
+  include_dirs = [ "." ]
+  defines = []
+}
+
+source_set("sleep-manager") {
+  sources = [
+    "SiWxSleepManager.cpp",
+    "SiWxSleepManager.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/app:app",
+    "${chip_root}/src/app/icd/server:manager",
+    "${chip_root}/src/app/icd/server:observer",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+  ]
+
+  public_configs = [ ":sleep-manager-config" ]
+}

--- a/examples/platform/silabs/wifi/icd/SleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/SleepManager.cpp
@@ -1,0 +1,56 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "SleepManager.h"
+
+using namespace chip::app;
+
+namespace chip {
+namespace DeviceLayer {
+namespace Silabs {
+
+// Initialize the static instance
+SleepManager SleepManager::mInstance;
+
+CHIP_ERROR SleepManager::Init()
+{
+    // Initialization logic
+    return CHIP_NO_ERROR;
+}
+
+void SleepManager::OnEnterActiveMode()
+{
+    // Execution logic for entering active mode
+}
+
+void SleepManager::OnEnterIdleMode()
+{
+    // Execution logic for entering idle mode
+}
+
+void SleepManager::OnSubscriptionEstablished(ReadHandler & aReadHandler)
+{
+    // Implement logic for when a subscription is established
+}
+
+void SleepManager::OnSubscriptionTerminated(ReadHandler & aReadHandler)
+{
+    // Implement logic for when a subscription is terminated
+}
+
+} // namespace Silabs
+} // namespace DeviceLayer
+} // namespace chip

--- a/examples/platform/silabs/wifi/icd/SleepManager.h
+++ b/examples/platform/silabs/wifi/icd/SleepManager.h
@@ -1,0 +1,73 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+#pragma once
+
+#include <app/ReadHandler.h>
+#include <app/icd/server/ICDManager.h>
+#include <app/icd/server/ICDStateObserver.h>
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Silabs {
+
+/**
+ * @brief SleepManager is a singleton class that manages the sleep modes for Wi-Fi devices.
+ *        The class contains the buisness logic associated with optimizing the sleep states based on the Matter SDK internal states
+ *
+ *        The class implements two disctint optimization states; one of SIT devices and one of LIT devices
+ *        For SIT ICDs, the logic is based on the Subscriptions established with the device.
+ *        For LIT ICDs, the logic is based on the ICDManager operating modes. The LIT mode also utilizes the SIT mode logic.
+ */
+class SleepManager : public chip::app::ICDStateObserver, public chip::app::ReadHandler::ApplicationCallback
+{
+public:
+    SleepManager(const SleepManager &)             = delete;
+    SleepManager & operator=(const SleepManager &) = delete;
+
+    static SleepManager & GetInstance() { return mInstance; }
+
+    /**
+     * @brief Init function that configure the SleepManager APIs based on the type of ICD
+     *        SIT ICD: Init function registers the ReadHandler Application callback to be notified when a subscription is
+     *                 established or destroyed.
+     *
+     *        LIT ICD: Init function registers with the ICDManager as an observer to be notified of the ICD mode changes.
+     *
+     * @return CHIP_ERROR
+     */
+    CHIP_ERROR Init();
+
+    // ICDSateObserver implementation overrides
+
+    void OnEnterActiveMode() override;
+    void OnEnterIdleMode() override;
+    void OnTransitionToIdle() override { /* No execution logic */ }
+    void OnICDModeChange() override { /* No execution logic */ }
+
+    // ReadHandler::ApplicationCallback implementation overrides
+
+    void OnSubscriptionEstablished(chip::app::ReadHandler & aReadHandler);
+    void OnSubscriptionTerminated(chip::app::ReadHandler & aReadHandler);
+
+private:
+    SleepManager()  = default;
+    ~SleepManager() = default;
+
+    static SleepManager mInstance;
+};
+
+} // namespace Silabs
+} // namespace DeviceLayer
+} // namespace chip


### PR DESCRIPTION
#### Description
PR introduces the SleepManager class which will be responsible of managing the sleep states of the Wi-Fi chip.
PR brings not functionnal changes, it just creates the necessary classes to simplify reviews in follow up PRs.

**Note to reviews:** The class is only being added to the 917 as the first support. Support for other chips will be done once the feature is completed.

#### Tests
It builds
