### PR TITLE
[SL-ONLY] Add ApplicationSleepManager structure for the selective listenning implementation

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -32,6 +32,10 @@
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #endif /* SL_WIFI */
 
+#if SL_MATTER_ENABLE_APP_SLEEP_MANAGER
+#include "ApplicationSleepManager.h"
+#endif // SL_MATTER_ENABLE_APP_SLEEP_MANAGER
+
 #if PW_RPC_ENABLED
 #include "Rpc.h"
 #endif
@@ -318,17 +322,13 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
               .SetFabricTable(&Server::GetInstance().GetFabricTable())
               .SetSubscriptionInfoProvider(app::InteractionModelEngine::GetInstance())
               .SetCommissioningWindowManager(&Server::GetInstance().GetCommissioningWindowManager())
+              .SetWifiSleepManager(&WifiSleepManager::GetInstance())
               .Init();
     VerifyOrReturnError(err == CHIP_NO_ERROR, err, ChipLogError(DeviceLayer, "ApplicationSleepManager init failed"));
-
-    // Register WifiSleepManager::ApplicationCallback
-    DeviceLayer::Silabs::WifiSleepManager::GetInstance().SetApplicationCallback(
-        &app::Silabs::ApplicationSleepManager::GetInstance());
 
     // Register ReadHandler::ApplicationCallback
     app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(
         &app::Silabs::ApplicationSleepManager::GetInstance());
-
 #endif // SL_MATTER_ENABLE_APP_SLEEP_MANAGER
 
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();

--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/efr32_sdk.gni")
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/examples/platform/silabs/args.gni")
+import("${chip_root}/src/app/icd/icd.gni")
 import("${chip_root}/src/lib/lib.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${chip_root}/src/platform/silabs/wifi/args.gni")
@@ -202,6 +203,10 @@ source_set("siwx917-common") {
       "${silabs_common_plat_dir}/Si70xxSensor.cpp",
       "${silabs_common_plat_dir}/Si70xxSensor.h",
     ]
+  }
+
+  if (chip_enable_icd_server) {
+    public_deps += [ "${silabs_common_plat_dir}/wifi/icd:app-sleep-manager" ]
   }
 
   if (app_data_model != "") {

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * @file ApplicationSleepManager.cpp
+ * @brief Implementation for the buisness logic around Optimizing Wi-Fi sleep states
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#include "ApplicationSleepManager.h"
+#include <lib/support/logging/CHIPLogging.h>
+
+using namespace chip::DeviceLayer::Silabs;
+
+namespace chip {
+namespace app {
+namespace Silabs {
+
+ApplicationSleepManager ApplicationSleepManager::mInstance;
+
+CHIP_ERROR ApplicationSleepManager::Init()
+{
+    VerifyOrReturnError(mFabricTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT, ChipLogError(AppServer, "FabricTable is null"));
+    VerifyOrReturnError(mSubscriptionsInfoProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT,
+                        ChipLogError(AppServer, "SubscriptionsInfoProvider is null"));
+    VerifyOrReturnError(mCommissioningWindowManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT,
+                        ChipLogError(AppServer, "CommissioningWindowManager is null"));
+
+    ReturnErrorOnFailure(mFabricTable->AddFabricDelegate(this));
+
+    return CHIP_NO_ERROR;
+}
+
+void ApplicationSleepManager::OnSubscriptionEstablished(chip::app::ReadHandler & aReadHandler)
+{
+    WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
+}
+
+void ApplicationSleepManager::OnSubscriptionTerminated(chip::app::ReadHandler & aReadHandler)
+{
+    WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
+}
+
+CHIP_ERROR ApplicationSleepManager::OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler,
+                                                            chip::Transport::SecureSession & aSecureSession)
+{
+    // Nothing to execute for the ApplicationSleepManager
+    return CHIP_NO_ERROR;
+}
+
+void ApplicationSleepManager::OnFabricRemoved(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex)
+{
+    WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
+}
+
+void ApplicationSleepManager::OnFabricCommitted(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex)
+{
+    WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
+}
+
+bool ApplicationSleepManager::CanGoToLIBasedSleep()
+{
+    // TODO: Implement your logic here
+
+    ChipLogProgress(AppServer, "CanGoToLIBasedSleep was called!");
+    return false;
+}
+
+} // namespace Silabs
+} // namespace app
+} // namespace chip

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
@@ -18,8 +18,6 @@
 #include "ApplicationSleepManager.h"
 #include <lib/support/logging/CHIPLogging.h>
 
