### PR TITLE
[SL-UP] Delete unnecessary double abstraction for the wiseconnect power save functions

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -545,37 +545,6 @@ int32_t sl_wifi_platform_disconnect(void)
     return sl_net_down((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE);
 }
 
-/******************************************************************
- * @fn   wfx_rsi_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state)
- * @brief
- *       Setting the RS911x in DTIM sleep based mode
- *
- * @param[in] sl_si91x_ble_state : State to set for the BLE
- * @param[in] sl_si91x_wifi_state : State to set for the WiFi
- * @return
- *        None
- *********************************************************************/
-int32_t wfx_rsi_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state)
-{
-    int32_t status;
-
-    status = rsi_bt_power_save_profile(sl_si91x_ble_state, 0);
-    if (status != RSI_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: 0x%lx", static_cast<uint32_t>(status));
-        return status;
-    }
-    sl_wifi_performance_profile_t wifi_profile = { .profile = sl_si91x_wifi_state };
-    status                                     = sl_wifi_set_performance_profile(&wifi_profile);
-    if (status != RSI_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile failed: 0x%lx", static_cast<uint32_t>(status));
-        return status;
-    }
-
-    return status;
-}
-
 sl_status_t show_scan_results(sl_wifi_scan_result_t * scan_result)
 {
     SL_WIFI_ARGS_CHECK_NULL_POINTER(scan_result);
@@ -894,9 +863,23 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
  * @return  SL_STATUS_OK if successful,
  *          SL_STATUS_FAIL otherwise
  ***********************************************************************/
-sl_status_t wfx_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state,
-                           sl_si91x_performance_profile_t sl_si91x_wifi_state) // TODO : Figure out why the extern C is necessary
+sl_status_t wfx_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state)
 {
-    return (wfx_rsi_power_save(sl_si91x_ble_state, sl_si91x_wifi_state) ? SL_STATUS_FAIL : SL_STATUS_OK);
+    int32_t error = rsi_bt_power_save_profile(sl_si91x_ble_state, 0);
+    if (error != RSI_SUCCESS)
+    {
+        ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: %ld", error);
+        return SL_STATUS_FAIL;
+    }
+
+    sl_wifi_performance_profile_t wifi_profile = { .profile = sl_si91x_wifi_state };
+    sl_status_t status                         = sl_wifi_set_performance_profile(&wifi_profile);
+    if (status != SL_STATUS_OK)
+    {
+        ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile failed: 0x%lx", static_cast<uint32_t>(status));
+        return status;
+    }
+
+    return SL_STATUS_OK;
 }
 #endif

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
@@ -51,7 +51,7 @@ osTimerId_t sRetryTimer;
 void RetryConnectionTimerHandler(void * arg)
 {
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI91X_MCU_INTERFACE
-    wfx_rsi_power_save(RSI_ACTIVE, HIGH_PERFORMANCE);
+    wfx_power_save(RSI_ACTIVE, HIGH_PERFORMANCE);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI91X_MCU_INTERFACE
     if (wfx_connect_to_ap() != SL_STATUS_OK)
     {
@@ -192,7 +192,7 @@ void wfx_retry_connection(uint16_t retryAttempt)
         return;
     }
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI91X_MCU_INTERFACE
-    wfx_rsi_power_save(RSI_SLEEP_MODE_8, DEEP_SLEEP_WITH_RAM_RETENTION);
+    wfx_power_save(RSI_SLEEP_MODE_8, DEEP_SLEEP_WITH_RAM_RETENTION);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI91X_MCU_INTERFACE
     ChipLogProgress(DeviceLayer, "wfx_retry_connection : Next attempt after %d Seconds", retryInterval);
     retryInterval += retryInterval;

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -275,14 +275,6 @@ int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info);
 int32_t wfx_rsi_reset_count();
 int32_t sl_wifi_platform_disconnect();
 
-#if CHIP_CONFIG_ENABLE_ICD_SERVER
-#if SLI_SI917
-int32_t wfx_rsi_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state);
-#else
-int32_t wfx_rsi_power_save();
-#endif /* SLI_SI917 */
-#endif /* SL_ICD_ENABLED */
-
 /**
  * @brief Posts an event to the Wi-Fi task
  *

--- a/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
@@ -234,39 +234,6 @@ int32_t sl_wifi_platform_disconnect(void)
     return rsi_wlan_disconnect();
 }
 
-#if SL_ICD_ENABLED
-/******************************************************************
- * @fn   wfx_rsi_power_save(void)
- * @brief
- *       Setting the RS911x in DTIM sleep based mode
- *
- * @param[in] None
- * @return
- *        None
- *********************************************************************/
-int32_t wfx_rsi_power_save(void)
-{
-    int32_t status;
-#ifdef RSI_BLE_ENABLE
-    status = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
-    if (status != RSI_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "BT Powersave Config Failed, Error Code : 0x%lX", status);
-        return status;
-    }
-#endif /* RSI_BLE_ENABLE */
-
-    status = rsi_wlan_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
-    if (status != RSI_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "Powersave Config Failed, Error Code : 0x%lX", status);
-        return status;
-    }
-    ChipLogDetail(DeviceLayer, "Powersave Config Success");
-    return status;
-}
-#endif /* SL_ICD_ENABLED */
-
 /******************************************************************
  * @fn   wfx_rsi_join_cb(uint16_t status, const uint8_t *buf, const uint16_t len)
  * @brief
@@ -966,8 +933,26 @@ int32_t wfx_rsi_send_data(void * p, uint16_t len)
  * @return  SL_STATUS_OK if successful,
  *          SL_STATUS_FAIL otherwise
  ***********************************************************************/
-sl_status_t wfx_power_save(void) // TODO : Figure out why the extern C is necessary
+sl_status_t wfx_power_save(void)
 {
-    return (wfx_rsi_power_save() ? SL_STATUS_FAIL : SL_STATUS_OK);
+    int32_t status;
+#ifdef RSI_BLE_ENABLE
+    status = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
+    if (status != RSI_SUCCESS)
+    {
+        ChipLogError(DeviceLayer, "BT Powersave Config Failed, Error Code : 0x%lX", status);
+        return SL_STATUS_FAIL;
+    }
+#endif /* RSI_BLE_ENABLE */
+
+    status = rsi_wlan_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
+    if (status != RSI_SUCCESS)
+    {
+        ChipLogError(DeviceLayer, "Powersave Config Failed, Error Code : 0x%lX", status);
+        return SL_STATUS_FAIL;
+    }
+
+    ChipLogDetail(DeviceLayer, "Powersave Config Success");
+    return SL_STATUS_OK;
 }
 #endif /* SL_ICD_ENABLED */


### PR DESCRIPTION
#### Description
Wiseconnect wifi interface has a double abstraction :
- wfx_power_save
- wfx_rsi_power_save

Both function executed the same code. As such, removed the wfx_rsi_power_save function to only use the "standard" API.

