### PR TITLE
[SL-UP]Adding the dimmer switch App

### DIFF
--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -490,6 +490,132 @@ cluster OnOff = 6 {
   command OnWithTimedOff(OnWithTimedOffRequest): DefaultSuccess = 66;
 }
 
+/** Attributes and commands for controlling devices that can be set to a level between fully 'On' and fully 'Off.' */
+cluster LevelControl = 8 {
+  revision 6;
+
+  enum MoveModeEnum : enum8 {
+    kUp = 0;
+    kDown = 1;
+  }
+
+  enum StepModeEnum : enum8 {
+    kUp = 0;
+    kDown = 1;
+  }
+
+  bitmap Feature : bitmap32 {
+    kOnOff = 0x1;
+    kLighting = 0x2;
+    kFrequency = 0x4;
+  }
+
+  bitmap OptionsBitmap : bitmap8 {
+    kExecuteIfOff = 0x1;
+    kCoupleColorTempToLevel = 0x2;
+  }
+
+  readonly attribute nullable int8u currentLevel = 0;
+  readonly attribute optional int16u remainingTime = 1;
+  readonly attribute optional int8u minLevel = 2;
+  readonly attribute optional int8u maxLevel = 3;
+  readonly attribute optional int16u currentFrequency = 4;
+  readonly attribute optional int16u minFrequency = 5;
+  readonly attribute optional int16u maxFrequency = 6;
+  attribute OptionsBitmap options = 15;
+  attribute optional int16u onOffTransitionTime = 16;
+  attribute nullable int8u onLevel = 17;
+  attribute optional nullable int16u onTransitionTime = 18;
+  attribute optional nullable int16u offTransitionTime = 19;
+  attribute optional nullable int8u defaultMoveRate = 20;
+  attribute access(write: manage) optional nullable int8u startUpCurrentLevel = 16384;
+  readonly attribute command_id generatedCommandList[] = 65528;
+  readonly attribute command_id acceptedCommandList[] = 65529;
+  readonly attribute event_id eventList[] = 65530;
+  readonly attribute attrib_id attributeList[] = 65531;
+  readonly attribute bitmap32 featureMap = 65532;
+  readonly attribute int16u clusterRevision = 65533;
+
+  request struct MoveToLevelRequest {
+    int8u level = 0;
+    nullable int16u transitionTime = 1;
+    OptionsBitmap optionsMask = 2;
+    OptionsBitmap optionsOverride = 3;
+  }
+
+  request struct MoveRequest {
+    MoveModeEnum moveMode = 0;
+    nullable int8u rate = 1;
+    OptionsBitmap optionsMask = 2;
+    OptionsBitmap optionsOverride = 3;
+  }
+
+  request struct StepRequest {
+    StepModeEnum stepMode = 0;
+    int8u stepSize = 1;
+    nullable int16u transitionTime = 2;
+    OptionsBitmap optionsMask = 3;
+    OptionsBitmap optionsOverride = 4;
+  }
+
+  request struct StopRequest {
+    OptionsBitmap optionsMask = 0;
+    OptionsBitmap optionsOverride = 1;
+  }
+
+  request struct MoveToLevelWithOnOffRequest {
+    int8u level = 0;
+    nullable int16u transitionTime = 1;
+    OptionsBitmap optionsMask = 2;
+    OptionsBitmap optionsOverride = 3;
+  }
+
+  request struct MoveWithOnOffRequest {
+    MoveModeEnum moveMode = 0;
+    nullable int8u rate = 1;
+    OptionsBitmap optionsMask = 2;
+    OptionsBitmap optionsOverride = 3;
+  }
+
+  request struct StepWithOnOffRequest {
+    StepModeEnum stepMode = 0;
+    int8u stepSize = 1;
+    nullable int16u transitionTime = 2;
+    OptionsBitmap optionsMask = 3;
+    OptionsBitmap optionsOverride = 4;
+  }
+
+  request struct StopWithOnOffRequest {
+    OptionsBitmap optionsMask = 0;
+    OptionsBitmap optionsOverride = 1;
+  }
+
+  request struct MoveToClosestFrequencyRequest {
+    int16u frequency = 0;
+  }
+
+  /** Command description for MoveToLevel */
+  command MoveToLevel(MoveToLevelRequest): DefaultSuccess = 0;
+  /** Command description for Move */
+  command Move(MoveRequest): DefaultSuccess = 1;
+  /** Command description for Step */
+  command Step(StepRequest): DefaultSuccess = 2;
+  /** Command description for Stop */
+  command Stop(StopRequest): DefaultSuccess = 3;
+  /** Command description for MoveToLevelWithOnOff */
+  command MoveToLevelWithOnOff(MoveToLevelWithOnOffRequest): DefaultSuccess = 4;
+  /** Command description for MoveWithOnOff */
+  command MoveWithOnOff(MoveWithOnOffRequest): DefaultSuccess = 5;
+  /** Command description for StepWithOnOff */
+  command StepWithOnOff(StepWithOnOffRequest): DefaultSuccess = 6;
+  /** Command description for StopWithOnOff */
+  command StopWithOnOff(StopWithOnOffRequest): DefaultSuccess = 7;
+  /** Change the currrent frequency to the provided one, or a close
+        approximation if the exact provided one is not possible. */
+  command MoveToClosestFrequency(MoveToClosestFrequencyRequest): DefaultSuccess = 8;
+}
+
+
 /** The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its endpoints and clusters. */
 cluster Descriptor = 29 {
   revision 2;
@@ -3135,10 +3261,11 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type ma_onofflightswitch = 259, version 1;
+  device type ma_dimmerswitch = 260, version 1;
 
   binding cluster Identify;
   binding cluster OnOff;
+  binding cluster LevelControl;
   binding cluster ScenesManagement;
   binding cluster ColorControl;
 

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -615,7 +615,6 @@ cluster LevelControl = 8 {
   command MoveToClosestFrequency(MoveToClosestFrequencyRequest): DefaultSuccess = 8;
 }
 
-
 /** The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its endpoints and clusters. */
 cluster Descriptor = 29 {
   revision 2;

--- a/examples/light-switch-app/light-switch-common/light-switch-app.zap
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.zap
@@ -4400,29 +4400,29 @@
     },
     {
       "id": 2,
-      "name": "MA-onofflightswitch",
+      "name": "MA-dimmerswitch",
       "deviceTypeRef": {
-        "code": 259,
+        "code": 260,
         "profileId": 259,
-        "label": "MA-onofflightswitch",
-        "name": "MA-onofflightswitch"
+        "label": "MA-dimmerswitch",
+        "name": "MA-dimmerswitch"
       },
       "deviceTypes": [
         {
-          "code": 259,
+          "code": 260,
           "profileId": 259,
-          "label": "MA-onofflightswitch",
-          "name": "MA-onofflightswitch"
+          "label": "MA-dimmerswitch",
+          "name": "MA-dimmerswitch"
         }
       ],
       "deviceVersions": [
         1
       ],
       "deviceIdentifiers": [
-        259
+        260
       ],
-      "deviceTypeName": "MA-onofflightswitch",
-      "deviceTypeCode": 259,
+      "deviceTypeName": "MA-dimmerswitch",
+      "deviceTypeCode": 260,
       "deviceTypeProfileId": 259,
       "clusters": [
         {
@@ -4726,6 +4726,80 @@
             {
               "name": "Toggle",
               "code": 2,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 0,
+              "isEnabled": 1
+            }
+          ]
+        },
+        {
+          "name": "Level Control",
+          "code": 8,
+          "mfgCode": null,
+          "define": "LEVEL_CONTROL_CLUSTER",
+          "side": "client",
+          "enabled": 1,
+          "commands": [
+            {
+              "name": "MoveToLevel",
+              "code": 0,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "Move",
+              "code": 1,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "Step",
+              "code": 2,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "Stop",
+              "code": 3,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "MoveToLevelWithOnOff",
+              "code": 4,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "MoveWithOnOff",
+              "code": 5,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "StepWithOnOff",
+              "code": 6,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "StopWithOnOff",
+              "code": 7,
               "mfgCode": null,
               "source": "client",
               "isIncoming": 0,
@@ -5633,7 +5707,7 @@
       "parentEndpointIdentifier": null
     },
     {
-      "endpointTypeName": "MA-onofflightswitch",
+      "endpointTypeName": "MA-dimmerswitch",
       "endpointTypeIndex": 1,
       "profileId": 259,
       "endpointId": 1,

--- a/examples/light-switch-app/silabs/include/AppConfig.h
+++ b/examples/light-switch-app/silabs/include/AppConfig.h
@@ -31,6 +31,8 @@
 // state to another.
 #define ACTUATOR_MOVEMENT_PERIOS_MS 10
 
+#define LONG_PRESS_TIMEOUT 3000
+
 // APP Logo, boolean only. must be 64x64
 #define ON_DEMO_BITMAP                                                                                                             \
     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  \

--- a/examples/light-switch-app/silabs/include/AppEvent.h
+++ b/examples/light-switch-app/silabs/include/AppEvent.h
@@ -30,6 +30,13 @@ struct AppEvent
         kEventType_Timer,
         kEventType_Light,
         kEventType_Install,
+        kEventType_ResetWarning,
+        kEventType_ResetCanceled,
+        // Button events
+        kEventType_UpPressed,
+        kEventType_UpReleased,
+        kEventType_DownPressed,
+        kEventType_DownReleased,
     };
 
     uint16_t Type;
@@ -49,6 +56,10 @@ struct AppEvent
             uint8_t Action;
             int32_t Actor;
         } LightEvent;
+        struct
+        {
+            void * Context;
+        } LightSwitchEvent;
     };
 
     EventHandler Handler;

--- a/examples/light-switch-app/silabs/include/AppEvent.h
+++ b/examples/light-switch-app/silabs/include/AppEvent.h
@@ -53,11 +53,6 @@ struct AppEvent
         } TimerEvent;
         struct
         {
-            uint8_t Action;
-            int32_t Actor;
-        } LightEvent;
-        struct
-        {
             void * Context;
         } LightSwitchEvent;
     };

--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -66,16 +66,6 @@ public:
 
     CHIP_ERROR StartAppTask();
 