-using namespace chip::DeviceLayer::Silabs;
-
 namespace chip {
 namespace app {
 namespace Silabs {
@@ -33,20 +31,25 @@ CHIP_ERROR ApplicationSleepManager::Init()
                         ChipLogError(AppServer, "SubscriptionsInfoProvider is null"));
     VerifyOrReturnError(mCommissioningWindowManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT,
                         ChipLogError(AppServer, "CommissioningWindowManager is null"));
+    VerifyOrReturnError(mWifiSleepManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT,
+                        ChipLogError(AppServer, "WifiSleepManager is null"));
 
     ReturnErrorOnFailure(mFabricTable->AddFabricDelegate(this));
+
+    // Register WifiSleepManager::ApplicationCallback
+    mWifiSleepManager->SetApplicationCallback(this);
 
     return CHIP_NO_ERROR;
 }
 
 void ApplicationSleepManager::OnSubscriptionEstablished(chip::app::ReadHandler & aReadHandler)
 {
-    WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
+    mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
 }
 
 void ApplicationSleepManager::OnSubscriptionTerminated(chip::app::ReadHandler & aReadHandler)
 {
-    WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
+    mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
 }
 
 CHIP_ERROR ApplicationSleepManager::OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler,
@@ -58,12 +61,12 @@ CHIP_ERROR ApplicationSleepManager::OnSubscriptionRequested(chip::app::ReadHandl
 
 void ApplicationSleepManager::OnFabricRemoved(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex)
 {
-    WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
+    mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
 }
 
 void ApplicationSleepManager::OnFabricCommitted(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex)
 {
-    WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
+    mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
 }
 
 bool ApplicationSleepManager::CanGoToLIBasedSleep()

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.h
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.h
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * @file ApplicationSleepManager.h
+ * @brief Header for the buisness logic around Optimizing Wi-Fi sleep states
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <app/ReadHandler.h>
+#include <app/SubscriptionsInfoProvider.h>
+#include <app/server/CommissioningWindowManager.h>
+#include <credentials/FabricTable.h>
+#include <platform/silabs/wifi/icd/WifiSleepManager.h>
+
+namespace chip {
+namespace app {
+namespace Silabs {
+
+class ApplicationSleepManager : public chip::app::ReadHandler::ApplicationCallback,
+                                public chip::DeviceLayer::Silabs::WifiSleepManager::ApplicationCallback,
+                                public chip::FabricTable::Delegate
+{
+public:
+    static ApplicationSleepManager & GetInstance() { return mInstance; }
+
+    /**
+     * @brief Init function validates that the necessary pointers where correctly set
+     *        before registering the object with the FabricTable and the WifiSleepManager.
+     *
+     *        Init function does not register with the InteractionModelEngine since depending on the whole interation model engine
+     *        complexifies unit testing when we can use the SubscriptionInfoProvider which provides the necessary APIs.
+     *
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR if the init succeed
+     *         CHIP_ERROR_INVALID_ARGUMENT, if the fabricTable, subscriptionsInfoProvider or commissioningWindowManager were not set
+     *                                      correctly
+     *         other, if the FabricTable::AddFabricDelegate failed
+     */
+    CHIP_ERROR Init();
+
+    ApplicationSleepManager & SetFabricTable(chip::FabricTable * fabricTable)
+    {
+        mFabricTable = fabricTable;
+        return *this;
+    }
+
+    ApplicationSleepManager & SetSubscriptionInfoProvider(chip::app::SubscriptionsInfoProvider * subscriptionsInfoProvider)
+    {
+        mSubscriptionsInfoProvider = subscriptionsInfoProvider;
+        return *this;
+    }
+
+    ApplicationSleepManager & SetCommissioningWindowManager(chip::CommissioningWindowManager * commissioningWindowManager)
+    {
+        mCommissioningWindowManager = commissioningWindowManager;
+        return *this;
+    }
+
+    // ReadHandler::ApplicationCallback implementation
+
+    /**
+     * @brief Calls the WifiSleepManager VerifyAndTransitionToLowPowerMode.
+     *        The VerifyAndTransitionToLowPowerMode function is responsible of then queriyng the ApplicationSleepManager to
+     *        determine in which low power state the Wi-Fi device can transition to.
+     */
+    void OnSubscriptionTerminated(chip::app::ReadHandler & aReadHandler);
+
+    /**
+     * @brief Calls the WifiSleepManager VerifyAndTransitionToLowPowerMode.
+     *        The VerifyAndTransitionToLowPowerMode function is responsible of then queriyng the ApplicationSleepManager to
+     *        determine in which low power state the Wi-Fi device can transition to.
+     */
+    void OnSubscriptionEstablished(chip::app::ReadHandler & aReadHandler);
+
+    CHIP_ERROR OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler, chip::Transport::SecureSession & aSecureSession);
+
+    // WifiSleepManager::ApplicationCallback implementation
+
+    /**
+     * @brief TODO
+     *
+     * @return true
+     * @return false
+     */
+    bool CanGoToLIBasedSleep() override;
+
+    // FabricTable::Delegate implementation
+
+    /**
+     * @brief Calls the WifiSleepManager VerifyAndTransitionToLowPowerMode.
+     *        The VerifyAndTransitionToLowPowerMode function is responsible of then queriyng the ApplicationSleepManager to
+     *        determine in which low power state the Wi-Fi device can transition to.
+     */
+    void OnFabricRemoved(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex) override;
+
+    /**
+     * @brief Calls the WifiSleepManager VerifyAndTransitionToLowPowerMode.
+     *        The VerifyAndTransitionToLowPowerMode function is responsible of then queriyng the ApplicationSleepManager to
+     *        determine in which low power state the Wi-Fi device can transition to.
+     */
+    void OnFabricCommitted(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex) override;
+
+    void OnFabricUpdated(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex) override {}
+
+private:
+    ApplicationSleepManager()  = default;
+    ~ApplicationSleepManager() = default;
+
+    ApplicationSleepManager(const ApplicationSleepManager &)             = delete;
+    ApplicationSleepManager & operator=(const ApplicationSleepManager &) = delete;
+
+    static ApplicationSleepManager mInstance;
+    chip::FabricTable * mFabricTable                                  = nullptr;
+    chip::app::SubscriptionsInfoProvider * mSubscriptionsInfoProvider = nullptr;
+    chip::CommissioningWindowManager * mCommissioningWindowManager    = nullptr;
+};
+
+} // namespace Silabs
+} // namespace app
+} // namespace chip

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.h
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.h
@@ -43,8 +43,8 @@ public:
      *
      *
      * @return CHIP_ERROR CHIP_NO_ERROR if the init succeed
-     *         CHIP_ERROR_INVALID_ARGUMENT, if the fabricTable, subscriptionsInfoProvider or commissioningWindowManager were not set
-     *                                      correctly
+     *         CHIP_ERROR_INVALID_ARGUMENT, if the fabricTable, subscriptionsInfoProvider or commissioningWindowManager,
+     *                                      wifiSleepManager were not set correctly
      *         other, if the FabricTable::AddFabricDelegate failed
      */
     CHIP_ERROR Init();
@@ -64,6 +64,12 @@ public:
     ApplicationSleepManager & SetCommissioningWindowManager(chip::CommissioningWindowManager * commissioningWindowManager)
     {
         mCommissioningWindowManager = commissioningWindowManager;
+        return *this;
+    }
+
+    ApplicationSleepManager & SetWifiSleepManager(chip::DeviceLayer::Silabs::WifiSleepManager * wifiSleepManager)
+    {
+        mWifiSleepManager = wifiSleepManager;
         return *this;
     }
 
@@ -124,6 +130,7 @@ private:
     chip::FabricTable * mFabricTable                                  = nullptr;
     chip::app::SubscriptionsInfoProvider * mSubscriptionsInfoProvider = nullptr;
     chip::CommissioningWindowManager * mCommissioningWindowManager    = nullptr;
+    chip::DeviceLayer::Silabs::WifiSleepManager * mWifiSleepManager   = nullptr;
 };
 
 } // namespace Silabs

