### PR TITLE
[SL-ONLY] Add business logic for the selective listening impl

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -96,6 +96,11 @@
 #include <platform/silabs/tracing/SilabsTracing.h>
 #endif // MATTER_TRACING_ENABLED
 
+// sl-only
+#if SL_MATTER_ENABLE_APP_SLEEP_MANAGER
+#include <ApplicationSleepManager.h>
+#endif // SL_MATTER_ENABLE_APP_SLEEP_MANAGER
+
 /**********************************************************
  * Defines and Constants
  *********************************************************/
@@ -213,8 +218,19 @@ void BaseApplicationDelegate::OnCommissioningSessionStopped()
 #endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
+void BaseApplicationDelegate::OnCommissioningWindowOpened()
+{
+#if SL_MATTER_ENABLE_APP_SLEEP_MANAGER
+    app::Silabs::ApplicationSleepManager::GetInstance().OnCommissioningWindowOpened();
+#endif // SL_MATTER_ENABLE_APP_SLEEP_MANAGER
+}
+
 void BaseApplicationDelegate::OnCommissioningWindowClosed()
 {
+#if SL_MATTER_ENABLE_APP_SLEEP_MANAGER
+    app::Silabs::ApplicationSleepManager::GetInstance().OnCommissioningWindowClosed();
+#endif // SL_MATTER_ENABLE_APP_SLEEP_MANAGER
+
     if (BaseApplication::GetProvisionStatus())
     {
         // After the device is provisioned and the commissioning passed

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -74,6 +74,7 @@ private:
     void OnCommissioningSessionStarted() override;
     void OnCommissioningSessionStopped() override;
     void OnCommissioningWindowClosed() override;
+    void OnCommissioningWindowOpened() override;
 
     // FabricTable::Delegate
     void OnFabricCommitted(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex) override;

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -342,7 +342,6 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     err = app::Silabs::ApplicationSleepManager::GetInstance()
               .SetFabricTable(&Server::GetInstance().GetFabricTable())
               .SetSubscriptionInfoProvider(app::InteractionModelEngine::GetInstance())
-              .SetCommissioningWindowManager(&Server::GetInstance().GetCommissioningWindowManager())
               .SetWifiSleepManager(&WifiSleepManager::GetInstance())
               .Init();
     VerifyOrReturnError(err == CHIP_NO_ERROR, err, ChipLogError(DeviceLayer, "ApplicationSleepManager init failed"));

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.h
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.h
@@ -61,17 +61,25 @@ public:
         return *this;
     }
 
-    ApplicationSleepManager & SetCommissioningWindowManager(chip::CommissioningWindowManager * commissioningWindowManager)
-    {
-        mCommissioningWindowManager = commissioningWindowManager;
-        return *this;
-    }
-
     ApplicationSleepManager & SetWifiSleepManager(chip::DeviceLayer::Silabs::WifiSleepManager * wifiSleepManager)
     {
         mWifiSleepManager = wifiSleepManager;
         return *this;
     }
+
+    /**
+     * @brief Sets the commissioning window state to open and calls the WifiSleepManager VerifyAndTransitionToLowPowerMode.
+     *        The VerifyAndTransitionToLowPowerMode function is responsible of then queriyng the ApplicationSleepManager to
+     *        determine in which low power state the Wi-Fi device can transition to.
+     */
+    void OnCommissioningWindowOpened();
+
+    /**
+     * @brief Sets the commissioning window state to open and calls the WifiSleepManager VerifyAndTransitionToLowPowerMode.
+     *        The VerifyAndTransitionToLowPowerMode function is responsible of then queriyng the ApplicationSleepManager to
+     *        determine in which low power state the Wi-Fi device can transition to.
+     */
+    void OnCommissioningWindowClosed();
 
     // ReadHandler::ApplicationCallback implementation
 
@@ -94,10 +102,14 @@ public:
     // WifiSleepManager::ApplicationCallback implementation
 
     /**
-     * @brief TODO
+     * @brief Function encapsulates the application logic to determine if the Wi-Fi device can go into LI based sleep.
      *
-     * @return true
-     * @return false
+     *        - 1. Check if the commissioning window is open. If it is open, the Wi-Fi device cannot go to LI based sleep.
+     *        - 2. Check if all Fabrics have at least 1 subscription. If there is at least one fabric without a subscription, the
+     *             Wi-Fi cannot go to LI based sleep.
+     *
+     * @return true if the device can go to LI sleep
+     * @return false if the device cannot go to LI sleep
      */
     bool CanGoToLIBasedSleep() override;
 
@@ -131,6 +143,8 @@ private:
     chip::app::SubscriptionsInfoProvider * mSubscriptionsInfoProvider = nullptr;
     chip::CommissioningWindowManager * mCommissioningWindowManager    = nullptr;
     chip::DeviceLayer::Silabs::WifiSleepManager * mWifiSleepManager   = nullptr;
+
+    bool mIsCommissionningWindowOpen = false;
 };
 
 } // namespace Silabs


### PR DESCRIPTION
#### Description
PR implements the `CanGoToLIBasedSleep` which is the core of the of the Selective Listening Design.
The initial logic is to check that there is at least 1 subscription per fabric and that the commissioning window is not opened to enable LI based sleep.

PR removes the dependency on the CommissioningWindowManager because the window is considered open while the 
`OnCommissioningWindowClosed` callback is being processed.

#### Tests
Manual tests to validate that device is in LI / DTIm based sleep at the right moments. The way the Wi-Fi integration is implemented prevents from having unit tests. This will be in a follow up once the platform layer is improved.
