### PR TITLE
[SL-UP] Fix builds for sleep manager

### DIFF
--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -201,7 +201,7 @@ extern "C" void silabsLog(const char * aFormat, ...)
     va_end(v);
 }
 
-#ifdef SILABS_LOG_ENABLED
+#if SILABS_LOG_ENABLED
 bool isLogInitialized()
 {
     return sLogInitialized;

--- a/src/platform/silabs/SiWx917/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/SiWx917/OTAImageProcessorImpl.cpp
@@ -20,7 +20,10 @@
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 #include <platform/silabs/OTAImageProcessorImpl.h>
 #include <platform/silabs/SilabsConfig.h>
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
 #include <platform/silabs/wifi/icd/WifiSleepManager.h>
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -33,7 +33,6 @@
 #include "sl_status.h"
 #include "sl_wifi_device.h"
 #include "task.h"
-#include <app/icd/server/ICDConfigurationData.h>
 #include <app/icd/server/ICDServerConfig.h>
 #include <inet/IPAddress.h>
 #include <lib/support/CHIPMem.h>
@@ -72,6 +71,7 @@ extern "C" {
 #endif
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
+#include <app/icd/server/ICDConfigurationData.h>
 #include <platform/silabs/wifi/icd/WifiSleepManager.h>
 
 #if SLI_SI91X_MCU_INTERFACE

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -71,7 +71,7 @@ extern "C" {
 #endif
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-#include <app/icd/server/ICDConfigurationData.h>
+#include <app/icd/server/ICDConfigurationData.h> // nogncheck
 #include <platform/silabs/wifi/icd/WifiSleepManager.h>
 
 #if SLI_SI91X_MCU_INTERFACE

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
@@ -23,7 +23,9 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/silabs/wifi/WifiInterfaceAbstraction.h>
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
 #include <platform/silabs/wifi/icd/WifiSleepManager.h>
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
- While adding wifi sleep manager component in extension , build and copy contents are failing for EFR and SoC platforms.
- Added CHIP_CONFIG_ENABLE_ICD_SERVER macro, wherever WifiSleepManager.h is included.

