### PR TITLE
[SL-UP] Add supported wifi bands attribute for lock-app.

### DIFF
--- a/examples/lock-app/silabs/data_model/lock-app.matter
+++ b/examples/lock-app/silabs/data_model/lock-app.matter
@@ -2934,6 +2934,7 @@ endpoint 0 {
     ram      attribute lastNetworkingStatus;
     ram      attribute lastNetworkID;
     ram      attribute lastConnectErrorValue;
+    callback attribute supportedWiFiBands;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute eventList;

--- a/examples/lock-app/silabs/data_model/lock-app.zap
+++ b/examples/lock-app/silabs/data_model/lock-app.zap
@@ -1859,6 +1859,22 @@
               "reportableChange": 0
             },
             {
+              "name": "SupportedWiFiBands",
+              "code": 8,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "GeneratedCommandList",
               "code": 65528,
               "mfgCode": null,


### PR DESCRIPTION
**JIRA** : [MATTER-4302](https://jira.silabs.com/browse/MATTER-4302)

**Issue** : SupportedWifiBands attribute is not added in lock-app zap file, so we are getting UNSUPPORTED_ATTRIBUTE error while trying to read through chip-tool.

**Fix** : Added the missing attribute in zap file.