-    /**
-     * @brief Event handler when a button is pressed
-     * Function posts an event for button processing
-     *
-     * @param buttonHandle APP_LIGHT_SWITCH or APP_FUNCTION_BUTTON
-     * @param btnAction button action - SL_SIMPLE_BUTTON_PRESSED,
-     *                  SL_SIMPLE_BUTTON_RELEASED or SL_SIMPLE_BUTTON_DISABLED
-     */
-    static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
-
 private:
     static AppTask sAppTask;
 
@@ -86,20 +76,4 @@ private:
      */
     CHIP_ERROR Init();
 
-    /**
-     * @brief PB0 Button event processing function
-     *        Press and hold will trigger a factory reset timer start
-     *        Press and release will restart BLEAdvertising if not commisionned
-     *
-     * @param aEvent button event being processed
-     */
-    static void ButtonHandler(AppEvent * aEvent);
-
-    /**
-     * @brief PB1 Button event processing function
-     *        Function triggers a switch action sent to the CHIP task
-     *
-     * @param aEvent button event being processed
-     */
-    static void SwitchActionEventHandler(AppEvent * aEvent);
 };

--- a/examples/light-switch-app/silabs/include/BindingHandler.h
+++ b/examples/light-switch-app/silabs/include/BindingHandler.h
@@ -19,16 +19,57 @@
 #include "app-common/zap-generated/ids/Clusters.h"
 #include "app-common/zap-generated/ids/Commands.h"
 #include "lib/core/CHIPError.h"
+#include <platform/CHIPDeviceLayer.h>
+#include <app/clusters/bindings/bindings.h>
+#include <variant>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters::LevelControl;
 
 CHIP_ERROR InitBindingHandler();
 void SwitchWorkerFunction(intptr_t context);
 void BindingWorkerFunction(intptr_t context);
+
 
 struct BindingCommandData
 {
     chip::EndpointId localEndpointId = 1;
     chip::CommandId commandId;
     chip::ClusterId clusterId;
-    bool isGroup         = false;
-    uint32_t args[7];
+    bool isGroup = false;
+
+    struct MoveToLevel
+    {
+        uint8_t level;
+        DataModel::Nullable<uint16_t> transitionTime;
+        chip::BitMask<OptionsBitmap> optionsMask;
+        chip::BitMask<OptionsBitmap> optionsOverride;
+    };
+
+    struct Move
+    {
+        MoveModeEnum moveMode;
+        DataModel::Nullable<uint8_t> rate;
+        chip::BitMask<OptionsBitmap> optionsMask;
+        chip::BitMask<OptionsBitmap> optionsOverride;
+    };
+
+    struct Step
+    {
+        StepModeEnum stepMode;
+        uint8_t stepSize;
+        DataModel::Nullable<uint16_t> transitionTime;
+        chip::BitMask<OptionsBitmap> optionsMask;
+        chip::BitMask<OptionsBitmap> optionsOverride;
+    };
+
+    struct Stop
+    {
+        chip::BitMask<OptionsBitmap> optionsMask;
+        chip::BitMask<OptionsBitmap> optionsOverride;
+    };
+
+    // Use std::variant to replace the union
+    std::variant<MoveToLevel, Move, Step, Stop> commandData;
 };

--- a/examples/light-switch-app/silabs/include/BindingHandler.h
+++ b/examples/light-switch-app/silabs/include/BindingHandler.h
@@ -32,6 +32,16 @@ void SwitchWorkerFunction(intptr_t context);
 void BindingWorkerFunction(intptr_t context);
 
 
+struct CommandBase
+{
+    chip::BitMask<OptionsBitmap> optionsMask;
+    chip::BitMask<OptionsBitmap> optionsOverride;
+
+    // Constructor to initialize the BitMask
+    CommandBase()
+        : optionsMask(0), optionsOverride(0) {}
+};
+
 struct BindingCommandData
 {
     chip::EndpointId localEndpointId = 1;
@@ -39,37 +49,26 @@ struct BindingCommandData
     chip::ClusterId clusterId;
     bool isGroup = false;
 
-    struct MoveToLevel
+    struct MoveToLevel : public CommandBase
     {
         uint8_t level;
         DataModel::Nullable<uint16_t> transitionTime;
-        chip::BitMask<OptionsBitmap> optionsMask;
-        chip::BitMask<OptionsBitmap> optionsOverride;
     };
-
-    struct Move
+    struct Move : public CommandBase
     {
         MoveModeEnum moveMode;
         DataModel::Nullable<uint8_t> rate;
-        chip::BitMask<OptionsBitmap> optionsMask;
-        chip::BitMask<OptionsBitmap> optionsOverride;
     };
-
-    struct Step
+    struct Step : public CommandBase
     {
         StepModeEnum stepMode;
         uint8_t stepSize;
         DataModel::Nullable<uint16_t> transitionTime;
-        chip::BitMask<OptionsBitmap> optionsMask;
-        chip::BitMask<OptionsBitmap> optionsOverride;
     };
-
-    struct Stop
+    struct Stop : public CommandBase
     {
-        chip::BitMask<OptionsBitmap> optionsMask;
-        chip::BitMask<OptionsBitmap> optionsOverride;
+        // Inherits optionsMask and optionsOverride from CommandBase
     };
-
-    // Use std::variant to replace the union
+    // Use std::variant to hold different command types
     std::variant<MoveToLevel, Move, Step, Stop> commandData;
 };

--- a/examples/light-switch-app/silabs/include/BindingHandler.h
+++ b/examples/light-switch-app/silabs/include/BindingHandler.h
@@ -29,5 +29,6 @@ struct BindingCommandData
     chip::EndpointId localEndpointId = 1;
     chip::CommandId commandId;
     chip::ClusterId clusterId;
-    bool isGroup = false;
+    bool isGroup         = false;
+    uint32_t args[7];
 };

--- a/examples/light-switch-app/silabs/include/LightSwitchMgr.h
+++ b/examples/light-switch-app/silabs/include/LightSwitchMgr.h
@@ -22,11 +22,17 @@
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
+#include <app/clusters/bindings/bindings.h>
+#include <platform/CHIPDeviceLayer.h>
+#include "app-common/zap-generated/ids/Clusters.h"
 
 #include "AppEvent.h"
 #include <cmsis_os2.h>
 #include <string>
 
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters::LevelControl;
 class LightSwitchMgr
 {
 public:
@@ -42,6 +48,12 @@ public:
         chip::EndpointId endpoint;
         chip::EventId event;
     };
+
+    static constexpr uint8_t stepSize = 1;
+    static constexpr DataModel::Nullable<uint16_t> transitionTime = 0;
+    static constexpr chip::BitMask<OptionsBitmap> optionsMask = 0;
+    static constexpr chip::BitMask<OptionsBitmap> optionsOverride = 0;
+
     struct Timer
     {
         typedef void (*Callback)(Timer & timer);
@@ -62,6 +74,9 @@ public:
     private:
         static void TimerCallback(void * timerCbArg);
     };
+
+    LightSwitchMgr() = default;
+
     CHIP_ERROR Init(chip::EndpointId lightSwitchEndpoint, chip::EndpointId genericSwitchEndpoint);
 
     void GenericSwitchOnInitialPress();
@@ -71,8 +86,6 @@ public:
     void TriggerLevelControlAction(uint8_t stepMode, bool isGroupCommand = false);
 
     static LightSwitchMgr & GetInstance() { return sSwitch; }
-
-    LightSwitchMgr();
 
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 

--- a/examples/light-switch-app/silabs/include/LightSwitchMgr.h
+++ b/examples/light-switch-app/silabs/include/LightSwitchMgr.h
@@ -48,10 +48,12 @@ public:
         chip::EventId event;
     };
 
-    static constexpr uint8_t stepSize = 1;
-    static constexpr DataModel::Nullable<uint16_t> transitionTime = 0;
-    static constexpr chip::BitMask<OptionsBitmap> optionsMask = 0;
-    static constexpr chip::BitMask<OptionsBitmap> optionsOverride = 0;
+    static constexpr Clusters::LevelControl::Commands::Step::Type stepCommand = {
+        .stepSize = 1,
+        .transitionTime = 0,
+        .optionsMask = 0,
+        .optionsOverride = 0
+    };
 
     struct Timer
     {
@@ -74,32 +76,35 @@ public:
         static void TimerCallback(void * timerCbArg);
     };
 
-    LightSwitchMgr() = default;
-
     CHIP_ERROR Init(chip::EndpointId lightSwitchEndpoint, chip::EndpointId genericSwitchEndpoint);
 
     void GenericSwitchOnInitialPress();
     void GenericSwitchOnShortRelease();
 
     void TriggerLightSwitchAction(LightSwitchAction action, bool isGroupCommand = false);
-    void TriggerLevelControlAction(uint8_t stepMode, bool isGroupCommand = false);
+    void TriggerLevelControlAction(StepModeEnum stepMode, bool isGroupCommand = false);
+
+    AppEvent CreateNewEvent(AppEvent::AppEventTypes type);
 
     static LightSwitchMgr & GetInstance() { return sSwitch; }
 
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
-    static void GeneralEventHandler(AppEvent * aEvent);
+    static void AppEventHandler(AppEvent * aEvent);
 
-protected:
+// protected:
 
-    static void OnLongPressTimeout(Timer & timer);
+
+private:
+    static LightSwitchMgr sSwitch;
 
     Timer * mLongPressTimer = nullptr;
     bool mDownPressed       = false;
     bool mResetWarning      = false;
 
-private:
-    static LightSwitchMgr sSwitch;
+    static void OnLongPressTimeout(Timer & timer);
+    LightSwitchMgr() = default;
+
     void HandleLongPress();
 
     static void GenericSwitchWorkerFunction(intptr_t context);

--- a/examples/light-switch-app/silabs/include/LightSwitchMgr.h
+++ b/examples/light-switch-app/silabs/include/LightSwitchMgr.h
@@ -24,8 +24,7 @@
 #include <lib/support/CodeUtils.h>
 #include <app/clusters/bindings/bindings.h>
 #include <platform/CHIPDeviceLayer.h>
-#include "app-common/zap-generated/ids/Clusters.h"
-
+#include <app-common/zap-generated/ids/Clusters.h>
 #include "AppEvent.h"
 #include <cmsis_os2.h>
 #include <string>
@@ -107,7 +106,8 @@ private:
 
     chip::EndpointId mLightSwitchEndpoint   = chip::kInvalidEndpointId;
     chip::EndpointId mGenericSwitchEndpoint = chip::kInvalidEndpointId;
