### PR TITLE
[SL-TEMP] Temp/ble adv timeout

### DIFF
--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -1005,7 +1005,8 @@ void BLEManagerImpl::BleAdvTimeoutHandler(void * arg)
 {
     if (BLEMgrImpl().mFlags.Has(Flags::kFastAdvertisingEnabled))
     {
-        ChipLogDetail(DeviceLayer, "bleAdv Timeout : Start slow advertisement");
+        // TODO : This log causes a stack overflow in Series 3, need to investigate before re-enabling
+        // ChipLogDetail(DeviceLayer, "bleAdv Timeout : Start slow advertisement");
         BLEMgrImpl().mFlags.Set(Flags::kAdvertising);
         BLEMgr().SetAdvertisingMode(BLEAdvertisingMode::kSlowAdvertising);
 #if CHIP_DEVICE_CONFIG_EXT_ADVERTISING
@@ -1016,7 +1017,8 @@ void BLEManagerImpl::BleAdvTimeoutHandler(void * arg)
 #if CHIP_DEVICE_CONFIG_EXT_ADVERTISING
     else
     {
-        ChipLogDetail(DeviceLayer, "bleAdv Timeout : Start extended advertisement");
+        // TODO : This log causes a stack overflow in Series 3, need to investigate before re-enabling
+        // ChipLogDetail(DeviceLayer, "bleAdv Timeout : Start extended advertisement");
         BLEMgrImpl().mFlags.Set(Flags::kAdvertising);
         BLEMgrImpl().mFlags.Set(Flags::kExtAdvertisingEnabled);
         BLEMgr().SetAdvertisingMode(BLEAdvertisingMode::kSlowAdvertising);

--- a/src/platform/silabs/tracing/SilabsTracing.h
+++ b/src/platform/silabs/tracing/SilabsTracing.h
@@ -118,7 +118,7 @@ class SilabsTracer
 public:
     static constexpr size_t kNumTraces         = to_underlying(TimeTraceOperation::kNumTraces);
     static constexpr size_t kMaxBufferedTraces = 64;
-    static constexpr size_t kMaxTraceSize      = 256;
+    static constexpr size_t kMaxTraceSize      = 128;
 
     /** @brief Get the singleton instance of SilabsTracer */
     static SilabsTracer & Instance() { return sInstance; }


### PR DESCRIPTION
Deactivating the ChipLogDetail in `BleAdvTimeoutHandler` as it is causing a stack overflow.

Reducing the buffer size in SilabsTracing as the biggest message so far is around 100 bytes, letting us a buffer of 28bytes in the event of bigger trace names.