### PR TITLE
[SL-UP] Remove WF200 define duplication to avoid value conflicts at runtime

### DIFF
--- a/src/platform/silabs/wifi/BUILD.gn
+++ b/src/platform/silabs/wifi/BUILD.gn
@@ -49,7 +49,7 @@ if (chip_enable_wifi && !wifi_soc) {
 }
 
 config("wifi-platform-config") {
-  defines = []
+  defines = [ "WIFI_DEBUG_ENABLED=0" ]
   include_dirs = []
 
   if (use_rs9116) {
@@ -59,7 +59,6 @@ config("wifi-platform-config") {
     # All the stuff from wiseconnect
     include_dirs += rs9117_inc_plat
   }
-
   if (chip_default_wifi_ssid != "") {
     defines += [
       "SL_ONNETWORK_PAIRING=1",
@@ -122,8 +121,6 @@ source_set("wifi-platform") {
 
     # All the stuff from wiseconnect
     sources += rs9117_src_sapi
-
-    #add compilation flags for rs991x build. This will be addressed directly in wiseconnect sdk in the next version release of that sdk
   } else if (use_wf200) {
     sources += wf200_plat_src
   }
@@ -144,6 +141,7 @@ source_set("wifi-platform") {
   if (use_wf200 || use_rs9116) {
     sources += [
       "${silabs_platform_dir}/wifi/lwip-support/dhcp_client.cpp",
+      "${silabs_platform_dir}/wifi/lwip-support/dhcp_client.h",
       "${silabs_platform_dir}/wifi/lwip-support/ethernetif.cpp",
       "${silabs_platform_dir}/wifi/lwip-support/ethernetif.h",
       "${silabs_platform_dir}/wifi/lwip-support/lwip_netif.cpp",

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -63,11 +63,6 @@
 #define GET_IPV6_FAIL (0)
 #define IP_STATUS_SUCCESS (1)
 
-#define SL_WFX_STARTUP_IND_ID (1)
-#define SL_WFX_CONNECT_IND_ID (2)
-#define SL_WFX_DISCONNECT_IND_ID (3)
-#define SL_WFX_SCAN_COMPLETE_ID (4)
-
 // TASK and Interrupt Macros
 #define SUCCESS_STATUS (1)
 
@@ -255,7 +250,7 @@ bool wfx_hw_ready(void);
 /* RSI Power Save */
 #if (SLI_SI91X_MCU_INTERFACE | EXP_BOARD)
 sl_status_t ConfigurePowerSave(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state,
-                              uint32_t listenInterval);
+                               uint32_t listenInterval);
 #else
 sl_status_t ConfigurePowerSave();
 #endif /* (SLI_SI91X_MCU_INTERFACE | EXP_BOARD) */

--- a/src/platform/silabs/wifi/wf200/wf200.gni
+++ b/src/platform/silabs/wifi/wf200/wf200.gni
@@ -26,5 +26,4 @@ wf200_plat_src = [
   "${chip_root}/src/platform/silabs/wifi/wf200/platform/sl_wfx_task.h",
   "${chip_root}/src/platform/silabs/wifi/wf200/platform/sl_custom_board.h",
   "${chip_root}/src/platform/silabs/wifi/wf200/platform/spi_multiplex.h",
-  "${chip_root}/src/platform/silabs/wifi/wf200/platform/sl_wfx_board.h",
 ]

--- a/src/platform/silabs/wifi/wfx_msgs.h
+++ b/src/platform/silabs/wifi/wfx_msgs.h
@@ -26,6 +26,15 @@
 #include "sl_wfx_api.h"
 #include "sl_wfx_constants.h"
 #else
+
+// These names exists in the Si SDK as typedef enum. If they are present in the WF200 builds, we end up with conflicting
+// definitions but no erros because one is a define the other is a typedef enum. This causes different files to use different
+// values.
+#define SL_WFX_STARTUP_IND_ID (1)
+#define SL_WFX_CONNECT_IND_ID (2)
+#define SL_WFX_DISCONNECT_IND_ID (3)
+#define SL_WFX_SCAN_COMPLETE_ID (4)
+
 typedef struct
 {
     uint8_t octet[6]; ///< Table to store a MAC address

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -1010,8 +1010,6 @@ template("efr32_sdk") {
       sources += [
         "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/bus/sl_wfx_bus.c",
         "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/bus/sl_wfx_bus_spi.c",
-
-        # "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/secure_link/sl_wfx_secure_link.c",
         "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/sl_wfx.c",
       ]
     }

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -643,18 +643,6 @@ template("efr32_sdk") {
           ]
         }
       }
-
-      if (defined(invoker.chip_enable_wifi) && invoker.chip_enable_wifi) {
-        defines += [
-          # Used for wifi devices to get packet details
-          # TODO: Remove this flag, once the communication is fixed
-          "WIFI_DEBUG_ENABLED=1",
-        ]
-
-        # This is kept due to the warning on the LWIP when on demand timer is added
-        # TODO: remove this flag once the warning is fixed in SiSDK MATTER-3946
-        cflags_c = [ "-Wno-implicit-function-declaration" ]
-      }
     }
 
     if (chip_build_libshell) {  # matter shell
@@ -1022,7 +1010,8 @@ template("efr32_sdk") {
       sources += [
         "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/bus/sl_wfx_bus.c",
         "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/bus/sl_wfx_bus_spi.c",
-        "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/secure_link/sl_wfx_secure_link.c",
+
+        # "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/secure_link/sl_wfx_secure_link.c",
         "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/sl_wfx.c",
       ]
     }


### PR DESCRIPTION
#### Description
When additional Wi-Fi platforms were added, WF200 defines and constructs were used for "non-silabs" platforms. During the Wi-Fi abstraction work, an effort was done to reduce the number of location where defines we set. 

Since the names were re-used with defines and the Si SDK defines thses names as typedef enums, there were build issue to flag that there could be values mismatchs.

PR moves the defines in a gatted section that is not used by the WF200 to avoid anything conflicting values.

#### Tests
Manuel tests to validates that WF200 can join a Wi-Fi network