-    /**
+   
+     /**
      * @brief Button event processing function
      *        Function triggers a switch action sent to the CHIP task
      *

--- a/examples/light-switch-app/silabs/include/LightSwitchMgr.h
+++ b/examples/light-switch-app/silabs/include/LightSwitchMgr.h
@@ -88,12 +88,17 @@ public:
 
     static LightSwitchMgr & GetInstance() { return sSwitch; }
 
+    /**
+     * @brief Event handler when a button is pressed
+     * Function posts an event for button processing
+     *
+     * @param button BUTTON0 or BUTTON1
+     * @param btnAction button action - SL_SIMPLE_BUTTON_PRESSED,
+     *                  SL_SIMPLE_BUTTON_RELEASED
+     */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
     static void AppEventHandler(AppEvent * aEvent);
-
-// protected:
-
 
 private:
     static LightSwitchMgr sSwitch;
@@ -105,6 +110,10 @@ private:
     static void OnLongPressTimeout(Timer & timer);
     LightSwitchMgr() = default;
 
+    /*
+    This function will be called when PB0 is 
+    long-pressed to trigger the factory-reset
+    */
     void HandleLongPress();
 
     static void GenericSwitchWorkerFunction(intptr_t context);

--- a/examples/light-switch-app/silabs/include/LightSwitchMgr.h
+++ b/examples/light-switch-app/silabs/include/LightSwitchMgr.h
@@ -110,10 +110,10 @@ private:
     static void OnLongPressTimeout(Timer & timer);
     LightSwitchMgr() = default;
 
-    /*
-    This function will be called when PB0 is 
-    long-pressed to trigger the factory-reset
-    */
+     /**
+     * @brief This function will be called when PB0 is 
+     *        long-pressed to trigger the factory-reset
+     */
     void HandleLongPress();
 
     static void GenericSwitchWorkerFunction(intptr_t context);

--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -49,9 +49,6 @@
 
 #define SYSTEM_STATE_LED &sl_led_led0
 
-#define APP_FUNCTION_BUTTON 0
-#define APP_LIGHT_SWITCH 1
-
 namespace {
 constexpr chip::EndpointId kLightSwitchEndpoint   = 1;
 constexpr chip::EndpointId kGenericSwitchEndpoint = 2;
@@ -74,7 +71,7 @@ AppTask AppTask::sAppTask;
 CHIP_ERROR AppTask::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
+    chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(LightSwitchMgr::ButtonEventHandler);
 
 #ifdef DISPLAY_ENABLED
     GetLCD().Init((uint8_t *) "Light Switch");
@@ -127,48 +124,5 @@ void AppTask::AppTaskMain(void * pvParameter)
             sAppTask.DispatchEvent(&event);
             eventReceived = osMessageQueueGet(sAppEventQueue, &event, NULL, 0);
         }
-    }
-}
-
-void AppTask::SwitchActionEventHandler(AppEvent * aEvent)
-{
-    VerifyOrReturn(aEvent->Type == AppEvent::kEventType_Button);
-
-    static bool mCurrentButtonState = false;
-
-    if (aEvent->ButtonEvent.Action == static_cast<uint8_t>(SilabsPlatform::ButtonAction::ButtonPressed))
-    {
-        mCurrentButtonState = !mCurrentButtonState;
-        LightSwitchMgr::LightSwitchAction action =
-            mCurrentButtonState ? LightSwitchMgr::LightSwitchAction::On : LightSwitchMgr::LightSwitchAction::Off;
-
-        LightSwitchMgr::GetInstance().TriggerLightSwitchAction(action);
-        LightSwitchMgr::GetInstance().GenericSwitchOnInitialPress();
-
-#ifdef DISPLAY_ENABLED
-        sAppTask.GetLCD().WriteDemoUI(mCurrentButtonState);
-#endif
-    }
-    else if (aEvent->ButtonEvent.Action == static_cast<uint8_t>(SilabsPlatform::ButtonAction::ButtonReleased))
-    {
-        LightSwitchMgr::GetInstance().GenericSwitchOnShortRelease();
-    }
-}
-
-void AppTask::ButtonEventHandler(uint8_t button, uint8_t btnAction)
-{
-    AppEvent button_event           = {};
-    button_event.Type               = AppEvent::kEventType_Button;
-    button_event.ButtonEvent.Action = btnAction;
-
-    if (button == APP_LIGHT_SWITCH)
-    {
-        button_event.Handler = SwitchActionEventHandler;
-        sAppTask.PostEvent(&button_event);
-    }
-    else if (button == APP_FUNCTION_BUTTON)
-    {
-        button_event.Handler = BaseApplication::ButtonHandler;
-        sAppTask.PostEvent(&button_event);
     }
 }

--- a/examples/light-switch-app/silabs/src/BindingHandler.cpp
+++ b/examples/light-switch-app/silabs/src/BindingHandler.cpp
@@ -101,18 +101,11 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
 
     VerifyOrDie(peer_device != nullptr && peer_device->ConnectionReady());
 
-    Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
-    Clusters::LevelControl::Commands::Move::Type moveCommand;
-    Clusters::LevelControl::Commands::Step::Type stepCommand;
-    Clusters::LevelControl::Commands::Stop::Type stopCommand;
-    Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type moveToLevelWithOnOffCommand;
-    Clusters::LevelControl::Commands::MoveWithOnOff::Type moveWithOnOffCommand;
-    Clusters::LevelControl::Commands::StepWithOnOff::Type stepWithOnOffCommand;
-    Clusters::LevelControl::Commands::StopWithOnOff::Type stopWithOnOffCommand;
-
     switch (data->commandId)
     {
     case Clusters::LevelControl::Commands::MoveToLevel::Id:
+    {
+        Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
         moveToLevelCommand.level           = static_cast<uint8_t>(data->args[0]);
         moveToLevelCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
         moveToLevelCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
@@ -120,8 +113,11 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveToLevelCommand, onSuccess, onFailure);
         break;
+    }
 
     case Clusters::LevelControl::Commands::Move::Id:
+    {
+        Clusters::LevelControl::Commands::Move::Type moveCommand;
         moveCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
         moveCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
         moveCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
@@ -129,8 +125,11 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveCommand, onSuccess, onFailure);
         break;
+    }
 
     case Clusters::LevelControl::Commands::Step::Id:
+    {
+        Clusters::LevelControl::Commands::Step::Type stepCommand;
         stepCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
         stepCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
         stepCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
@@ -139,15 +138,21 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stepCommand, onSuccess, onFailure);
         break;
+    }
 
     case Clusters::LevelControl::Commands::Stop::Id:
+    {
+        Clusters::LevelControl::Commands::Stop::Type stopCommand;
         stopCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
         stopCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stopCommand, onSuccess, onFailure);
         break;
+    }
 
     case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id:
+    {
+        Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type moveToLevelWithOnOffCommand;
         moveToLevelWithOnOffCommand.level           = static_cast<uint8_t>(data->args[0]);
         moveToLevelWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
         moveToLevelWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
@@ -155,8 +160,11 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveToLevelWithOnOffCommand, onSuccess, onFailure);
         break;
+    }
 
     case Clusters::LevelControl::Commands::MoveWithOnOff::Id:
+    {
+        Clusters::LevelControl::Commands::MoveWithOnOff::Type moveWithOnOffCommand;
         moveWithOnOffCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
         moveWithOnOffCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
         moveWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
@@ -164,8 +172,11 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveWithOnOffCommand, onSuccess, onFailure);
         break;
+    }
 
     case Clusters::LevelControl::Commands::StepWithOnOff::Id:
+    {
+        Clusters::LevelControl::Commands::StepWithOnOff::Type stepWithOnOffCommand;
         stepWithOnOffCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
         stepWithOnOffCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
         stepWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
@@ -174,12 +185,18 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stepWithOnOffCommand, onSuccess, onFailure);
         break;
+    }
 
     case Clusters::LevelControl::Commands::StopWithOnOff::Id:
+    {
+        Clusters::LevelControl::Commands::StopWithOnOff::Type stopWithOnOffCommand;
         stopWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
         stopWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stopWithOnOffCommand, onSuccess, onFailure);
+        break;
+    }
+    default:
         break;
     }
 }
@@ -188,34 +205,33 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 
-    Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
-    Clusters::LevelControl::Commands::Move::Type moveCommand;
-    Clusters::LevelControl::Commands::Step::Type stepCommand;
-    Clusters::LevelControl::Commands::Stop::Type stopCommand;
-    Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type moveToLevelWithOnOffCommand;
-    Clusters::LevelControl::Commands::MoveWithOnOff::Type moveWithOnOffCommand;
-    Clusters::LevelControl::Commands::StepWithOnOff::Type stepWithOnOffCommand;
-    Clusters::LevelControl::Commands::StopWithOnOff::Type stopWithOnOffCommand;
-
     switch (data->commandId)
     {
     case Clusters::LevelControl::Commands::MoveToLevel::Id:
+    {
+        Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
         moveToLevelCommand.level           = static_cast<uint8_t>(data->args[0]);
         moveToLevelCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
         moveToLevelCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
         moveToLevelCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveToLevelCommand);
         break;
+    }
 
     case Clusters::LevelControl::Commands::Move::Id:
+    {
+        Clusters::LevelControl::Commands::Move::Type moveCommand;
         moveCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
         moveCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
         moveCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
         moveCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveCommand);
         break;
+    }
 
     case Clusters::LevelControl::Commands::Step::Id:
+    {
+        Clusters::LevelControl::Commands::Step::Type stepCommand;
         stepCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
         stepCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
         stepCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
@@ -223,30 +239,42 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
         stepCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[4]);
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stepCommand);
         break;
+    }
 
     case Clusters::LevelControl::Commands::Stop::Id:
+    {
+        Clusters::LevelControl::Commands::Stop::Type stopCommand;
         stopCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
         stopCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stopCommand);
         break;
+    }
 
     case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id:
+    {
+        Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type moveToLevelWithOnOffCommand;
         moveToLevelWithOnOffCommand.level           = static_cast<uint8_t>(data->args[0]);
         moveToLevelWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
         moveToLevelWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
         moveToLevelWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveToLevelWithOnOffCommand);
         break;
+    }
 
     case Clusters::LevelControl::Commands::MoveWithOnOff::Id:
