### PR TITLE
[SL-UP] Bugfix/silabs out rtt removal

### DIFF
--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -52,13 +52,8 @@
 #include "uart.h"
 #endif
 
-// Enable RTT by default
-#ifndef SILABS_LOG_OUT_RTT
-#define SILABS_LOG_OUT_RTT 1
-#endif
-
 // SEGGER_RTT includes
-#if SILABS_LOG_OUT_RTT
+#if !SILABS_LOG_OUT_UART
 #include "SEGGER_RTT.h"
 #include "SEGGER_RTT_Conf.h"
 #endif
@@ -137,7 +132,7 @@ static void PrintLog(const char * msg)
         SEGGER_RTT_WriteNoLock(LOG_RTT_BUFFER_INDEX, msg, sz);
 #endif // SILABS_LOG_OUT_UART
 
-#if SILABS_LOG_OUT_RTT || PW_RPC_ENABLED
+#if !SILABS_LOG_OUT_UART || PW_RPC_ENABLED
         const char * newline = "\r\n";
         sz                   = strlen(newline);
 #if PW_RPC_ENABLED
@@ -155,7 +150,7 @@ static void PrintLog(const char * msg)
 extern "C" void silabsInitLog(void)
 {
 #if SILABS_LOG_ENABLED
-#if SILABS_LOG_OUT_RTT
+#if !SILABS_LOG_OUT_UART
 #if LOG_RTT_BUFFER_INDEX != 0
     SEGGER_RTT_ConfigUpBuffer(LOG_RTT_BUFFER_INDEX, LOG_RTT_BUFFER_NAME, sLogBuffer, LOG_RTT_BUFFER_SIZE,
                               SEGGER_RTT_MODE_NO_BLOCK_TRIM);
@@ -165,7 +160,7 @@ extern "C" void silabsInitLog(void)
 #else
     SEGGER_RTT_SetFlagsUpBuffer(LOG_RTT_BUFFER_INDEX, SEGGER_RTT_MODE_NO_BLOCK_TRIM);
 #endif
-#endif // SILABS_LOG_OUT_RTT
+#endif // !SILABS_LOG_OUT_UART
 
 #ifdef PW_RPC_ENABLED
     PigweedLogger::init();

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -334,10 +334,9 @@ template("siwx917_sdk") {
     }
 
     if (sl_uart_log_output) {
-      defines += [
-        "SILABS_LOG_OUT_UART=1",
-        "SILABS_LOG_OUT_RTT=0",
-      ]
+      defines += [ "SILABS_LOG_OUT_UART=1" ]
+    } else {
+      defines += [ "SILABS_LOG_OUT_UART=0" ]
     }
 
     if (chip_build_libshell) {  # matter shell

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -251,6 +251,7 @@ template("siwx917_sdk") {
       "UDMA_ROMDRIVER_PRESENT=1",
       "PLL_ROMDRIVER_PRESENT=1",
       "SL_MATTER_GN_BUILD=1",
+      "SILABS_LOG_OUT_UART=${sl_uart_log_output}",
     ]
 
     if (silabs_log_enabled && chip_logging) {
@@ -331,12 +332,6 @@ template("siwx917_sdk") {
         "SL_ENABLE_GPIO_WAKEUP_SOURCE=1",
         "ENABLE_NPSS_GPIO_2=1",
       ]
-    }
-
-    if (sl_uart_log_output) {
-      defines += [ "SILABS_LOG_OUT_UART=1" ]
-    } else {
-      defines += [ "SILABS_LOG_OUT_UART=0" ]
     }
 
     if (chip_build_libshell) {  # matter shell

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -490,10 +490,9 @@ template("efr32_sdk") {
     }
 
     if (sl_uart_log_output) {
-      defines += [
-        "SILABS_LOG_OUT_UART=1",
-        "SILABS_LOG_OUT_RTT=0",
-      ]
+      defines += [ "SILABS_LOG_OUT_UART=1" ]
+    } else {
+      defines += [ "SILABS_LOG_OUT_UART=0" ]
     }
 
     if (use_silabs_thread_lib) {

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -481,18 +481,13 @@ template("efr32_sdk") {
       "SL_OPENTHREAD_STACK_FEATURES_CONFIG_FILE=\"sl_openthread_features_config.h\"",
       "SL_CSL_TIMEOUT=${sl_ot_csl_timeout_sec}",
       "CIRCULAR_QUEUE_USE_LOCAL_CONFIG_HEADER=1",
+      "SILABS_LOG_OUT_UART=${sl_uart_log_output}",
     ]
 
     if (silabs_log_enabled && chip_logging) {
       defines += [ "SILABS_LOG_ENABLED=1" ]
     } else {
       defines += [ "SILABS_LOG_ENABLED=0" ]
-    }
-
-    if (sl_uart_log_output) {
-      defines += [ "SILABS_LOG_OUT_UART=1" ]
-    } else {
-      defines += [ "SILABS_LOG_OUT_UART=0" ]
     }
 
     if (use_silabs_thread_lib) {


### PR DESCRIPTION
`SILABS_LOG_OUT_RTT ` 
Had not been added to any slcc files, it was therefore always set to true in Logging.cpp.

Since we are already using SILABS_LOG_OUT_UART as the conditionto toggle between both, I chose to completely remove 
SILABS_LOG_OUT_RTT as it was redundant. 

We could just as well update our logging components to add a define to SILABS_LOG_OUT_RTT's value in there though.