### PR TITLE
[SL-UP] Update spi-multiplex header inclusion

### DIFF
--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -53,7 +53,7 @@ extern "C" {
 #endif
 #include "sl_uartdrv_instances.h"
 #if SL_WIFI
-#include "spi_multiplex.h"
+#include <platform/silabs/wifi/wf200/platform/spi_multiplex.h>
 #endif // SL_WIFI
 #ifdef SL_CATALOG_UARTDRV_EUSART_PRESENT
 #include "sl_uartdrv_eusart_vcom_config.h"

--- a/examples/refrigerator-app/silabs/src/RefrigeratorUI.cpp
+++ b/examples/refrigerator-app/silabs/src/RefrigeratorUI.cpp
@@ -27,9 +27,8 @@
 #include <lib/support/logging/CHIPLogging.h>
 
 #if SL_WIFI && !defined(SLI_SI91X_MCU_INTERFACE)
-// Only needed for wifi NCP devices
-#include "spi_multiplex.h"
-#endif // SL_WIFI
+#include <platform/silabs/wifi/wf200/platform/spi_multiplex.h>
+#endif // SL_WIFI && !defined(SLI_SI91X_MCU_INTERFACE)
 
 // LCD line define
 constexpr uint8_t kTempLcdInitialX = 30;

--- a/examples/refrigerator-app/silabs/src/RefrigeratorUI.cpp
+++ b/examples/refrigerator-app/silabs/src/RefrigeratorUI.cpp
@@ -26,6 +26,7 @@
 #include "lcd.h"
 #include <lib/support/logging/CHIPLogging.h>
 
+// Only needed for wifi NCP devices
 #if SL_WIFI && !defined(SLI_SI91X_MCU_INTERFACE)
 #include <platform/silabs/wifi/wf200/platform/spi_multiplex.h>
 #endif // SL_WIFI && !defined(SLI_SI91X_MCU_INTERFACE)

--- a/examples/thermostat/silabs/src/ThermostatUI.cpp
+++ b/examples/thermostat/silabs/src/ThermostatUI.cpp
@@ -26,9 +26,8 @@
 #include "lcd.h"
 
 #if SL_WIFI && !defined(SLI_SI91X_MCU_INTERFACE)
-// Only needed for wifi NCP devices
-#include "spi_multiplex.h"
-#endif // SL_WIFI
+#include <platform/silabs/wifi/wf200/platform/spi_multiplex.h>
+#endif // SL_WIFI && !defined(SLI_SI91X_MCU_INTERFACE)
 
 // LCD line define
 constexpr uint8_t kTempLcdInitialX = 30;

--- a/examples/thermostat/silabs/src/ThermostatUI.cpp
+++ b/examples/thermostat/silabs/src/ThermostatUI.cpp
@@ -25,6 +25,7 @@
 #include "glib.h"
 #include "lcd.h"
 
+// Only needed for wifi NCP devices
 #if SL_WIFI && !defined(SLI_SI91X_MCU_INTERFACE)
 #include <platform/silabs/wifi/wf200/platform/spi_multiplex.h>
 #endif // SL_WIFI && !defined(SLI_SI91X_MCU_INTERFACE)

--- a/src/platform/silabs/multi-ota/OTACustomProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTACustomProcessor.cpp
@@ -22,12 +22,13 @@
 
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 
+#if SL_WIFI
+#include <platform/silabs/wifi/wf200/platform/spi_multiplex.h>
+#endif // SL_WIFI
+
 extern "C" {
 #include "btl_interface.h"
 #include "sl_core.h"
-#if SL_WIFI
-#include "spi_multiplex.h"
-#endif // SL_WIFI
 }
 
 /// No error, operation OK

--- a/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
@@ -22,12 +22,13 @@
 
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 
+#if SL_WIFI
+#include <platform/silabs/wifi/wf200/platform/spi_multiplex.h>
+#endif // SL_WIFI
+
 extern "C" {
 #include "btl_interface.h"
 #include "sl_core.h"
-#if SL_WIFI
-#include "spi_multiplex.h"
-#endif // SL_WIFI
 }
 
 /// No error, operation OK

--- a/src/platform/silabs/multi-ota/OTAMultiImageProcessorImpl.cpp
+++ b/src/platform/silabs/multi-ota/OTAMultiImageProcessorImpl.cpp
@@ -30,12 +30,13 @@ using namespace ::chip::DeviceLayer::Internal;
 
 static chip::OTAMultiImageProcessorImpl gImageProcessor;
 
+#if SL_WIFI
+#include <platform/silabs/wifi/wf200/platform/spi_multiplex.h>
+#endif // SL_WIFI
+
 extern "C" {
 #include "btl_interface.h"
 #include "sl_core.h"
-#if SL_WIFI
-#include "spi_multiplex.h"
-#endif // SL_WIFI
 }
 
 namespace chip {


### PR DESCRIPTION
#### Description
After the Wi-Fi abstraction refactor, the way to include certain files has changed since they moved from the examples directory to the platform directory. 

Some of the includes were not updated when the header was moved. PR updates the inclusion statement.