--- a/examples/platform/silabs/wifi/icd/BUILD.gn
+++ b/examples/platform/silabs/wifi/icd/BUILD.gn
@@ -1,0 +1,40 @@
+#******************************************************************************
+# @file BUILD.gn
+# @brief BUILD.gn to build the Application Sleep Manager implementation
+#******************************************************************************
+# # License
+# <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
+#******************************************************************************
+#
+# The licensor of this software is Silicon Laboratories Inc. Your use of this
+# software is governed by the terms of Silicon Labs Master Software License
+# Agreement (MSLA) available at
+# www.silabs.com/about-us/legal/master-software-license-agreement. This
+# software is distributed to you in Source Code format and is governed by the
+# sections of the MSLA applicable to Source Code.
+#
+#*****************************************************************************/
+
+import("//build_overrides/chip.gni")
+
+config("app-sleep-manager-config") {
+  include_dirs = [ "." ]
+  defines = [ "SL_MATTER_ENABLE_APP_SLEEP_MANAGER=1" ]
+}
+
+source_set("app-sleep-manager") {
+  sources = [
+    "ApplicationSleepManager.cpp",
+    "ApplicationSleepManager.h",
+  ]
+
+  deps = [
+    "${chip_root}/src/app",
+    "${chip_root}/src/app/server:server",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/platform/silabs/wifi:wifi-platform",
+  ]
+
+  public_configs = [ ":app-sleep-manager-config" ]
+}

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -160,6 +160,8 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode()
 #elif RS911X_WIFI // rs9116
     VerifyOrReturnError(ConfigurePowerSave() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
     return CHIP_NO_ERROR;
+#else             // wf200
+    return CHIP_NO_ERROR;
 #endif
 }
 

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -26,6 +26,7 @@
 #include "sl_wfx_cmd_api.h"
 #include "sl_wfx_constants.h"
 #include "task.h"
+#include <app/icd/server/ICDServerConfig.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -729,7 +730,7 @@ static void wfx_events_task(void * p_arg)
             retryJoin = 0;
             wfx_lwip_set_sta_link_up();
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-            if (!(wfx_get_wifi_state() & SL_WFX_AP_INTERFACE_UP))
+            if (!(wifiContext.state & SL_WFX_AP_INTERFACE_UP))
             {
                 // Enable the power save
                 ChipLogProgress(DeviceLayer, "WF200 going to DTIM based sleep");


### PR DESCRIPTION
#### Description 
PR introduces the ApplicationSleepManager for Wi-Fi low power apps. The ApplicationSleepManager is responsible of analysing the Matter SDK states and pipe that information to the WifiSleepManager. Based on the information given to the WifiSleepManager by the `CanGoToLIBasedSleep` callback, the WiFiSleepManager can go to the most optimal sleep state.

PR only introduces the structure; the buisness logic that will go in `CanGoToLIBasedSleep` will be in a follow Up PR.

#### Note to reviewers
I wasn't able to add unit tests to cover this class due to a dependecy with underlying platform code. In a follow up, i will need to figure out how to brake the platform dependency or leverage the test driver which doesn't support the 917 at this point.

#### Tests
Manual tests to validate behavior
