### PR TITLE
[SL-ONLY] Move SiWx917 Sleep Calls to the SleepManager class

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -910,7 +910,7 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 #endif // SILABS_OTA_ENABLED
 #if (CHIP_CONFIG_ENABLE_ICD_SERVER && RS911X_WIFI)
 #if !SLI_SI917
-            // Todo: sl-only - Only 9116 - 917 is managed by the SleepManager
+            // [sl-only] Only 9116 - 917 is managed by the SleepManager
             // on power cycle, let the device go to sleep after connection is established
             if (BaseApplication::sAppDelegate.isCommissioningInProgress() == false)
             {
@@ -929,7 +929,7 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
     case DeviceEventType::kCommissioningComplete: {
 #if (CHIP_CONFIG_ENABLE_ICD_SERVER && RS911X_WIFI)
 #if !SLI_SI917
-        // TODO: sl-ony - Only 9116 - 917 is managed by the SleepManager
+        // [sl-only] Only 9116 - 917 is managed by the SleepManager
         sl_status_t status = wfx_power_save();
         if (status != SL_STATUS_OK)
         {

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -71,6 +71,7 @@ public:
 private:
     // AppDelegate
     bool isComissioningStarted = false;
+    void OnCommissioningWindowOpened() override;
     void OnCommissioningSessionStarted() override;
     void OnCommissioningSessionStopped() override;
     void OnCommissioningWindowClosed() override;

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -45,6 +45,11 @@
 #include <platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.h>
 #endif // SLI_SI91X_MCU_INTERFACE
 
+// sl-only: Wi-Fi Sleep Manager support
+#if SL_MATTER_SLEEP_MANAGER_ENABLED
+#include "SleepManager.h"
+#endif // SL_MATTER_SLEEP_MANAGER_ENABLED
+
 #include <crypto/CHIPCryptoPAL.h>
 // If building with the EFR32-provided crypto backend, we can use the
 // opaque keystore
@@ -299,6 +304,15 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 #endif
 
     initParams.appDelegate = &BaseApplication::sAppDelegate;
+
+#if SL_MATTER_SLEEP_MANAGER_ENABLED
+    err = DeviceLayer::Silabs::SleepManager::GetInstance()
+              .SetInteractionModelEngine(app::InteractionModelEngine::GetInstance())
+              .SetFabricTable(&Server::GetInstance().GetFabricTable())
+              .Init();
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err);
+#endif // SL_MATTER_SLEEP_MANAGER_ENABLED
+
     // Init Matter Server and Start Event Loop
     err = chip::Server::GetInstance().Init(initParams);
 

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -230,6 +230,10 @@ source_set("efr32-common") {
     ]
   }
 
+  if (chip_enable_icd_server && use_SiWx917) {
+    public_deps += [ "${silabs_common_plat_dir}/wifi/icd:sleep-manager" ]
+  }
+
   if (app_data_model != "") {
     public_deps += [ app_data_model ]
   }

--- a/examples/platform/silabs/wifi/icd/BUILD.gn
+++ b/examples/platform/silabs/wifi/icd/BUILD.gn
@@ -16,7 +16,7 @@ import("//build_overrides/chip.gni")
 
 config("sleep-manager-config") {
   include_dirs = [ "." ]
-  defines = []
+  defines = [ "SL_MATTER_SLEEP_MANAGER_ENABLED=1" ]
 }
 
 source_set("sleep-manager") {
@@ -29,8 +29,10 @@ source_set("sleep-manager") {
     "${chip_root}/src/app:app",
     "${chip_root}/src/app/icd/server:manager",
     "${chip_root}/src/app/icd/server:observer",
+    "${chip_root}/src/credentials:credentials",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/platform/silabs/wifi:wifi-platform",
   ]
 
   public_configs = [ ":sleep-manager-config" ]

--- a/examples/platform/silabs/wifi/icd/SleepManager.h
+++ b/examples/platform/silabs/wifi/icd/SleepManager.h
@@ -1,9 +1,10 @@
-
 #pragma once
 
+#include <app/InteractionModelEngine.h>
 #include <app/ReadHandler.h>
 #include <app/icd/server/ICDManager.h>
 #include <app/icd/server/ICDStateObserver.h>
+#include <credentials/FabricTable.h>
 #include <lib/core/CHIPError.h>
 
 namespace chip {
@@ -18,7 +19,9 @@ namespace Silabs {
  *        For SIT ICDs, the logic is based on the Subscriptions established with the device.
  *        For LIT ICDs, the logic is based on the ICDManager operating modes. The LIT mode also utilizes the SIT mode logic.
  */
-class SleepManager : public chip::app::ICDStateObserver, public chip::app::ReadHandler::ApplicationCallback
+class SleepManager : public chip::app::ICDStateObserver,
+                     public chip::app::ReadHandler::ApplicationCallback,
+                     public chip::FabricTable::Delegate
 {
 public:
     SleepManager(const SleepManager &)             = delete;
@@ -37,23 +40,71 @@ public:
      */
     CHIP_ERROR Init();
 
+    SleepManager & SetInteractionModelEngine(chip::app::InteractionModelEngine * engine)
+    {
+        mIMEngine = engine;
+        return *this;
+    }
+
+    SleepManager & SetFabricTable(chip::FabricTable * fabricTable)
+    {
+        mFabricTable = fabricTable;
+        return *this;
+    }
+
     // ICDStateObserver implementation overrides
 
     void OnEnterActiveMode();
     void OnEnterIdleMode();
-    void OnTransitionToIdle() { /* No execution logic */ }
-    void OnICDModeChange() { /* No execution logic */ }
+    void OnTransitionToIdle()
+    { /* No execution logic */
+    }
+    void OnICDModeChange()
+    { /* No execution logic */
+    }
 
     // ReadHandler::ApplicationCallback implementation overrides
 
     void OnSubscriptionEstablished(chip::app::ReadHandler & aReadHandler);
     void OnSubscriptionTerminated(chip::app::ReadHandler & aReadHandler);
 
+    // FabricTable::Delegate implementation overrides
+    void FabricWillBeRemoved(const chip::FabricTable & fabricTable,
+                             chip::FabricIndex fabricIndex) override{ /* No execution logic */ };
+    void OnFabricRemoved(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex) override;
+    void OnFabricCommitted(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex) override;
+    void OnFabricUpdated(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex) override{ /* No execution logic*/ };
+
+    static void OnPlatformEvent(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
+
+    /**
+     * @brief Set the commissioning status of the device
+     *
+     * @param[in] inProgress bool true if commissioning is in progress, false otherwise
+     */
+    void SetCommissioningInProgress(bool inProgress) { isCommissioningInProgress = inProgress; }
+
+    /**
+     * @brief Returns the current commissioning status of the device
+     *
+     * @return bool true if commissioning is in progress, false otherwise
+     */
+    bool IsCommissioningInProgress() { return isCommissioningInProgress; }
+
 private:
     SleepManager()  = default;
     ~SleepManager() = default;
 
+    void HandleCommissioningComplete();
+    void HandleInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);
+    void HandleCommissioningWindowClose();
+    void HandleCommissioningSessionStarted();
+    void HandleCommissioningSessionStopped();
+
     static SleepManager mInstance;
+    chip::app::InteractionModelEngine * mIMEngine = nullptr;
+    chip::FabricTable * mFabricTable              = nullptr;
+    bool isCommissioningInProgress                = false;
 };
 
 } // namespace Silabs

--- a/src/platform/silabs/CHIPDevicePlatformEvent.h
+++ b/src/platform/silabs/CHIPDevicePlatformEvent.h
@@ -39,7 +39,10 @@ namespace DeviceEventType {
  */
 enum PublicPlatformSpecificEventTypes
 {
-    /* None currently defined */
+    kCommissioningWindowOpen = kRange_PublicPlatformSpecific,
+    kCommissioningWindowClose,
+    kCommissioningSessionStarted,
+    kCommissioningSessionStopped,
 };
 
 /**

--- a/src/platform/silabs/wifi/BUILD.gn
+++ b/src/platform/silabs/wifi/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/chip.gni")
 import("//build_overrides/lwip.gni")
+import("${chip_root}/src/app/icd/icd.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${chip_root}/third_party/silabs/efr32_sdk.gni")
 import("${chip_root}/third_party/silabs/silabs_board.gni")
@@ -146,5 +147,9 @@ source_set("wifi-platform") {
       "${silabs_platform_dir}/wifi/lwip-support/ethernetif.h",
       "${silabs_platform_dir}/wifi/lwip-support/lwip_netif.cpp",
     ]
+  }
+
+  if (chip_enable_icd_server) {
+    public_deps += [ "${chip_root}/src/app/icd/server:configuration-data" ]
   }
 }

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -33,6 +33,7 @@
 #include "sl_status.h"
 #include "sl_wifi_device.h"
 #include "task.h"
+#include <app/icd/server/ICDConfigurationData.h>
 #include <app/icd/server/ICDServerConfig.h>
 #include <inet/IPAddress.h>
 #include <lib/support/CHIPMem.h>
@@ -415,6 +416,8 @@ sl_status_t JoinWifiNetwork(void)
 
     if (status == SL_STATUS_OK || status == SL_STATUS_IN_PROGRESS)
     {
+        // TODO: Set listen interval to 0 with DTIM sync
+
         WifiEvent event = WifiEvent::kStationConnect;
         sl_matter_wifi_post_event(event);
         return status;


### PR DESCRIPTION
#### Description
The SleepManager class is now the responsible entity of managing the Wi-Fi sleep states based on the Matter SDK states.
PR moves the SiWx917 power saves class to the SleepManager. In this PR, the behavior isn't changed.

#### Tests
Manual tests with the 917 SoC that the different states still work
- Sleep after commissioning
- Sleep on power cycle