+    {
+        Clusters::LevelControl::Commands::MoveWithOnOff::Type moveWithOnOffCommand;
         moveWithOnOffCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
         moveWithOnOffCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
         moveWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
         moveWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveWithOnOffCommand);
         break;
+    }
 
     case Clusters::LevelControl::Commands::StepWithOnOff::Id:
+    {
+        Clusters::LevelControl::Commands::StepWithOnOff::Type stepWithOnOffCommand;
         stepWithOnOffCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
         stepWithOnOffCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
         stepWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
@@ -254,11 +282,17 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
         stepWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[4]);
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stepWithOnOffCommand);
         break;
+    }
 
     case Clusters::LevelControl::Commands::StopWithOnOff::Id:
+    {
+        Clusters::LevelControl::Commands::StopWithOnOff::Type stopWithOnOffCommand;
         stopWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
         stopWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stopWithOnOffCommand);
+        break;
+    }
+    default:
         break;
     }
 }

--- a/examples/light-switch-app/silabs/src/BindingHandler.cpp
+++ b/examples/light-switch-app/silabs/src/BindingHandler.cpp
@@ -26,8 +26,13 @@
 #include <app/clusters/bindings/bindings.h>
 #include <lib/support/CodeUtils.h>
 
+#include <lib/support/TypeTraits.h>
+
 using namespace chip;
 using namespace chip::app;
+using chip::app::Clusters::LevelControl::MoveModeEnum;
+using chip::app::Clusters::LevelControl::OptionsBitmap;
+using chip::app::Clusters::LevelControl::StepModeEnum;
 
 namespace {
 
@@ -85,6 +90,181 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
+void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding,
+                                              OperationalDeviceProxy * peer_device)
+{
+    auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
+        ChipLogProgress(NotSpecified, "LevelControl command succeeds");
+    };
+
+    auto onFailure = [](CHIP_ERROR error) {
+        ChipLogError(NotSpecified, "LevelControl command failed: %" CHIP_ERROR_FORMAT, error.Format());
+    };
+
+    VerifyOrDie(peer_device != nullptr && peer_device->ConnectionReady());
+
+    Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
+    Clusters::LevelControl::Commands::Move::Type moveCommand;
+    Clusters::LevelControl::Commands::Step::Type stepCommand;
+    Clusters::LevelControl::Commands::Stop::Type stopCommand;
+    Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type moveToLevelWithOnOffCommand;
+    Clusters::LevelControl::Commands::MoveWithOnOff::Type moveWithOnOffCommand;
+    Clusters::LevelControl::Commands::StepWithOnOff::Type stepWithOnOffCommand;
+    Clusters::LevelControl::Commands::StopWithOnOff::Type stopWithOnOffCommand;
+
+    switch (data->commandId)
+    {
+    case Clusters::LevelControl::Commands::MoveToLevel::Id:
+        moveToLevelCommand.level           = static_cast<uint8_t>(data->args[0]);
+        moveToLevelCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
+        moveToLevelCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
+        moveToLevelCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+                                         moveToLevelCommand, onSuccess, onFailure);
+        break;
+
+    case Clusters::LevelControl::Commands::Move::Id:
+        moveCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
+        moveCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
+        moveCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
+        moveCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+                                         moveCommand, onSuccess, onFailure);
+        break;
+
+    case Clusters::LevelControl::Commands::Step::Id:
+        stepCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
+        stepCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
+        stepCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
+        stepCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        stepCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[4]);
+        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+                                         stepCommand, onSuccess, onFailure);
+        break;
+
+    case Clusters::LevelControl::Commands::Stop::Id:
+        stopCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
+        stopCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
+        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+                                         stopCommand, onSuccess, onFailure);
+        break;
+
+    case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id:
+        moveToLevelWithOnOffCommand.level           = static_cast<uint8_t>(data->args[0]);
+        moveToLevelWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
+        moveToLevelWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
+        moveToLevelWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+                                         moveToLevelWithOnOffCommand, onSuccess, onFailure);
+        break;
+
+    case Clusters::LevelControl::Commands::MoveWithOnOff::Id:
+        moveWithOnOffCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
+        moveWithOnOffCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
+        moveWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
+        moveWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+                                         moveWithOnOffCommand, onSuccess, onFailure);
+        break;
+
+    case Clusters::LevelControl::Commands::StepWithOnOff::Id:
+        stepWithOnOffCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
+        stepWithOnOffCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
+        stepWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
+        stepWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        stepWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[4]);
+        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+                                         stepWithOnOffCommand, onSuccess, onFailure);
+        break;
+
+    case Clusters::LevelControl::Commands::StopWithOnOff::Id:
+        stopWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
+        stopWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
+        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+                                         stopWithOnOffCommand, onSuccess, onFailure);
+        break;
+    }
+}
+
+void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding)
+{
+    Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
+
+    Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
+    Clusters::LevelControl::Commands::Move::Type moveCommand;
+    Clusters::LevelControl::Commands::Step::Type stepCommand;
+    Clusters::LevelControl::Commands::Stop::Type stopCommand;
+    Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type moveToLevelWithOnOffCommand;
+    Clusters::LevelControl::Commands::MoveWithOnOff::Type moveWithOnOffCommand;
+    Clusters::LevelControl::Commands::StepWithOnOff::Type stepWithOnOffCommand;
+    Clusters::LevelControl::Commands::StopWithOnOff::Type stopWithOnOffCommand;
+
+    switch (data->commandId)
+    {
+    case Clusters::LevelControl::Commands::MoveToLevel::Id:
+        moveToLevelCommand.level           = static_cast<uint8_t>(data->args[0]);
+        moveToLevelCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
+        moveToLevelCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
+        moveToLevelCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveToLevelCommand);
+        break;
+
+    case Clusters::LevelControl::Commands::Move::Id:
+        moveCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
+        moveCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
+        moveCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
+        moveCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveCommand);
+        break;
+
+    case Clusters::LevelControl::Commands::Step::Id:
+        stepCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
+        stepCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
+        stepCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
+        stepCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        stepCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[4]);
+        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stepCommand);
+        break;
+
+    case Clusters::LevelControl::Commands::Stop::Id:
+        stopCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
+        stopCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
+        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stopCommand);
+        break;
+
+    case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id:
+        moveToLevelWithOnOffCommand.level           = static_cast<uint8_t>(data->args[0]);
+        moveToLevelWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
+        moveToLevelWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
+        moveToLevelWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveToLevelWithOnOffCommand);
+        break;
+
+    case Clusters::LevelControl::Commands::MoveWithOnOff::Id:
+        moveWithOnOffCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
+        moveWithOnOffCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
+        moveWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
+        moveWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveWithOnOffCommand);
+        break;
+
+    case Clusters::LevelControl::Commands::StepWithOnOff::Id:
+        stepWithOnOffCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
+        stepWithOnOffCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
+        stepWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
+        stepWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        stepWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[4]);
+        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stepWithOnOffCommand);
+        break;
+
+    case Clusters::LevelControl::Commands::StopWithOnOff::Id:
+        stopWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
+        stopWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
+        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stopWithOnOffCommand);
+        break;
+    }
+}
+
 void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
@@ -97,6 +277,9 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
         case Clusters::OnOff::Id:
             ProcessOnOffGroupBindingCommand(data->commandId, binding);
             break;
+        case Clusters::LevelControl::Id:
+            ProcessLevelControlGroupBindingCommand(data, binding);
+            break;
         }
     }
     else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
@@ -107,6 +290,9 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
             VerifyOrDie(peer_device != nullptr && peer_device->ConnectionReady());
             ProcessOnOffUnicastBindingCommand(data->commandId, binding, peer_device->GetExchangeManager(),
                                               peer_device->GetSecureSession().Value());
+            break;
+        case Clusters::LevelControl::Id:
+            ProcessLevelControlUnicastBindingCommand(data, binding, peer_device);
             break;
         }
     }

--- a/examples/light-switch-app/silabs/src/BindingHandler.cpp
+++ b/examples/light-switch-app/silabs/src/BindingHandler.cpp
@@ -323,6 +323,8 @@ void SwitchWorkerFunction(intptr_t context)
 
     BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
     BindingManager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
+
+    Platform::Delete(data);
 }
 
 void BindingWorkerFunction(intptr_t context)

--- a/examples/light-switch-app/silabs/src/BindingHandler.cpp
+++ b/examples/light-switch-app/silabs/src/BindingHandler.cpp
@@ -110,9 +110,9 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             moveToLevelCommand.transitionTime  = moveToLevel->transitionTime;
             moveToLevelCommand.optionsMask     = moveToLevel->optionsMask;
             moveToLevelCommand.optionsOverride = moveToLevel->optionsOverride;
-        }
-        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveToLevelCommand, onSuccess, onFailure);
+        }
         break;
     }
 
@@ -125,9 +125,9 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             moveCommand.rate            = move->rate;
             moveCommand.optionsMask     = move->optionsMask;
             moveCommand.optionsOverride = move->optionsOverride;
-        }
-        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveCommand, onSuccess, onFailure);
+        }
         break;
     }
 
@@ -141,9 +141,9 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             stepCommand.transitionTime  = step->transitionTime;
             stepCommand.optionsMask     = step->optionsMask;
             stepCommand.optionsOverride = step->optionsOverride;
-        }
-        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stepCommand, onSuccess, onFailure);
+        }
         break;
     }
 
@@ -154,9 +154,9 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
         {
             stopCommand.optionsMask     = stop->optionsMask;
             stopCommand.optionsOverride = stop->optionsOverride;
-        }
-        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stopCommand, onSuccess, onFailure);
+        }
         break;
     }
 
@@ -169,9 +169,9 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             moveToLevelWithOnOffCommand.transitionTime  = moveToLevel->transitionTime;
             moveToLevelWithOnOffCommand.optionsMask     = moveToLevel->optionsMask;
             moveToLevelWithOnOffCommand.optionsOverride = moveToLevel->optionsOverride;
-        }
-        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveToLevelWithOnOffCommand, onSuccess, onFailure);
+        }
         break;
     }
 
@@ -184,9 +184,9 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             moveWithOnOffCommand.rate            = move->rate;
             moveWithOnOffCommand.optionsMask     = move->optionsMask;
             moveWithOnOffCommand.optionsOverride = move->optionsOverride;
-        }
-        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveWithOnOffCommand, onSuccess, onFailure);
+        }
         break;
     }
 
