### PR TITLE
[SL-ONLY] Fix init sequence for the Application Sleep Manager

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -331,9 +331,6 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 
     initParams.appDelegate = &BaseApplication::sAppDelegate;
 
-    // Init Matter Server and Start Event Loop
-    err = chip::Server::GetInstance().Init(initParams);
-
     // [sl-only]: Configure Wi-Fi App Sleep Manager
 #if SL_MATTER_ENABLE_APP_SLEEP_MANAGER
     err = app::Silabs::ApplicationSleepManager::GetInstance()
@@ -347,6 +344,9 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(
         &app::Silabs::ApplicationSleepManager::GetInstance());
 #endif // SL_MATTER_ENABLE_APP_SLEEP_MANAGER
+
+    // Init Matter Server and Start Event Loop
+    err = chip::Server::GetInstance().Init(initParams);
 
 #if MATTER_TRACING_ENABLED
     static Tracing::Silabs::BackendImpl backend;

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
@@ -99,6 +99,7 @@ bool ApplicationSleepManager::CanGoToLIBasedSleep()
                 canGoToLIBasedSleep = false;
                 break;
             }
+            ChipLogProgress(AppServer, "All Fabrics have at least 1 active subscription!");
         }
     }
 


### PR DESCRIPTION
#### Description
Due to a merge conflict, the init ended up being after the Server::Init which caused a crash upon boot up.
Re-ordered the init sequence

#### Tests
Manual tests

