### PR TITLE
[SL-UP] Add application callback to allow the application to inject logic

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -217,13 +217,7 @@ void BaseApplicationDelegate::OnCommissioningWindowClosed()
 #endif // QR_CODE_ENABLED
 #endif // DISPLAY_ENABLED
     }
-
-#if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
-    WifiSleepManager::GetInstance().HandleCommissioningWindowClose();
-#endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
-
-void BaseApplicationDelegate::OnCommissioningWindowOpened() {}
 
 void BaseApplicationDelegate::OnFabricCommitted(const FabricTable & fabricTable, FabricIndex fabricIndex)
 {
@@ -905,7 +899,7 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 #if SL_WIFI
             chip::app::DnssdServer::Instance().StartServer();
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-            WifiSleepManager::GetInstance().HandleInternetConnectivityChange();
+            WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #endif // SL_WIFI
 
@@ -920,7 +914,7 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 
     case DeviceEventType::kCommissioningComplete: {
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
-        WifiSleepManager::GetInstance().HandleCommissioningComplete();
+        WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
 #endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 
 // SL-Only

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -71,7 +71,6 @@ public:
 private:
     // AppDelegate
     bool isComissioningStarted = false;
-    void OnCommissioningWindowOpened() override;
     void OnCommissioningSessionStarted() override;
     void OnCommissioningSessionStopped() override;
     void OnCommissioningWindowClosed() override;
@@ -90,7 +89,7 @@ class BaseApplication
 
 public:
     BaseApplication() = default;
-    virtual ~BaseApplication(){};
+    virtual ~BaseApplication() {};
     static bool sIsProvisioned;
     static bool sIsFactoryResetTriggered;
     static LEDWidget * sAppActionLed;

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -865,9 +865,8 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-
-sl_status_t wfx_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state,
-                           uint32_t listenInterval)
+sl_status_t CofigurePowerSave(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state,
+                              uint32_t listenInterval)
 {
     int32_t error = rsi_bt_power_save_profile(sl_si91x_ble_state, 0);
     VerifyOrReturnError(error == RSI_SUCCESS, SL_STATUS_FAIL,
@@ -882,6 +881,20 @@ sl_status_t wfx_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_
     sl_status_t status = sl_wifi_set_performance_profile(&wifi_profile);
     VerifyOrReturnError(status == SL_STATUS_OK, status,
                         ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile failed: 0x%lx", status));
+
+    return status;
+}
+
+sl_status_t ConfigureBroadcastFilter(bool enableBroadcastFilter)
+{
+    sl_status_t status = SL_STATUS_OK;
+
+    uint16_t beaconDropThreshold = (enableBroadcastFilter) ? kTimeToFullBeaconReception : 0;
+    uint8_t filterBcastInTim     = (enableBroadcastFilter) ? 1 : 0;
+
+    status = sl_wifi_filter_broadcast(beaconDropThreshold, filterBcastInTim, 1 /* valid till next update*/);
+    VerifyOrReturnError(status == SL_STATUS_OK, status,
+                        ChipLogError(DeviceLayer, "sl_wifi_filter_broadcast failed: 0x%lx", static_cast<uint32_t>(status)));
 
     return status;
 }

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -865,8 +865,8 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-sl_status_t CofigurePowerSave(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state,
-                              uint32_t listenInterval)
+sl_status_t ConfigurePowerSave(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state,
+                               uint32_t listenInterval)
 {
     int32_t error = rsi_bt_power_save_profile(sl_si91x_ble_state, 0);
     VerifyOrReturnError(error == RSI_SUCCESS, SL_STATUS_FAIL,

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
@@ -197,7 +197,7 @@ void wfx_retry_connection(uint16_t retryAttempt)
         }
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-        //  Remove High performance request before giving up due to a timer start errorto save battery life
+        //  Remove High performance request before giving up due to a timer start error to save battery life
         Silabs::WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
         return;

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
@@ -186,6 +186,7 @@ void wfx_retry_connection(uint16_t retryAttempt)
     {
         retryInterval = kWlanMaxRetryIntervalsInSec;
     }
+
     if (osTimerStart(sRetryTimer, pdMS_TO_TICKS(CONVERT_SEC_TO_MS(retryInterval))) != osOK)
     {
         ChipLogProgress(DeviceLayer, "Failed to start retry timer");
@@ -194,11 +195,18 @@ void wfx_retry_connection(uint16_t retryAttempt)
         {
             ChipLogError(DeviceLayer, "wfx_connect_to_ap() failed.");
         }
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+        //  Remove High performance request before giving up due to a timer start errorto save battery life
+        Silabs::WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
         return;
     }
+
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     Silabs::WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
     ChipLogProgress(DeviceLayer, "wfx_retry_connection : Next attempt after %d Seconds", retryInterval);
     retryInterval += retryInterval;
 }

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -254,12 +254,20 @@ bool wfx_hw_ready(void);
 #ifdef RS911X_WIFI // for RS9116, 917 NCP and 917 SoC
 /* RSI Power Save */
 #if (SLI_SI91X_MCU_INTERFACE | EXP_BOARD)
-sl_status_t wfx_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state,
-                           uint32_t listenInterval);
+sl_status_t CofigurePowerSave(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state,
+                              uint32_t listenInterval);
 #else
-sl_status_t wfx_power_save();
+sl_status_t CofigurePowerSave();
 #endif /* (SLI_SI91X_MCU_INTERFACE | EXP_BOARD) */
 #endif /* RS911X_WIFI */
+
+/**
+ * @brief Configures the broadcast filter.
+ *
+ * @param[in] enableBroadcastFilter Boolean to enable or disable the broadcast filter.
+ * @return sl_status_t Returns the status of the operation.
+ */
+sl_status_t ConfigureBroadcastFilter(bool enableBroadcastFilter);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 void sl_matter_wifi_task(void * arg);

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -254,10 +254,10 @@ bool wfx_hw_ready(void);
 #ifdef RS911X_WIFI // for RS9116, 917 NCP and 917 SoC
 /* RSI Power Save */
 #if (SLI_SI91X_MCU_INTERFACE | EXP_BOARD)
-sl_status_t CofigurePowerSave(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state,
+sl_status_t ConfigurePowerSave(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state,
                               uint32_t listenInterval);
 #else
-sl_status_t CofigurePowerSave();
+sl_status_t ConfigurePowerSave();
 #endif /* (SLI_SI91X_MCU_INTERFACE | EXP_BOARD) */
 #endif /* RS911X_WIFI */
 

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -108,10 +108,10 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode()
     else
     {
 
-        if (mCallbacks && mCallbacks->CanGoToLIBasedSleep())
+        if (mCallback && mCallback->CanGoToLIBasedSleep())
         {
             VerifyOrReturnError(ConfigurePowerSave(RSI_SLEEP_MODE_2, ASSOCIATED_POWER_SAVE,
-                                                  ICDConfigurationData::GetInstance().GetSlowPollingInterval().count()) !=
+                                                   ICDConfigurationData::GetInstance().GetSlowPollingInterval().count()) !=
                                     SL_STATUS_OK,
                                 CHIP_ERROR_INTERNAL, ChipLogError(DeviceLayer, "Failed to enable to go to sleep."));
 

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -62,11 +62,6 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode()
 {
 
 #if SLI_SI917 // 917 SoC & NCP
-    // State machine logic:
-    // 1. If there are high performance requests, configure high performance mode.
-    // 2. If commissioning is in progress, configure DTIM based sleep.
-    // 3. If no commissioning is in progress and the device is unprovisioned, configure deep sleep.
-    // 4. If the application callback allows, configure LI based sleep; otherwise, configure DTIM based sleep.
     if (mHighPerformanceRequestCounter > 0)
     {
         VerifyOrReturnError(ConfigureHighPerformance() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -68,7 +68,7 @@ CHIP_ERROR WifiSleepManager::RequestHighPerformance()
     if (mHighPerformanceRequestCounter == 0)
     {
 #if SLI_SI917 // 917 SoC & NCP
-        VerifyOrReturnError(CofigurePowerSave(RSI_ACTIVE, HIGH_PERFORMANCE, 0) == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+        VerifyOrReturnError(ConfigurePowerSave(RSI_ACTIVE, HIGH_PERFORMANCE, 0) == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
                             ChipLogError(DeviceLayer, "Failed to set Wi-FI configuration to HighPerformance"));
 #endif // SLI_SI917
     }
@@ -102,7 +102,7 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode()
 
     if (!(wifiConfig.ssid[0] != 0) && !isCommissioningInProgress)
     {
-        VerifyOrReturnError(CofigurePowerSave(RSI_SLEEP_MODE_8, DEEP_SLEEP_WITH_RAM_RETENTION, 0) != SL_STATUS_OK,
+        VerifyOrReturnError(ConfigurePowerSave(RSI_SLEEP_MODE_8, DEEP_SLEEP_WITH_RAM_RETENTION, 0) != SL_STATUS_OK,
                             CHIP_ERROR_INTERNAL, ChipLogError(DeviceLayer, "Failed to enable Deep Sleep."));
     }
     else
@@ -110,7 +110,7 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode()
 
         if (mCallbacks && mCallbacks->CanGoToLIBasedSleep())
         {
-            VerifyOrReturnError(CofigurePowerSave(RSI_SLEEP_MODE_2, ASSOCIATED_POWER_SAVE,
+            VerifyOrReturnError(ConfigurePowerSave(RSI_SLEEP_MODE_2, ASSOCIATED_POWER_SAVE,
                                                   ICDConfigurationData::GetInstance().GetSlowPollingInterval().count()) !=
                                     SL_STATUS_OK,
                                 CHIP_ERROR_INTERNAL, ChipLogError(DeviceLayer, "Failed to enable to go to sleep."));
@@ -121,7 +121,7 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode()
         else
         {
 
-            VerifyOrReturnError(CofigurePowerSave(RSI_SLEEP_MODE_2, ASSOCIATED_POWER_SAVE, 0) != SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+            VerifyOrReturnError(ConfigurePowerSave(RSI_SLEEP_MODE_2, ASSOCIATED_POWER_SAVE, 0) != SL_STATUS_OK, CHIP_ERROR_INTERNAL,
                                 ChipLogError(DeviceLayer, "Failed to enable to go to sleep."));
 
             VerifyOrReturnError(ConfigureBroadcastFilter(false), CHIP_ERROR_INTERNAL,
@@ -129,7 +129,7 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode()
         }
     }
 #elif RS911X_WIFI // rs9116
-    VerifyOrReturnError(CofigurePowerSave() != SL_STATUS_OK, CHIP_ERROR_INTERNAL,
+    VerifyOrReturnError(ConfigurePowerSave() != SL_STATUS_OK, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "Failed to enable to go to sleep."));
 #endif
 

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.h
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.h
@@ -118,10 +118,9 @@ public:
      *
      *        State machine logic:
      *        1. If there are high performance requests, configure high performance mode.
-     *        2. If no commissioning is in progress and the device is unprovisioned, configure deep sleep.
-     *        3. If commissioning is in progress, use the application callback to decide between LI based sleep and DTIM based
-     *           sleep.
-     *        4. If none of the above conditions are met, configure DTIM based sleep.
+     *        2. If commissioning is in progress, configure DTIM based sleep.
+     *        3. If no commissioning is in progress and the device is unprovisioned, configure deep sleep.
+     *        4. If the application callback allows, configure LI based sleep; otherwise, configure DTIM based sleep.
      *
      * @return CHIP_ERROR CHIP_NO_ERROR if the device was transitionned to low power
      *         CHIP_ERROR_INTERNAL if an error occured

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.h
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.h
@@ -140,7 +140,7 @@ private:
      *         returns WifiInterface error if the configuration failed. See ConfigurePowerSave and ConfigureBroadcastFilter of the
      *         possible errors.
      */
-    sl_status_t ConfigureLIBasedSleep();
+    CHIP_ERROR ConfigureLIBasedSleep();
 
     /**
      * @brief Configures the Wi-Fi Chip to go to DTIM based sleep.
@@ -150,7 +150,7 @@ private:
      *         returns WifiInterface error if the configuration failed. See ConfigurePowerSave and ConfigureBroadcastFilter of the
      *         possible errors.
      */
-    sl_status_t ConfigureDTIMBasedSleep();
+    CHIP_ERROR ConfigureDTIMBasedSleep();
 
     /**
      * @brief Configures the Wi-Fi Chip to go to High Performance.
@@ -160,7 +160,7 @@ private:
      *         returns WifiInterface error if the configuration failed. See ConfigurePowerSave and ConfigureBroadcastFilter of the
      *         possible errors.
      */
-    sl_status_t ConfigureHighPerformance();
+    CHIP_ERROR ConfigureHighPerformance();
 #endif // SLI_SI917
 
     static WifiSleepManager mInstance;

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.h
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.h
@@ -39,10 +39,10 @@ public:
      * @brief Class implements the callbacks that the application can implement
      *        to alter the WifiSleepManager behaviors.
      */
-    class ApplicationCallbacks
+    class ApplicationCallback
     {
     public:
-        virtual ~ApplicationCallbacks() = default;
+        virtual ~ApplicationCallback() = default;
 
         /**
          * @brief Function informs the WifiSleepManager in which Low Power mode the device can go to.
@@ -94,12 +94,12 @@ public:
     CHIP_ERROR RemoveHighPerformanceRequest();
 
     /**
-     * @brief Set the Application Callbacks
+     * @brief Set the Application Callback
      *
      * @param callbacks pointer to the application callbacks.
-     *                  The callbacks can be set to nullptr if the application wants to remove its callbacks
+     *                  The callback can be set to nullptr if the application wants to remove its callback
      */
-    void SetApplicationCallbacks(ApplicationCallbacks * callbacks);
+    void SetApplicationCallback(ApplicationCallback * callback) { mCallback = callback; }
 
     void HandleCommissioningComplete();
     void HandleInternetConnectivityChange();
@@ -127,7 +127,7 @@ private:
     bool isCommissioningInProgress         = false;
     uint8_t mHighPerformanceRequestCounter = 0;
 
-    ApplicationCallbacks * mCallbacks = nullptr;
+    ApplicationCallback * mCallback = nullptr;
 };
 
 } // namespace Silabs

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.h
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.h
@@ -131,38 +131,6 @@ private:
     WifiSleepManager()  = default;
     ~WifiSleepManager() = default;
 
-#if SLI_SI917 // 917 SoC & NCP
-    /**
-     * @brief Configures the Wi-Fi Chip to go to LI based sleep.
-     *        Function sets the listen interval the ICD Transort Slow Poll configuration and enables the broadcast filter.
-     *
-     * @return sl_status_t SL_STATUS_OK if the configurations of the Wi-Fi was successful
-     *         returns WifiInterface error if the configuration failed. See ConfigurePowerSave and ConfigureBroadcastFilter of the
-     *         possible errors.
-     */
-    CHIP_ERROR ConfigureLIBasedSleep();
-
-    /**
-     * @brief Configures the Wi-Fi Chip to go to DTIM based sleep.
-     *        Function sets the listen interval to be synced with the DTIM beacon and disables the broadcast filter.
-     *
-     * @return sl_status_t SL_STATUS_OK if the configurations of the Wi-Fi was successful
-     *         returns WifiInterface error if the configuration failed. See ConfigurePowerSave and ConfigureBroadcastFilter of the
-     *         possible errors.
-     */
-    CHIP_ERROR ConfigureDTIMBasedSleep();
-
-    /**
-     * @brief Configures the Wi-Fi Chip to go to High Performance.
-     *        Function doesn't change the broad cast filter configuration.
-     *
-     * @return sl_status_t SL_STATUS_OK if the configurations of the Wi-Fi was successful
-     *         returns WifiInterface error if the configuration failed. See ConfigurePowerSave and ConfigureBroadcastFilter of the
-     *         possible errors.
-     */
-    CHIP_ERROR ConfigureHighPerformance();
-#endif // SLI_SI917
-
     static WifiSleepManager mInstance;
 
     bool mIsCommissioningInProgress        = false;

--- a/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
@@ -926,14 +926,14 @@ int32_t wfx_rsi_send_data(void * p, uint16_t len)
 
 #if SL_ICD_ENABLED
 /*********************************************************************
- * @fn  sl_status_t CofigurePowerSave(void)
+ * @fn  sl_status_t ConfigurePowerSave(void)
  * @brief
  *      Implements the power save in sleepy application
  * @param[in]  None
  * @return  SL_STATUS_OK if successful,
  *          SL_STATUS_FAIL otherwise
  ***********************************************************************/
-sl_status_t CofigurePowerSave(void)
+sl_status_t ConfigurePowerSave(void)
 {
     int32_t status;
 #ifdef RSI_BLE_ENABLE

--- a/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
@@ -926,14 +926,14 @@ int32_t wfx_rsi_send_data(void * p, uint16_t len)
 
 #if SL_ICD_ENABLED
 /*********************************************************************
- * @fn  sl_status_t wfx_power_save(void)
+ * @fn  sl_status_t CofigurePowerSave(void)
  * @brief
  *      Implements the power save in sleepy application
  * @param[in]  None
  * @return  SL_STATUS_OK if successful,
  *          SL_STATUS_FAIL otherwise
  ***********************************************************************/
-sl_status_t wfx_power_save(void)
+sl_status_t CofigurePowerSave(void)
 {
     int32_t status;
 #ifdef RSI_BLE_ENABLE

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -322,6 +322,8 @@ template("siwx917_sdk") {
         "SL_ACTIVE_MODE_DURATION_MS=${sl_active_mode_duration_ms}",
         "SL_IDLE_MODE_DURATION_S=${sl_idle_mode_duration_s}",
         "SL_ICD_SUPPORTED_CLIENTS_PER_FABRIC=${sl_icd_supported_clients_per_fabric}",
+        "SL_TRANSPORT_IDLE_INTERVAL=${sl_transport_idle_interval_ms}",
+        "SL_TRANSPORT_ACTIVE_INTERVAL=${sl_transport_active_interval_ms}",
         "SL_SI91X_POWER_MANAGER_UC_AVAILABLE=1",
         "SL_SI91X_TICKLESS_MODE=1",
 


### PR DESCRIPTION
#### Description
PR introduces the WifiSleepManager application callback class to enable application level logic to be injected into the WifiSleepManager to determine if in which low power mode can the Wi-Fi chip go to.

The structure of ApplicationCallback is to allow the WifiSleepManager to work with and without application logic being injected.

#### Tests
Validate that standard behavior still works if no callback is provided.