@@ -200,9 +200,9 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             stepWithOnOffCommand.transitionTime  = step->transitionTime;
             stepWithOnOffCommand.optionsMask     = step->optionsMask;
             stepWithOnOffCommand.optionsOverride = step->optionsOverride;
-        }
-        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stepWithOnOffCommand, onSuccess, onFailure);
+        }
         break;
     }
 
@@ -213,9 +213,9 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
         {
             stopWithOnOffCommand.optionsMask     = stop->optionsMask;
             stopWithOnOffCommand.optionsOverride = stop->optionsOverride;
-        }
-        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stopWithOnOffCommand, onSuccess, onFailure);
+        }
         break;
     }
     default:
@@ -238,8 +238,8 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
             moveToLevelCommand.transitionTime  = moveToLevel->transitionTime;
             moveToLevelCommand.optionsMask     = moveToLevel->optionsMask;
             moveToLevelCommand.optionsOverride = moveToLevel->optionsOverride;
+            Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveToLevelCommand);
         }
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveToLevelCommand);
         break;
     }
 
@@ -252,8 +252,8 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
             moveCommand.rate            = move->rate;
             moveCommand.optionsMask     = move->optionsMask;
             moveCommand.optionsOverride = move->optionsOverride;
+            Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveCommand);
         }
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveCommand);
         break;
     }
 
@@ -267,8 +267,8 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
             stepCommand.transitionTime  = step->transitionTime;
             stepCommand.optionsMask     = step->optionsMask;
             stepCommand.optionsOverride = step->optionsOverride;
+            Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stepCommand);
         }
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stepCommand);
         break;
     }
 
@@ -279,8 +279,8 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
         {
             stopCommand.optionsMask     = stop->optionsMask;
             stopCommand.optionsOverride = stop->optionsOverride;
+            Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stopCommand);
         }
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stopCommand);
         break;
     }
 
@@ -293,8 +293,8 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
             moveToLevelWithOnOffCommand.transitionTime  = moveToLevel->transitionTime;
             moveToLevelWithOnOffCommand.optionsMask     = moveToLevel->optionsMask;
             moveToLevelWithOnOffCommand.optionsOverride = moveToLevel->optionsOverride;
+            Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveToLevelWithOnOffCommand);
         }
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveToLevelWithOnOffCommand);
         break;
     }
 
@@ -307,8 +307,8 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
             moveWithOnOffCommand.rate            = move->rate;
             moveWithOnOffCommand.optionsMask     = move->optionsMask;
             moveWithOnOffCommand.optionsOverride = move->optionsOverride;
+            Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveWithOnOffCommand);
         }
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveWithOnOffCommand);
         break;
     }
 
@@ -322,8 +322,8 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
             stepWithOnOffCommand.transitionTime  = step->transitionTime;
             stepWithOnOffCommand.optionsMask     = step->optionsMask;
             stepWithOnOffCommand.optionsOverride = step->optionsOverride;
+            Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stepWithOnOffCommand);
         }
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stepWithOnOffCommand);
         break;
     }
 
@@ -334,8 +334,8 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
         {
             stopWithOnOffCommand.optionsMask     = stop->optionsMask;
             stopWithOnOffCommand.optionsOverride = stop->optionsOverride;
+            Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stopWithOnOffCommand);
         }
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stopWithOnOffCommand);
         break;
     }
     default:

--- a/examples/light-switch-app/silabs/src/BindingHandler.cpp
+++ b/examples/light-switch-app/silabs/src/BindingHandler.cpp
@@ -28,9 +28,7 @@
 
 using namespace chip;
 using namespace chip::app;
-using chip::app::Clusters::LevelControl::MoveModeEnum;
-using chip::app::Clusters::LevelControl::OptionsBitmap;
-using chip::app::Clusters::LevelControl::StepModeEnum;
+using namespace chip::app::Clusters::LevelControl;
 
 namespace {
 
@@ -106,10 +104,13 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
     case Clusters::LevelControl::Commands::MoveToLevel::Id:
     {
         Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
-        moveToLevelCommand.level           = static_cast<uint8_t>(data->args[0]);
-        moveToLevelCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
-        moveToLevelCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
-        moveToLevelCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        if (auto moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
+        {
+            moveToLevelCommand.level           = moveToLevel->level;
+            moveToLevelCommand.transitionTime  = moveToLevel->transitionTime;
+            moveToLevelCommand.optionsMask     = moveToLevel->optionsMask;
+            moveToLevelCommand.optionsOverride = moveToLevel->optionsOverride;
+        }
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveToLevelCommand, onSuccess, onFailure);
         break;
@@ -118,10 +119,13 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
     case Clusters::LevelControl::Commands::Move::Id:
     {
         Clusters::LevelControl::Commands::Move::Type moveCommand;
-        moveCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
-        moveCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
-        moveCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
-        moveCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        if (auto move = std::get_if<BindingCommandData::Move>(&data->commandData))
+        {
+            moveCommand.moveMode        = move->moveMode;
+            moveCommand.rate            = move->rate;
+            moveCommand.optionsMask     = move->optionsMask;
+            moveCommand.optionsOverride = move->optionsOverride;
+        }
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveCommand, onSuccess, onFailure);
         break;
@@ -130,11 +134,14 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
     case Clusters::LevelControl::Commands::Step::Id:
     {
         Clusters::LevelControl::Commands::Step::Type stepCommand;
-        stepCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
-        stepCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
-        stepCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
-        stepCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
-        stepCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[4]);
+        if (auto step = std::get_if<BindingCommandData::Step>(&data->commandData))
+        {
+            stepCommand.stepMode        = step->stepMode;
+            stepCommand.stepSize        = step->stepSize;
+            stepCommand.transitionTime  = step->transitionTime;
+            stepCommand.optionsMask     = step->optionsMask;
+            stepCommand.optionsOverride = step->optionsOverride;
+        }
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stepCommand, onSuccess, onFailure);
         break;
@@ -143,8 +150,11 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
     case Clusters::LevelControl::Commands::Stop::Id:
     {
         Clusters::LevelControl::Commands::Stop::Type stopCommand;
-        stopCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
-        stopCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
+        if (auto stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
+        {
+            stopCommand.optionsMask     = stop->optionsMask;
+            stopCommand.optionsOverride = stop->optionsOverride;
+        }
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stopCommand, onSuccess, onFailure);
         break;
@@ -153,10 +163,13 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
     case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id:
     {
         Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type moveToLevelWithOnOffCommand;
-        moveToLevelWithOnOffCommand.level           = static_cast<uint8_t>(data->args[0]);
-        moveToLevelWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
-        moveToLevelWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
-        moveToLevelWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        if (auto moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
+        {
+            moveToLevelWithOnOffCommand.level           = moveToLevel->level;
+            moveToLevelWithOnOffCommand.transitionTime  = moveToLevel->transitionTime;
+            moveToLevelWithOnOffCommand.optionsMask     = moveToLevel->optionsMask;
+            moveToLevelWithOnOffCommand.optionsOverride = moveToLevel->optionsOverride;
+        }
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveToLevelWithOnOffCommand, onSuccess, onFailure);
         break;
@@ -165,10 +178,13 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
     case Clusters::LevelControl::Commands::MoveWithOnOff::Id:
     {
         Clusters::LevelControl::Commands::MoveWithOnOff::Type moveWithOnOffCommand;
-        moveWithOnOffCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
-        moveWithOnOffCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
-        moveWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
-        moveWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        if (auto move = std::get_if<BindingCommandData::Move>(&data->commandData))
+        {
+            moveWithOnOffCommand.moveMode        = move->moveMode;
+            moveWithOnOffCommand.rate            = move->rate;
+            moveWithOnOffCommand.optionsMask     = move->optionsMask;
+            moveWithOnOffCommand.optionsOverride = move->optionsOverride;
+        }
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          moveWithOnOffCommand, onSuccess, onFailure);
         break;
@@ -177,11 +193,14 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
     case Clusters::LevelControl::Commands::StepWithOnOff::Id:
     {
         Clusters::LevelControl::Commands::StepWithOnOff::Type stepWithOnOffCommand;
-        stepWithOnOffCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
-        stepWithOnOffCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
-        stepWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
-        stepWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
-        stepWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[4]);
+        if (auto step = std::get_if<BindingCommandData::Step>(&data->commandData))
+        {
+            stepWithOnOffCommand.stepMode        = step->stepMode;
+            stepWithOnOffCommand.stepSize        = step->stepSize;
+            stepWithOnOffCommand.transitionTime  = step->transitionTime;
+            stepWithOnOffCommand.optionsMask     = step->optionsMask;
+            stepWithOnOffCommand.optionsOverride = step->optionsOverride;
+        }
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stepWithOnOffCommand, onSuccess, onFailure);
         break;
@@ -190,8 +209,11 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
     case Clusters::LevelControl::Commands::StopWithOnOff::Id:
     {
         Clusters::LevelControl::Commands::StopWithOnOff::Type stopWithOnOffCommand;
-        stopWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
-        stopWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
+        if (auto stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
+        {
+            stopWithOnOffCommand.optionsMask     = stop->optionsMask;
+            stopWithOnOffCommand.optionsOverride = stop->optionsOverride;
+        }
         Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
                                          stopWithOnOffCommand, onSuccess, onFailure);
         break;
@@ -210,10 +232,13 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
     case Clusters::LevelControl::Commands::MoveToLevel::Id:
     {
         Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
-        moveToLevelCommand.level           = static_cast<uint8_t>(data->args[0]);
-        moveToLevelCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
-        moveToLevelCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
-        moveToLevelCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        if (auto moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
+        {
+            moveToLevelCommand.level           = moveToLevel->level;
+            moveToLevelCommand.transitionTime  = moveToLevel->transitionTime;
+            moveToLevelCommand.optionsMask     = moveToLevel->optionsMask;
+            moveToLevelCommand.optionsOverride = moveToLevel->optionsOverride;
+        }
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveToLevelCommand);
         break;
     }
@@ -221,10 +246,13 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
     case Clusters::LevelControl::Commands::Move::Id:
     {
         Clusters::LevelControl::Commands::Move::Type moveCommand;
-        moveCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
-        moveCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
-        moveCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
-        moveCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        if (auto move = std::get_if<BindingCommandData::Move>(&data->commandData))
+        {
+            moveCommand.moveMode        = move->moveMode;
+            moveCommand.rate            = move->rate;
+            moveCommand.optionsMask     = move->optionsMask;
+            moveCommand.optionsOverride = move->optionsOverride;
+        }
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveCommand);
         break;
     }
@@ -232,11 +260,14 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
     case Clusters::LevelControl::Commands::Step::Id:
     {
         Clusters::LevelControl::Commands::Step::Type stepCommand;
-        stepCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
-        stepCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
-        stepCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
-        stepCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
-        stepCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[4]);
+        if (auto step = std::get_if<BindingCommandData::Step>(&data->commandData))
+        {
+            stepCommand.stepMode        = step->stepMode;
+            stepCommand.stepSize        = step->stepSize;
+            stepCommand.transitionTime  = step->transitionTime;
+            stepCommand.optionsMask     = step->optionsMask;
+            stepCommand.optionsOverride = step->optionsOverride;
+        }
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stepCommand);
         break;
     }
