### PR TITLE
[SL-ONLY] Bugfix/gn true to define true

### DIFF
--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -251,7 +251,6 @@ template("siwx917_sdk") {
       "UDMA_ROMDRIVER_PRESENT=1",
       "PLL_ROMDRIVER_PRESENT=1",
       "SL_MATTER_GN_BUILD=1",
-      "SILABS_LOG_OUT_UART=${sl_uart_log_output}",
     ]
 
     if (silabs_log_enabled && chip_logging) {
@@ -332,6 +331,12 @@ template("siwx917_sdk") {
         "SL_ENABLE_GPIO_WAKEUP_SOURCE=1",
         "ENABLE_NPSS_GPIO_2=1",
       ]
+    }
+
+    if (sl_uart_log_output) {
+      defines += [ "SILABS_LOG_OUT_UART=1" ]
+    } else {
+      defines += [ "SILABS_LOG_OUT_UART=0" ]
     }
 
     if (chip_build_libshell) {  # matter shell

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -481,13 +481,18 @@ template("efr32_sdk") {
       "SL_OPENTHREAD_STACK_FEATURES_CONFIG_FILE=\"sl_openthread_features_config.h\"",
       "SL_CSL_TIMEOUT=${sl_ot_csl_timeout_sec}",
       "CIRCULAR_QUEUE_USE_LOCAL_CONFIG_HEADER=1",
-      "SILABS_LOG_OUT_UART=${sl_uart_log_output}",
     ]
 
     if (silabs_log_enabled && chip_logging) {
       defines += [ "SILABS_LOG_ENABLED=1" ]
     } else {
       defines += [ "SILABS_LOG_ENABLED=0" ]
+    }
+
+    if (sl_uart_log_output) {
+      defines += [ "SILABS_LOG_OUT_UART=1" ]
+    } else {
+      defines += [ "SILABS_LOG_OUT_UART=0" ]
     }
 
     if (use_silabs_thread_lib) {


### PR DESCRIPTION

Went back to if condition on gn args since :
In gn, `args=true `evaluates as a boolean, if `if(arg)` works
BUT
In preprocessor, `defines += "ARG=${arg}"` will yield :` #define ARG true` which is interpreted as a string, and doesn't work with the `#if !ARG` checks

