### PR TITLE
[SL-UP] Bugfix/matter shell crash nullptr

### DIFF
--- a/src/lib/shell/Engine.cpp
+++ b/src/lib/shell/Engine.cpp
@@ -86,6 +86,8 @@ CHIP_ERROR Engine::ExecCommand(int argc, char * argv[])
     CHIP_ERROR retval = CHIP_ERROR_INVALID_ARGUMENT;
 
     VerifyOrReturnError(argc > 0, retval);
+    VerifyOrReturnError(nullptr != argv, retval);
+
     // Find the command
     for (unsigned i = 0; i < _commandSetCount; i++)
     {


### PR DESCRIPTION
When using the matter shell, a combination of:
backspace + enter or any special characters such as arrow keys would cause 
ExecCommand to be call with argc > 0, but argv == nulptr, which would crash the app.

This was tested using UART logs and screen command.

Added a nullptr check to prevent the crashes, in the longterm we might want to investigate how the filtering left us with argc > 0 in those cases.