@@ -244,8 +275,11 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
     case Clusters::LevelControl::Commands::Stop::Id:
     {
         Clusters::LevelControl::Commands::Stop::Type stopCommand;
-        stopCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
-        stopCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
+        if (auto stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
+        {
+            stopCommand.optionsMask     = stop->optionsMask;
+            stopCommand.optionsOverride = stop->optionsOverride;
+        }
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stopCommand);
         break;
     }
@@ -253,10 +287,13 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
     case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id:
     {
         Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type moveToLevelWithOnOffCommand;
-        moveToLevelWithOnOffCommand.level           = static_cast<uint8_t>(data->args[0]);
-        moveToLevelWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[1]);
-        moveToLevelWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
-        moveToLevelWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        if (auto moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
+        {
+            moveToLevelWithOnOffCommand.level           = moveToLevel->level;
+            moveToLevelWithOnOffCommand.transitionTime  = moveToLevel->transitionTime;
+            moveToLevelWithOnOffCommand.optionsMask     = moveToLevel->optionsMask;
+            moveToLevelWithOnOffCommand.optionsOverride = moveToLevel->optionsOverride;
+        }
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveToLevelWithOnOffCommand);
         break;
     }
@@ -264,10 +301,13 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
     case Clusters::LevelControl::Commands::MoveWithOnOff::Id:
     {
         Clusters::LevelControl::Commands::MoveWithOnOff::Type moveWithOnOffCommand;
-        moveWithOnOffCommand.moveMode        = static_cast<MoveModeEnum>(data->args[0]);
-        moveWithOnOffCommand.rate            = static_cast<DataModel::Nullable<uint8_t>>(data->args[1]);
-        moveWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[2]);
-        moveWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
+        if (auto move = std::get_if<BindingCommandData::Move>(&data->commandData))
+        {
+            moveWithOnOffCommand.moveMode        = move->moveMode;
+            moveWithOnOffCommand.rate            = move->rate;
+            moveWithOnOffCommand.optionsMask     = move->optionsMask;
+            moveWithOnOffCommand.optionsOverride = move->optionsOverride;
+        }
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, moveWithOnOffCommand);
         break;
     }
@@ -275,11 +315,14 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
     case Clusters::LevelControl::Commands::StepWithOnOff::Id:
     {
         Clusters::LevelControl::Commands::StepWithOnOff::Type stepWithOnOffCommand;
-        stepWithOnOffCommand.stepMode        = static_cast<StepModeEnum>(data->args[0]);
-        stepWithOnOffCommand.stepSize        = static_cast<uint8_t>(data->args[1]);
-        stepWithOnOffCommand.transitionTime  = static_cast<DataModel::Nullable<uint16_t>>(data->args[2]);
-        stepWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[3]);
-        stepWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[4]);
+        if (auto step = std::get_if<BindingCommandData::Step>(&data->commandData))
+        {
+            stepWithOnOffCommand.stepMode        = step->stepMode;
+            stepWithOnOffCommand.stepSize        = step->stepSize;
+            stepWithOnOffCommand.transitionTime  = step->transitionTime;
+            stepWithOnOffCommand.optionsMask     = step->optionsMask;
+            stepWithOnOffCommand.optionsOverride = step->optionsOverride;
+        }
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stepWithOnOffCommand);
         break;
     }
@@ -287,8 +330,11 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
     case Clusters::LevelControl::Commands::StopWithOnOff::Id:
     {
         Clusters::LevelControl::Commands::StopWithOnOff::Type stopWithOnOffCommand;
-        stopWithOnOffCommand.optionsMask     = static_cast<chip::BitMask<OptionsBitmap>>(data->args[0]);
-        stopWithOnOffCommand.optionsOverride = static_cast<chip::BitMask<OptionsBitmap>>(data->args[1]);
+        if (auto stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
+        {
+            stopWithOnOffCommand.optionsMask     = stop->optionsMask;
+            stopWithOnOffCommand.optionsOverride = stop->optionsOverride;
+        }
         Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, stopWithOnOffCommand);
         break;
     }

--- a/examples/light-switch-app/silabs/src/BindingHandler.cpp
+++ b/examples/light-switch-app/silabs/src/BindingHandler.cpp
@@ -26,8 +26,6 @@
 #include <app/clusters/bindings/bindings.h>
 #include <lib/support/CodeUtils.h>
 
-#include <lib/support/TypeTraits.h>
-
 using namespace chip;
 using namespace chip::app;
 using chip::app::Clusters::LevelControl::MoveModeEnum;

