### PR TITLE
[SL-UP] Fix for access point power cycle rejoin issue with ecosystem

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -431,7 +431,7 @@ sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLe
     wfx_rsi.dev_state.Clear(WifiState::kStationConnecting);
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
     {
-        callback_status = *(sl_status_t *) result;
+        status = *reinterpret_cast<sl_status_t *> result;
         ChipLogError(DeviceLayer, "join_callback_handler: failed: 0x%lx", static_cast<uint32_t>(callback_status));
         wfx_rsi.dev_state.Clear(WifiState::kStationConnected);
         wfx_retry_connection(++wfx_rsi.join_retries);

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -461,7 +461,7 @@ sl_status_t JoinWifiNetwork(void)
     status = SetWifiConfigurations();
     VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "Failure to set the Wifi Configurations!"));
 
-    status = sl_wifi_set_join_callback(join_callback_handler, NULL);
+    status = sl_wifi_set_join_callback(join_callback_handler, nullptr);
     VerifyOrReturnError(status == SL_STATUS_OK, status);
 
     status = sl_net_up((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE, SL_NET_DEFAULT_WIFI_CLIENT_PROFILE_ID);

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -298,7 +298,7 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
     sl_status_t status = SL_STATUS_OK;
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
     {
-        if (NULL != scan_result)
+        if (scan_result != nullptr)
         {
             sl_status_t callback_status = *(sl_status_t *) scan_result;
             ChipLogError(DeviceLayer, "scan_callback_handler: failed: 0x%lx", static_cast<uint32_t>(callback_status));

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -300,7 +300,7 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
     {
         if (scan_result != nullptr)
         {
-            sl_status_t callback_status = *(sl_status_t *) scan_result;
+            sl_status_t callback_status = *reinterpret_cast<sl_status_t *> scan_result;
             ChipLogError(DeviceLayer, "scan_callback_handler: failed: 0x%lx", static_cast<uint32_t>(callback_status));
         }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -300,7 +300,7 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
     {
         if (scan_result != nullptr)
         {
-            sl_status_t callback_status = *reinterpret_cast<sl_status_t *> scan_result;
+            sl_status_t callback_status = *reinterpret_cast<sl_status_t *>(scan_result);
             ChipLogError(DeviceLayer, "ScanCallback: failed: 0x%lx", static_cast<uint32_t>(callback_status));
         }
 
@@ -418,10 +418,10 @@ sl_status_t SetWifiConfigurations()
  *
  * This callback handler will be invoked when any event within join event group occurs, providing the event details and any associated data
  *
- * @param[out] event sl_wifi_event_t that triggered the callback
- * @param[out] result Pointer to the response data received
- * @param[out] result_length Length of the data received in bytes
- * @param[out] arg Optional user provided argument
+ * @param[in] event sl_wifi_event_t that triggered the callback
+ * @param[in] result Pointer to the response data received
+ * @param[in] result_length Length of the data received in bytes
+ * @param[in] arg Optional user provided argument
  *
  * @return sl_status_t Returns the status of the operation.
  */
@@ -431,8 +431,8 @@ sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLe
     wfx_rsi.dev_state.Clear(WifiState::kStationConnecting);
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
     {
-        status = *reinterpret_cast<sl_status_t *> result;
-        ChipLogError(DeviceLayer, "join_callback_handler: failed: 0x%lx", static_cast<uint32_t>(callback_status));
+        status = *reinterpret_cast<sl_status_t *>(result);
+        ChipLogError(DeviceLayer, "JoinCallback: failed: 0x%lx", static_cast<uint32_t>(status));
         wfx_rsi.dev_state.Clear(WifiState::kStationConnected);
         wfx_retry_connection(++wfx_rsi.join_retries);
         return SL_STATUS_FAIL;
@@ -441,7 +441,7 @@ sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLe
     /*
      * Join was complete - Do the DHCP
      */
-    ChipLogDetail(DeviceLayer, "join_callback_handler: success");
+    ChipLogDetail(DeviceLayer, "JoinCallback: success");
     memset(&temp_reset, 0, sizeof(temp_reset));
 
     WifiEvent wifievent = WifiEvent::kStationConnect;
@@ -461,7 +461,7 @@ sl_status_t JoinWifiNetwork(void)
     status = SetWifiConfigurations();
     VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "Failure to set the Wifi Configurations!"));
 
-    status = sl_wifi_set_join_callback(join_callback_handler, nullptr);
+    status = sl_wifi_set_join_callback(JoinCallback, nullptr);
     VerifyOrReturnError(status == SL_STATUS_OK, status);
 
     status = sl_net_up((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE, SL_NET_DEFAULT_WIFI_CLIENT_PROFILE_ID);

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -301,7 +301,7 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
         if (scan_result != nullptr)
         {
             sl_status_t callback_status = *reinterpret_cast<sl_status_t *> scan_result;
-            ChipLogError(DeviceLayer, "scan_callback_handler: failed: 0x%lx", static_cast<uint32_t>(callback_status));
+            ChipLogError(DeviceLayer, "ScanCallback: failed: 0x%lx", static_cast<uint32_t>(callback_status));
         }
 
 #if WIFI_ENABLE_SECURITY_WPA3_TRANSITION

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -427,7 +427,7 @@ sl_status_t SetWifiConfigurations()
  */
 sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLenght, void * arg)
 {
-    sl_status_t callback_status = SL_STATUS_OK;
+    sl_status_t status = SL_STATUS_OK;
     wfx_rsi.dev_state.Clear(WifiState::kStationConnecting);
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
     {

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -413,6 +413,18 @@ sl_status_t SetWifiConfigurations()
     return status;
 }
 
+/**
+ * @brief Callback function for the SL_WIFI_JOIN_EVENTS group
+ *
+ * This callback handler will be invoked when any event within join event group occurs, providing the event details and any associated data
+ *
+ * @param[out] event sl_wifi_event_t that triggered the callback
+ * @param[out] result Pointer to the response data received
+ * @param[out] result_length Length of the data received in bytes
+ * @param[out] arg Optional user provided argument
+ *
+ * @return sl_status_t Returns the status of the operation.
+ */
 sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t result_length, void * arg)
 {
     sl_status_t callback_status = SL_STATUS_OK;

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -425,7 +425,7 @@ sl_status_t SetWifiConfigurations()
  *
  * @return sl_status_t Returns the status of the operation.
  */
-sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t result_length, void * arg)
+sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLenght, void * arg)
 {
     sl_status_t callback_status = SL_STATUS_OK;
     wfx_rsi.dev_state.Clear(WifiState::kStationConnecting);

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -416,7 +416,7 @@ sl_status_t SetWifiConfigurations()
 /**
  * @brief Callback function for the SL_WIFI_JOIN_EVENTS group
  *
- * This callback handler will be invoked when any event within join event group occurs, providing the event details and any associated data
+ * This callback handler will be invoked when any event within the join event group occurs, providing the event details and any associated data
  *
  * @param[in] event sl_wifi_event_t that triggered the callback
  * @param[in] result Pointer to the response data received

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -415,7 +415,6 @@ sl_status_t SetWifiConfigurations()
 
 /**
  * @brief Callback function for the SL_WIFI_JOIN_EVENTS group
- *
  * This callback handler will be invoked when any event within the join event group occurs, providing the event details and any associated data
  *
  * @param[in] event sl_wifi_event_t that triggered the callback

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -300,8 +300,8 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
     {
         if (scan_result != nullptr)
         {
-            sl_status_t callback_status = *reinterpret_cast<sl_status_t *>(scan_result);
-            ChipLogError(DeviceLayer, "ScanCallback: failed: 0x%lx", static_cast<uint32_t>(callback_status));
+            status = *reinterpret_cast<sl_status_t *>(scan_result);
+            ChipLogError(DeviceLayer, "ScanCallback: failed: 0x%lx", static_cast<uint32_t>(status));
         }
 
 #if WIFI_ENABLE_SECURITY_WPA3_TRANSITION
@@ -309,8 +309,6 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
 #else
         security = SL_WIFI_WPA_WPA2_MIXED;
 #endif /* WIFI_ENABLE_SECURITY_WPA3_TRANSITION */
-
-        status = SL_STATUS_FAIL;
     }
     else
     {
@@ -415,14 +413,17 @@ sl_status_t SetWifiConfigurations()
 
 /**
  * @brief Callback function for the SL_WIFI_JOIN_EVENTS group
- * This callback handler will be invoked when any event within the join event group occurs, providing the event details and any associated data
+ *
+ * This callback handler will be invoked when any event within join event group occurs, providing the event details and any associated data
+ * The callback doesn't get called when we join a network using the sl net APIs
  *
  * @param[in] event sl_wifi_event_t that triggered the callback
  * @param[in] result Pointer to the response data received
  * @param[in] result_length Length of the data received in bytes
  * @param[in] arg Optional user provided argument
  *
- * @return sl_status_t Returns the status of the operation.
+ * @return sl_status_t Returns the status of the operation
+ * @note In case of failure, the 'result' parameter will be of type sl_status_t, and the 'resultLenght' parameter should be ignored
  */
 sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLenght, void * arg)
 {
@@ -434,7 +435,7 @@ sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLe
         ChipLogError(DeviceLayer, "JoinCallback: failed: 0x%lx", static_cast<uint32_t>(status));
         wfx_rsi.dev_state.Clear(WifiState::kStationConnected);
         wfx_retry_connection(++wfx_rsi.join_retries);
-        return SL_STATUS_FAIL;
+        return status;
     }
 
     /*
@@ -446,7 +447,7 @@ sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLe
     WifiEvent wifievent = WifiEvent::kStationConnect;
     sl_matter_wifi_post_event(wifievent);
     wfx_rsi.join_retries = 0;
-    return SL_STATUS_OK;
+    return status;
 }
 sl_status_t JoinWifiNetwork(void)
 {

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -417,13 +417,14 @@ sl_status_t SetWifiConfigurations()
  * This callback handler will be invoked when any event within join event group occurs, providing the event details and any associated data
  * The callback doesn't get called when we join a network using the sl net APIs
  *
+  * @note In case of failure, the 'result' parameter will be of type sl_status_t, and the 'resultLenght' parameter should be ignored
+  *
  * @param[in] event sl_wifi_event_t that triggered the callback
  * @param[in] result Pointer to the response data received
  * @param[in] result_length Length of the data received in bytes
  * @param[in] arg Optional user provided argument
  *
  * @return sl_status_t Returns the status of the operation
- * @note In case of failure, the 'result' parameter will be of type sl_status_t, and the 'resultLenght' parameter should be ignored
  */
 sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLenght, void * arg)
 {


### PR DESCRIPTION
- Added a join callback handler
- The unnecessary join events have been removed. The join event is posted multiple times, causing issues with the ecosystem during AP power cycles.
- The join retry limit has been removed. During the commissioning process, the MAX_JOIN_RETRIES_COUNT is set to 5, and this limit should be removed once commissioning is successful

Fixes https://jira.silabs.com/browse/MATTER-4379 and https://jira.silabs.com/browse/MATTER-4297