--- a/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
+++ b/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
@@ -84,7 +84,7 @@ void LightSwitchMgr::HandleLongPress()
     {
         if (!mResetWarning)
         {
-            // Long press button up: Reset warning!
+            // Long press button down: Reset warning!
             event.Type = AppEvent::kEventType_ResetWarning;
             AppTask::GetAppTask().PostEvent(&event);
         }

--- a/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
+++ b/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
@@ -136,7 +136,7 @@ void LightSwitchMgr::Timer::Stop()
 
 void LightSwitchMgr::Timer::TimerCallback(void * timerCbArg)
 {
-    Timer * timer = static_cast<Timer *>(timerCbArg);
+    Timer * timer = reinterpret_cast<Timer *>(timerCbArg);
     if (timer)
     {
         timer->Timeout();
@@ -290,7 +290,7 @@ void LightSwitchMgr::GenericSwitchWorkerFunction(intptr_t context)
 void LightSwitchMgr::ButtonEventHandler(uint8_t button, uint8_t btnAction)
 {
     AppEvent event = {};
-    if (btnAction == static_cast<uint8_t>(SilabsPlatform::ButtonAction::ButtonPressed))
+    if (btnAction == to_underlying(SilabsPlatform::ButtonAction::ButtonPressed))
     {
         event = CreateNewEvent(button ? AppEvent::kEventType_UpPressed : AppEvent::kEventType_DownPressed);
     }

--- a/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
+++ b/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
@@ -345,16 +345,10 @@ void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
 
 void LightSwitchMgr::SwitchActionEventHandler(AppEvent * aEvent)
 {
-    static bool mCurrentButtonState = false;
-
     switch(aEvent->Type)
     {
     case AppEvent::kEventType_UpPressed: {
-        mCurrentButtonState = !mCurrentButtonState;
-        LightSwitchMgr::LightSwitchAction action =
-            mCurrentButtonState ? LightSwitchMgr::LightSwitchAction::On : LightSwitchMgr::LightSwitchAction::Off;
-        
-        LightSwitchMgr::GetInstance().TriggerLightSwitchAction(action);
+        LightSwitchMgr::GetInstance().TriggerLightSwitchAction(LightSwitchMgr::LightSwitchAction::Toggle);
         LightSwitchMgr::GetInstance().GenericSwitchOnInitialPress();
         }
         break;
@@ -364,7 +358,7 @@ void LightSwitchMgr::SwitchActionEventHandler(AppEvent * aEvent)
 #if 0
     // TODO: Fix the button handling for the btn0 and btn1
     case AppEvent::kEventType_DownPressed:
-        LightSwitchMgr::GetInstance().TriggerLightSwitchAction(action);
+        LightSwitchMgr::GetInstance().TriggerLevelControlAction(LevelControl::StepModeEnum::kDown);
         break;
 #endif
     default:

--- a/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
+++ b/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
@@ -345,18 +345,28 @@ void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
 
 void LightSwitchMgr::SwitchActionEventHandler(AppEvent * aEvent)
 {
+    static bool mCurrentButtonState = false;
+
     switch(aEvent->Type)
     {
-    case AppEvent::kEventType_UpPressed:
-        LightSwitchMgr::GetInstance().TriggerLevelControlAction(LevelControl::StepModeEnum::kUp);
+    case AppEvent::kEventType_UpPressed: {
+        mCurrentButtonState = !mCurrentButtonState;
+        LightSwitchMgr::LightSwitchAction action =
+            mCurrentButtonState ? LightSwitchMgr::LightSwitchAction::On : LightSwitchMgr::LightSwitchAction::Off;
+        
+        LightSwitchMgr::GetInstance().TriggerLightSwitchAction(action);
         LightSwitchMgr::GetInstance().GenericSwitchOnInitialPress();
+        }
         break;
     case AppEvent::kEventType_UpReleased:
         LightSwitchMgr::GetInstance().GenericSwitchOnShortRelease();
         break;
+#if 0
+    // TODO: Fix the button handling for the btn0 and btn1
     case AppEvent::kEventType_DownPressed:
-        LightSwitchMgr::GetInstance().TriggerLevelControlAction(LevelControl::StepModeEnum::kDown);
+        LightSwitchMgr::GetInstance().TriggerLightSwitchAction(action);
         break;
+#endif
     default:
         break;
     }

--- a/examples/light-switch-app/silabs/src/ShellCommands.cpp
+++ b/examples/light-switch-app/silabs/src/ShellCommands.cpp
@@ -38,9 +38,11 @@ using Shell::streamer_printf;
 
 Engine sShellSwitchSubCommands;
 Engine sShellSwitchOnOffSubCommands;
+Engine sShellSwitchLevelControlSubCommands;
 
 Engine sShellSwitchGroupsSubCommands;
 Engine sShellSwitchGroupsOnOffSubCommands;
+Engine sShellSwitchGroupsLevelControlSubCommands;
 
 Engine sShellSwitchBindingSubCommands;
 
@@ -238,6 +240,542 @@ CHIP_ERROR GroupToggleSwitchCommandHandler(int argc, char ** argv)
     return CHIP_NO_ERROR;
 }
 
+/********************************************************
+ * LevelControl switch shell functions
+ *********************************************************/
+
+CHIP_ERROR LevelControlHelpHandler(int argc, char ** argv)
+{
+    sShellSwitchLevelControlSubCommands.ForEachCommand(Shell::PrintCommandHelp, nullptr);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc == 0)
+    {
+        return LevelControlHelpHandler(argc, argv);
+    }
+
+    return sShellSwitchLevelControlSubCommands.ExecCommand(argc, argv);
+}
+
+CHIP_ERROR MoveToLevelSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 4)
+    {
+        return LevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::MoveToLevel::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR MoveSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 4)
+    {
+        return LevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::Move::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR StepSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 5)
+    {
+        return LevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::Step::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+    data->args[4]             = atoi(argv[4]);
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR StopSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 2)
+    {
+        return LevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::Stop::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR MoveToLevelWithOnOffSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 4)
+    {
+        return LevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR MoveWithOnOffSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 4)
+    {
+        return LevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::MoveWithOnOff::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR StepWithOnOffSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 5)
+    {
+        return LevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::StepWithOnOff::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+    data->args[4]             = atoi(argv[4]);
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR StopWithOnOffSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 2)
+    {
+        return LevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::StopWithOnOff::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+#if 0
+/********************************************************
+ * LevelControl Read switch shell functions
+ *********************************************************/
+
+CHIP_ERROR LevelControlReadHelpHandler(int argc, char ** argv)
+{
+    sShellSwitchLevelControlReadSubCommands.ForEachCommand(Shell::PrintCommandHelp, nullptr);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlRead(int argc, char ** argv)
+{
+    if (argc == 0)
+    {
+        return LevelControlReadHelpHandler(argc, argv);
+    }
+
+    return sShellSwitchLevelControlReadSubCommands.ExecCommand(argc, argv);
+}
+
+CHIP_ERROR LevelControlReadAttributeList(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::AttributeList::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadCurrentLevel(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::CurrentLevel::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadRemainingTime(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::RemainingTime::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadMinLevel(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::MinLevel::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadMaxLevel(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::MaxLevel::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadCurrentFrequency(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::CurrentFrequency::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadMinFrequency(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::MinFrequency::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadMaxFrequency(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::MaxFrequency::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadOptions(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::Options::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadOnOffTransitionTime(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::OnOffTransitionTime::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadOnLevel(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::OnLevel::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadOnTransitionTime(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::OnTransitionTime::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadOffTransitionTime(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::OffTransitionTime::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadDefaultMoveRate(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::DefaultMoveRate::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LevelControlReadStartUpCurrentLevel(int argc, char ** argv)
+{
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->attributeId         = Clusters::LevelControl::Attributes::StartUpCurrentLevel::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->isReadAttribute     = true;
+    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+#endif // commenting the read functions
+
+/********************************************************
+ * Groups LevelControl switch shell functions
+ *********************************************************/
+
+CHIP_ERROR GroupsLevelControlHelpHandler(int argc, char ** argv)
+{
+    sShellSwitchGroupsLevelControlSubCommands.ForEachCommand(Shell::PrintCommandHelp, nullptr);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GroupsLevelControlSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc == 0)
+    {
+        return GroupsLevelControlHelpHandler(argc, argv);
+    }
+
+    return sShellSwitchGroupsLevelControlSubCommands.ExecCommand(argc, argv);
+}
+
+CHIP_ERROR GroupsMoveToLevelSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 4)
+    {
+        return GroupsLevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::MoveToLevel::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+    data->isGroup             = true;
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GroupsMoveSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 4)
+    {
+        return GroupsLevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::Move::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+    data->isGroup             = true;
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GroupsStepSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 5)
+    {
+        return GroupsLevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::Step::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+    data->args[4]             = atoi(argv[4]);
+    data->isGroup             = true;
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GroupsStopSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 2)
+    {
+        return GroupsLevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::Stop::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->isGroup             = true;
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GroupsMoveToLevelWithOnOffSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 4)
+    {
+        return GroupsLevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+    data->isGroup             = true;
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GroupsMoveWithOnOffSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 4)
+    {
+        return GroupsLevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::MoveWithOnOff::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+    data->isGroup             = true;
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GroupsStepWithOnOffSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 5)
+    {
+        return GroupsLevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::StepWithOnOff::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->args[2]             = atoi(argv[2]);
+    data->args[3]             = atoi(argv[3]);
+    data->args[4]             = atoi(argv[4]);
+    data->isGroup             = true;
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GroupsStopWithOnOffSwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc != 2)
+    {
+        return GroupsLevelControlHelpHandler(argc, argv);
+    }
+
+    BindingCommandData * data = Platform::New<BindingCommandData>();
+    data->commandId           = Clusters::LevelControl::Commands::StopWithOnOff::Id;
+    data->clusterId           = Clusters::LevelControl::Id;
+    data->args[0]             = atoi(argv[0]);
+    data->args[1]             = atoi(argv[1]);
+    data->isGroup             = true;
+
+    DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
+    return CHIP_NO_ERROR;
+}
+
 /**
  * @brief configures switch matter shell
  */
@@ -246,6 +784,7 @@ void RegisterSwitchCommands()
     static const shell_command_t sSwitchSubCommands[] = {
         { &SwitchHelpHandler, "help", "Usage: switch <subcommand>" },
         { &OnOffSwitchCommandHandler, "onoff", " Usage: switch onoff <subcommand>" },
+        { &LevelControlSwitchCommandHandler, "levelcontrol", " Usage: switch levelcontrol <subcommand>" },
         { &GroupsSwitchCommandHandler, "groups", "Usage: switch groups <subcommand>" },
         { &BindingSwitchCommandHandler, "binding", "Usage: switch binding <subcommand>" }
     };
@@ -255,6 +794,26 @@ void RegisterSwitchCommands()
         { &OnSwitchCommandHandler, "on", "Sends on command to bound lighting app" },
         { &OffSwitchCommandHandler, "off", "Sends off command to bound lighting app" },
         { &ToggleSwitchCommandHandler, "toggle", "Sends toggle command to bound lighting app" }
+    };
+
+    static const shell_command_t sSwitchLevelControlSubCommands[] = {
+        { &LevelControlHelpHandler, "help", "Usage: switch levelcontrol <subcommand>" },
+        { &MoveToLevelSwitchCommandHandler, "move-to-level",
+          "Usage: switch levelcontrol move-to-level <level> <transitiontime> <optionsmask> <optionsoverride>" },
+        { &MoveSwitchCommandHandler, "move",
+          "Usage: switch levelcontrol move <movemode> <rate> <optionsmask> <optionsoverride>" },
+        { &StepSwitchCommandHandler, "step",
+          "Usage: switch levelcontrol step <stepmode> <stepsize> <transitiontime> <optionsmask> <optionsoverride>" },
+        { &StopSwitchCommandHandler, "stop", "step Usage: switch levelcontrol stop <optionsmask> <optionsoverride>" },
+        { &MoveToLevelWithOnOffSwitchCommandHandler, "move-to-level-with-on-off",
+          "Usage: switch levelcontrol move-with-to-level-with-on-off <level> <transitiontime> <optionsmask> <optionsoverride>" },
+        { &MoveWithOnOffSwitchCommandHandler, "move-with-on-off",
+          "Usage: switch levelcontrol move-with-on-off <movemode> <rate> <optionsmask> <optionsoverride>" },
+        { &StepWithOnOffSwitchCommandHandler, "step-with-on-off",
+          "Usage: switch levelcontrol step-with-on-off <stepmode> <stepsize> <transitiontime> <optionsmask> "
+          "<optionsoverride>" },
+        { &StopWithOnOffSwitchCommandHandler, "stop-with-on-off",
+          "Usage: switch levelcontrol stop-with-on-off <optionsmask> <optionsoverride>" },
     };
 
     static const shell_command_t sSwitchGroupsSubCommands[] = { { &GroupsHelpHandler, "help", "Usage: switch groups <subcommand>" },
@@ -268,6 +827,26 @@ void RegisterSwitchCommands()
         { &GroupToggleSwitchCommandHandler, "toggle", "Sends toggle command to group" }
     };
 
+    static const shell_command_t sSwitchGroupsLevelControlSubCommands[] = {
+        { &GroupsLevelControlHelpHandler, "help", "Usage: switch groups levelcontrol <subcommand>" },
+        { &GroupsMoveToLevelSwitchCommandHandler, "move-to-level",
+          "Usage: switch groups levelcontrol move-to-level <level> <transitiontime> <optionsmask> <optionsoverride>" },
+        { &GroupsMoveSwitchCommandHandler, "move",
+          "Usage: switch groups levelcontrol move <movemode> <rate> <optionsmask> <optionsoverride>" },
+        { &GroupsStepSwitchCommandHandler, "step",
+          "Usage: switch groups levelcontrol step <stepmode> <stepsize> <transitiontime> <optionsmask> <optionsoverride>" },
+        { &GroupsStopSwitchCommandHandler, "stop", "step Usage: switch groups levelcontrol stop <optionsmask> <optionsoverride>" },
+        { &GroupsMoveToLevelWithOnOffSwitchCommandHandler, "move-to-level-with-on-off",
+          "Usage: switch groups levelcontrol move-with-to-level-with-on-off <level> <transitiontime> <optionsmask> <optionsoverride>" },
+        { &GroupsMoveWithOnOffSwitchCommandHandler, "move-with-on-off",
+          "Usage: switch groups levelcontrol move-with-on-off <movemode> <rate> <optionsmask> <optionsoverride>" },
+        { &GroupsStepWithOnOffSwitchCommandHandler, "step-with-on-off",
+          "Usage: switch groups levelcontrol step-with-on-off <stepmode> <stepsize> <transitiontime> <optionsmask> "
+          "<optionsoverride>" },
+        { &GroupsStopWithOnOffSwitchCommandHandler, "stop-with-on-off",
+          "Usage: switch groups levelcontrol stop-with-on-off <optionsmask> <optionsoverride>" },
+    };
+
     static const shell_command_t sSwitchBindingSubCommands[] = {
         { &BindingHelpHandler, "help", "Usage: switch binding <subcommand>" },
         { &BindingGroupBindCommandHandler, "group", "Usage: switch binding group <fabric index> <group id>" },
@@ -278,7 +857,9 @@ void RegisterSwitchCommands()
                                                     "Light-switch commands. Usage: switch <subcommand>" };
 
     sShellSwitchGroupsOnOffSubCommands.RegisterCommands(sSwitchGroupsOnOffSubCommands, ArraySize(sSwitchGroupsOnOffSubCommands));
+    sShellSwitchGroupsLevelControlSubCommands.RegisterCommands(sSwitchGroupsLevelControlSubCommands, ArraySize(sSwitchGroupsLevelControlSubCommands));
     sShellSwitchOnOffSubCommands.RegisterCommands(sSwitchOnOffSubCommands, ArraySize(sSwitchOnOffSubCommands));
+    sShellSwitchLevelControlSubCommands.RegisterCommands(sSwitchLevelControlSubCommands, ArraySize(sSwitchLevelControlSubCommands));
     sShellSwitchGroupsSubCommands.RegisterCommands(sSwitchGroupsSubCommands, ArraySize(sSwitchGroupsSubCommands));
     sShellSwitchBindingSubCommands.RegisterCommands(sSwitchBindingSubCommands, ArraySize(sSwitchBindingSubCommands));
     sShellSwitchSubCommands.RegisterCommands(sSwitchSubCommands, ArraySize(sSwitchSubCommands));

--- a/examples/light-switch-app/silabs/src/ShellCommands.cpp
+++ b/examples/light-switch-app/silabs/src/ShellCommands.cpp
@@ -270,10 +270,11 @@ CHIP_ERROR MoveToLevelSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevel::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
+    for(int i = 0; i < 4; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -289,10 +290,11 @@ CHIP_ERROR MoveSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Move::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
+    for(int i = 0; i < 4; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -308,11 +310,11 @@ CHIP_ERROR StepSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Step::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
-    data->args[4]             = atoi(argv[4]);
+    for(int i = 0; i < 5; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -328,8 +330,11 @@ CHIP_ERROR StopSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Stop::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
+    for(int i = 0; i < 2; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -345,10 +350,11 @@ CHIP_ERROR MoveToLevelWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
+    for(int i = 0; i < 4; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -364,10 +370,11 @@ CHIP_ERROR MoveWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
+    for(int i = 0; i < 4; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -383,11 +390,11 @@ CHIP_ERROR StepWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::StepWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
-    data->args[4]             = atoi(argv[4]);
+    for(int i = 0; i < 5; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -403,8 +410,11 @@ CHIP_ERROR StopWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::StopWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
+    for(int i = 0; i < 2; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -628,10 +638,11 @@ CHIP_ERROR GroupsMoveToLevelSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevel::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
+    for(int i = 0; i < 4; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
     data->isGroup             = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -648,10 +659,11 @@ CHIP_ERROR GroupsMoveSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Move::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
+    for(int i = 0; i < 4; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
     data->isGroup             = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -668,11 +680,11 @@ CHIP_ERROR GroupsStepSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Step::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
-    data->args[4]             = atoi(argv[4]);
+    for(int i = 0; i < 5; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
     data->isGroup             = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -689,8 +701,11 @@ CHIP_ERROR GroupsStopSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Stop::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
+    for(int i = 0; i < 2; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
     data->isGroup             = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -707,10 +722,11 @@ CHIP_ERROR GroupsMoveToLevelWithOnOffSwitchCommandHandler(int argc, char ** argv
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
+    for(int i = 0; i < 4; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
     data->isGroup             = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -727,10 +743,11 @@ CHIP_ERROR GroupsMoveWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
+    for(int i = 0; i < 4; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
     data->isGroup             = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -747,11 +764,11 @@ CHIP_ERROR GroupsStepWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::StepWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
-    data->args[2]             = atoi(argv[2]);
-    data->args[3]             = atoi(argv[3]);
-    data->args[4]             = atoi(argv[4]);
+    for(int i = 0; i < 5; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
     data->isGroup             = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -768,8 +785,11 @@ CHIP_ERROR GroupsStopWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::StopWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->args[0]             = atoi(argv[0]);
-    data->args[1]             = atoi(argv[1]);
+    for(int i = 0; i < 2; i++)
+    {
+        char *endPtr;
+        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+    }
     data->isGroup             = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));

--- a/examples/light-switch-app/silabs/src/ShellCommands.cpp
+++ b/examples/light-switch-app/silabs/src/ShellCommands.cpp
@@ -270,12 +270,15 @@ CHIP_ERROR MoveToLevelSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevel::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 4; i++)
+    data->commandData = BindingCommandData::MoveToLevel{};
+    char * endPtr;
+    if (auto *moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        moveToLevel->level = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
+        moveToLevel->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
+        moveToLevel->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        moveToLevel->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
-
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -290,10 +293,14 @@ CHIP_ERROR MoveSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Move::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 4; i++)
+    data->commandData = BindingCommandData::Move{};
+    char * endPtr;
+    if (auto *move = std::get_if<BindingCommandData::Move>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        move->moveMode = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
+        move->rate = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
+        move->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        move->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -310,12 +317,16 @@ CHIP_ERROR StepSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Step::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 5; i++)
+    char * endPtr;
+    data->commandData = BindingCommandData::Step{};
+    if (auto *step = std::get_if<BindingCommandData::Step>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        step->stepMode = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
+        step->stepSize = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
+        step->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
+        step->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
+        step->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[4], &endPtr, 10));
     }
-
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -330,10 +341,12 @@ CHIP_ERROR StopSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Stop::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 2; i++)
+    char * endPtr;
+    data->commandData = BindingCommandData::Stop{};
+    if (auto *stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        stop->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
+        stop->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[1], &endPtr, 10));
     }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -350,10 +363,14 @@ CHIP_ERROR MoveToLevelWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 4; i++)
+    data->commandData = BindingCommandData::MoveToLevel{};
+    char * endPtr;
+    if (auto *moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        moveToLevel->level = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
+        moveToLevel->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
+        moveToLevel->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        moveToLevel->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -370,10 +387,14 @@ CHIP_ERROR MoveWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 4; i++)
+    data->commandData = BindingCommandData::Move{};
+    char * endPtr;
+    if (auto *move = std::get_if<BindingCommandData::Move>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        move->moveMode = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
+        move->rate = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
+        move->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        move->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -390,10 +411,15 @@ CHIP_ERROR StepWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::StepWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 5; i++)
+    char * endPtr;
+    data->commandData = BindingCommandData::Step{};
+    if (auto *step = std::get_if<BindingCommandData::Step>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        step->stepMode = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
+        step->stepSize = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
+        step->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
+        step->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
+        step->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[4], &endPtr, 10));
     }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -410,10 +436,12 @@ CHIP_ERROR StopWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::StopWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 2; i++)
+    char * endPtr;
+    data->commandData = BindingCommandData::Stop{};
+    if (auto *stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        stop->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
+        stop->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[1], &endPtr, 10));
     }
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -638,10 +666,14 @@ CHIP_ERROR GroupsMoveToLevelSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevel::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 4; i++)
+    data->commandData = BindingCommandData::MoveToLevel{};
+    char * endPtr;
+    if (auto *moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        moveToLevel->level = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
+        moveToLevel->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
+        moveToLevel->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        moveToLevel->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
     data->isGroup             = true;
 
@@ -659,10 +691,14 @@ CHIP_ERROR GroupsMoveSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Move::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 4; i++)
+    data->commandData = BindingCommandData::Move{};
+    char * endPtr;
+    if (auto *move = std::get_if<BindingCommandData::Move>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        move->moveMode = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
+        move->rate = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
+        move->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        move->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
     data->isGroup             = true;
 
@@ -680,10 +716,15 @@ CHIP_ERROR GroupsStepSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Step::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 5; i++)
+    char * endPtr;
+    data->commandData = BindingCommandData::Step{};
+    if (auto *step = std::get_if<BindingCommandData::Step>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        step->stepMode = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
+        step->stepSize = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
+        step->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
+        step->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
+        step->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[4], &endPtr, 10));
     }
     data->isGroup             = true;
 
@@ -701,10 +742,12 @@ CHIP_ERROR GroupsStopSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Stop::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 2; i++)
+    char * endPtr;
+    data->commandData = BindingCommandData::Stop{};
+    if (auto *stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        stop->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
+        stop->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[1], &endPtr, 10));
     }
     data->isGroup             = true;
 
@@ -722,10 +765,14 @@ CHIP_ERROR GroupsMoveToLevelWithOnOffSwitchCommandHandler(int argc, char ** argv
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 4; i++)
+    data->commandData = BindingCommandData::MoveToLevel{};
+    char * endPtr;
+    if (auto *moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        moveToLevel->level = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
+        moveToLevel->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
+        moveToLevel->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        moveToLevel->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
     data->isGroup             = true;
 
@@ -743,10 +790,14 @@ CHIP_ERROR GroupsMoveWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 4; i++)
+    data->commandData = BindingCommandData::Move{};
+    char * endPtr;
+    if (auto *move = std::get_if<BindingCommandData::Move>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        move->moveMode = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
+        move->rate = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
+        move->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        move->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
     data->isGroup             = true;
 
@@ -764,10 +815,15 @@ CHIP_ERROR GroupsStepWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::StepWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 5; i++)
+    char * endPtr;
+    data->commandData = BindingCommandData::Step{};
+    if (auto *step = std::get_if<BindingCommandData::Step>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        step->stepMode = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
+        step->stepSize = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
+        step->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
+        step->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
+        step->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[4], &endPtr, 10));
     }
     data->isGroup             = true;
 
@@ -785,10 +841,12 @@ CHIP_ERROR GroupsStopWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::StopWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    for(int i = 0; i < 2; i++)
+    char * endPtr;
+    data->commandData = BindingCommandData::Stop{};
+    if (auto *stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
     {
-        char *endPtr;
-        data->args[i] = static_cast<int>(strtol(argv[i], &endPtr, 10));
+        stop->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
+        stop->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[1], &endPtr, 10));
     }
     data->isGroup             = true;
 


### PR DESCRIPTION
This PR adds the dimmer-switch application by extending the existing light-switch application.


The zap file of light-switch app is modified by adding level-control-cluster client.The levelcontrol cluster can be controlled by sending commands from shell.

Button switch level control will be added in a follow up PR

**Tested:**
Tested locally with a lighting app device levelcontrol commands handled by the switch