### PR TITLE
[SL-ONLY] Silabs Tracing Macros

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -90,12 +90,9 @@
 #endif
 
 // Tracing
-#include <matter/tracing/build_config.h>
-#if MATTER_TRACING_ENABLED
-#ifdef ENABLE_CHIP_SHELL
+#include <platform/silabs/tracing/SilabsTracingMacros.h>
+#if MATTER_TRACING_ENABLED && defined(ENABLE_CHIP_SHELL)
 #include <TracingShellCommands.h>
-#endif // ENABLE_CHIP_SHELL
-#include <platform/silabs/tracing/SilabsTracing.h>
 #endif // MATTER_TRACING_ENABLED
 
 // sl-only
@@ -127,11 +124,7 @@ using namespace chip::app;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Silabs;
 
-#if MATTER_TRACING_ENABLED
 using TimeTraceOperation = chip::Tracing::Silabs::TimeTraceOperation;
-using SilabsTracer       = chip::Tracing::Silabs::SilabsTracer;
-#endif // MATTER_TRACING_ENABLED
-
 namespace {
 
 /**********************************************************
@@ -375,10 +368,8 @@ CHIP_ERROR BaseApplication::Init()
 
 void BaseApplication::InitCompleteCallback(CHIP_ERROR err)
 {
-#if MATTER_TRACING_ENABLED
-    SilabsTracer::Instance().TimeTraceEnd(TimeTraceOperation::kAppInit);
-    SilabsTracer::Instance().TimeTraceEnd(TimeTraceOperation::kBootup);
-#endif // MATTER_TRACING_ENABLED
+    SILABS_TRACE_END(TimeTraceOperation::kAppInit);
+    SILABS_TRACE_END(TimeTraceOperation::kBootup);
 }
 
 void BaseApplication::FunctionTimerEventHandler(void * timerCbArg)

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -48,11 +48,11 @@
 #include "MemMonitoring.h"
 #endif
 
-#if ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) || defined(EXP_BOARD) )
+#if ((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1) || defined(EXP_BOARD))
 #include <platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.h>
 #if !defined(EXP_BOARD)
 #include <platform/silabs/SiWx917/SiWxPlatformInterface.h>
-#endif  //!defined(EXP_BOARD)
+#endif //! defined(EXP_BOARD)
 #endif // ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) || defined(EXP_BOARD) )
 
 #include <crypto/CHIPCryptoPAL.h>
@@ -97,10 +97,9 @@ static chip::DeviceLayer::Internal::Efr32PsaOperationalKeystore gOperationalKeys
 #include "sl_power_manager.h"
 #endif
 
-#include <matter/tracing/build_config.h>
+#include <platform/silabs/tracing/SilabsTracingMacros.h>
 #if MATTER_TRACING_ENABLED
 #include <platform/silabs/tracing/BackendImpl.h>
-#include <platform/silabs/tracing/SilabsTracing.h>
 #include <tracing/registry.h>
 #endif // MATTER_TRACING_ENABLED
 
@@ -113,11 +112,7 @@ using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::Credentials;
 using namespace chip::DeviceLayer::Silabs;
-
-#if MATTER_TRACING_ENABLED
 using TimeTraceOperation = chip::Tracing::Silabs::TimeTraceOperation;
-using SilabsTracer       = chip::Tracing::Silabs::SilabsTracer;
-#endif // MATTER_TRACING_ENABLED
 
 #if CHIP_ENABLE_OPENTHREAD
 #include <inet/EndPointStateOpenThread.h>
@@ -193,10 +188,8 @@ void ApplicationStart(void * unused)
     if (err != CHIP_NO_ERROR)
         appError(err);
 
-#if MATTER_TRACING_ENABLED
-    SilabsTracer::Instance().TimeTraceEnd(TimeTraceOperation::kMatterInit);
-    SilabsTracer::Instance().TimeTraceBegin(TimeTraceOperation::kAppInit);
-#endif // MATTER_TRACING_ENABLED
+    SILABS_TRACE_END(TimeTraceOperation::kMatterInit);
+    SILABS_TRACE_BEGIN(TimeTraceOperation::kAppInit);
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
@@ -381,7 +374,7 @@ CHIP_ERROR SilabsMatterConfig::InitWiFi(void)
 #endif // SL_WFX_USE_SECURE_LINK
 #endif // WF200_WIFI
 
-#if ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) || defined(EXP_BOARD) )
+#if ((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1) || defined(EXP_BOARD))
     VerifyOrReturnError(sl_matter_wifi_platform_init() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
 #endif // ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) || defined(EXP_BOARD) )
 

--- a/examples/platform/silabs/main.cpp
+++ b/examples/platform/silabs/main.cpp
@@ -20,28 +20,17 @@
 #include "sl_system_init.h"
 #include "sl_system_kernel.h"
 #include <MatterConfig.h>
+#include <platform/silabs/tracing/SilabsTracingMacros.h>
 
-#include <matter/tracing/build_config.h>
-#if MATTER_TRACING_ENABLED
-#include <platform/silabs/tracing/SilabsTracing.h>
-#endif // MATTER_TRACING_ENABLED
-
-#if MATTER_TRACING_ENABLED
 using TimeTraceOperation = chip::Tracing::Silabs::TimeTraceOperation;
-using SilabsTracer       = chip::Tracing::Silabs::SilabsTracer;
-#endif // MATTER_TRACING_ENABLED
 
 int main(void)
 {
-#if MATTER_TRACING_ENABLED
-    SilabsTracer::Instance().TimeTraceBegin(TimeTraceOperation::kBootup);
-    SilabsTracer::Instance().TimeTraceBegin(TimeTraceOperation::kSilabsInit);
-#endif // MATTER_TRACING_ENABLED
+    SILABS_TRACE_BEGIN(chip::Tracing::Silabs::TimeTraceOperation::kBootup);
+    SILABS_TRACE_BEGIN(chip::Tracing::Silabs::TimeTraceOperation::kSilabsInit);
     sl_system_init();
-#if MATTER_TRACING_ENABLED
-    SilabsTracer::Instance().TimeTraceEnd(TimeTraceOperation::kSilabsInit);
-    SilabsTracer::Instance().TimeTraceBegin(TimeTraceOperation::kMatterInit);
-#endif // MATTER_TRACING_ENABLED
+    SILABS_TRACE_END(chip::Tracing::Silabs::TimeTraceOperation::kSilabsInit);
+    SILABS_TRACE_BEGIN(chip::Tracing::Silabs::TimeTraceOperation::kMatterInit);
     // Initialize the application. For example, create periodic timer(s) or
     // task(s) if the kernel is present.
     SilabsMatterConfig::AppInit();

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -116,14 +116,17 @@ static_library("efr32") {
     "${chip_root}/src/platform/logging:headers",
   ]
   deps = [
-    "${chip_root}/src/tracing",
+    "${chip_root}/src/tracing/silabs:silabs_tracing",
     "${silabs_platform_dir}/provision:provision-headers",
   ]
 
   public_configs = []
 
   if (matter_enable_tracing_support) {
-    public_deps += [ "${chip_root}/src/platform/silabs/tracing:SilabsTracing" ]
+    public_deps += [
+      "${chip_root}/src/platform/silabs/tracing:SilabsTracing",
+      "${chip_root}/src/tracing",
+    ]
   }
 
   # Add platform crypto implementation

--- a/src/platform/silabs/tracing/BackendImpl.h
+++ b/src/platform/silabs/tracing/BackendImpl.h
@@ -20,20 +20,6 @@
 #include <tracing/metric_event.h>
 #include <tracing/registry.h>
 
-#define _MATTER_TRACE_DISABLE(...)                                                                                                 \
-    do                                                                                                                             \
-    {                                                                                                                              \
-    } while (false)
-
-// This gets forwarded to the multiplexed instance
-#define MATTER_TRACE_BEGIN(label, group) ::chip::Tracing::Internal::Begin(label, group)
-#define MATTER_TRACE_END(label, group) ::chip::Tracing::Internal::End(label, group)
-#define MATTER_TRACE_INSTANT(label, group) ::chip::Tracing::Internal::Instant(label, group)
-#define MATTER_TRACE_COUNTER(label) ::chip::Tracing::Internal::Counter(label)
-
-// We are not using this in our current implementation, so we are disabling it.
-#define MATTER_TRACE_SCOPE(...) _MATTER_TRACE_DISABLE(__VA_ARGS__)
-
 namespace chip {
 namespace Tracing {
 namespace Silabs {
@@ -46,8 +32,8 @@ class BackendImpl : public ::chip::Tracing::Backend
 public:
     BackendImpl() = default;
     // TraceBegin, TraceEnd and TraceInstant are redundant with LogMetricEvent in the usecases that we are trying to track,
-    // so we are not implementing these at the moment to avoid duplication of the same information in the trace. We might implement them
-    // in the future if we want to add new traces that are not related to our metrics measurements
+    // so we are not implementing these at the moment to avoid duplication of the same information in the trace. We might implement
+    // them in the future if we want to add new traces that are not related to our metrics measurements
     void TraceBegin(const char * label, const char * group) override;
     void TraceEnd(const char * label, const char * group) override;
     void TraceInstant(const char * label, const char * group) override;

--- a/src/platform/silabs/tracing/SilabsTracing.h
+++ b/src/platform/silabs/tracing/SilabsTracing.h
@@ -16,6 +16,7 @@
  ******************************************************************************/
 #pragma once
 
+#include "SilabsTracingTypes.h"
 #include <cstddef>
 #include <cstdlib>
 #include <lib/core/CHIPError.h>
@@ -35,43 +36,6 @@
 namespace chip {
 namespace Tracing {
 namespace Silabs {
-
-// Enum for the different operation to trace
-enum class TimeTraceOperation : uint8_t
-{
-    kSpake2p,
-    kPake1,
-    kPake2,
-    kPake3,
-    kOperationalCredentials,
-    kAttestationVerification,
-    kCSR,
-    kNOC,
-    kTransportLayer,
-    kTransportSetup,
-    kFindOperational,
-    kCaseSession,
-    kSigma1,
-    kSigma2,
-    kSigma3,
-    kOTA,
-    kImageUpload,
-    kImageVerification,
-    kAppApplyTime,
-    kBootup,
-    kSilabsInit,
-    kMatterInit,
-    kAppInit,
-    kBufferFull,
-    kNumTraces,
-};
-
-enum class OperationType : uint8_t
-{
-    kBegin,
-    kEnd,
-    kInstant,
-};
 
 struct TimeTracker
 {

--- a/src/platform/silabs/tracing/SilabsTracingMacros.h
+++ b/src/platform/silabs/tracing/SilabsTracingMacros.h
@@ -1,0 +1,67 @@
+/***************************************************************************
+ * @file SilabsTracing.h
+ * @brief Instrumenting for matter operation tracing for the Silicon Labs platform.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+#pragma once
+
+#define _MATTER_TRACE_DISABLE(...)                                                                                                 \
+    do                                                                                                                             \
+    {                                                                                                                              \
+    } while (false)
+
+#include "SilabsTracingTypes.h"
+#include <matter/tracing/build_config.h>
+#if MATTER_TRACING_ENABLED
+#include "SilabsTracing.h"
+#include <lib/core/CHIPError.h>
+#include <tracing/backend.h>
+#include <tracing/metric_event.h>
+#include <tracing/registry.h>
+
+// This gets forwarded to the multiplexed instance
+#define MATTER_TRACE_BEGIN(label, group) ::chip::Tracing::Internal::Begin(label, group)
+#define MATTER_TRACE_END(label, group) ::chip::Tracing::Internal::End(label, group)
+#define MATTER_TRACE_INSTANT(label, group) ::chip::Tracing::Internal::Instant(label, group)
+#define MATTER_TRACE_COUNTER(label) ::chip::Tracing::Internal::Counter(label)
+
+// We are not using this in our current implementation, so we are disabling it.
+#define MATTER_TRACE_SCOPE(...) _MATTER_TRACE_DISABLE(__VA_ARGS__)
+
+#define SILABS_TRACE_BEGIN(operation) ::chip::Tracing::Silabs::SilabsTracer::Instance().TimeTraceBegin(operation)
+#define SILABS_TRACE_END(operation) ::chip::Tracing::Silabs::SilabsTracer::Instance().TimeTraceEnd(operation)
+#define SILABS_TRACE_END_ERROR(operation, error) ::chip::Tracing::Silabs::SilabsTracer::Instance().TimeTraceEnd(operation, error)
+#define SILABS_TRACE_INSTANT(operation) ::chip::Tracing::Silabs::SilabsTracer::Instance().TimeTraceInstant(operation)
+#define SILABS_TRACE_INSTANT_ERROR(operation, error)                                                                               \
+    ::chip::Tracing::Silabs::SilabsTracer::Instance().TimeTraceInstant(operation, error)
+
+#define SILABS_TRACE_FLUSH_ALL() ::chip::Tracing::Silabs::SilabsTracer::Instance().TraceBufferFlushAll()
+
+#else // MATTER_TRACING_ENABLED
+
+#define MATTER_TRACE_BEGIN(label, group) _MATTER_TRACE_DISABLE(label, group)
+#define MATTER_TRACE_END(label, group) _MATTER_TRACE_DISABLE(label, group)
+#define MATTER_TRACE_INSTANT(label, group) _MATTER_TRACE_DISABLE(label, group)
+#define MATTER_TRACE_COUNTER(label) _MATTER_TRACE_DISABLE(label)
+#define MATTER_TRACE_SCOPE(...) _MATTER_TRACE_DISABLE(__VA_ARGS__)
+
+#define SILABS_TRACE_BEGIN(operation) _MATTER_TRACE_DISABLE(operation)
+#define SILABS_TRACE_END(operation) _MATTER_TRACE_DISABLE(operation)
+#define SILABS_TRACE_END_ERROR(operation, error) _MATTER_TRACE_DISABLE(operation, error)
+#define SILABS_TRACE_INSTANT(operation) _MATTER_TRACE_DISABLE(operation)
+#define SILABS_TRACE_INSTANT_ERROR(operation, error) _MATTER_TRACE_DISABLE(operation, error)
+
+#define SILABS_TRACE_FLUSH_ALL() _MATTER_TRACE_DISABLE()
+
+#endif // MATTER_TRACING_ENABLED

--- a/src/platform/silabs/tracing/SilabsTracingTypes.h
+++ b/src/platform/silabs/tracing/SilabsTracingTypes.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+ * @file SilabsTracing.h
+ * @brief Instrumenting for matter operation tracing for the Silicon Labs platform.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include <stdint.h>
+
+namespace chip {
+namespace Tracing {
+namespace Silabs {
+
+// Enum for the different operation to trace
+enum class TimeTraceOperation : uint8_t
+{
+    kSpake2p,
+    kPake1,
+    kPake2,
+    kPake3,
+    kOperationalCredentials,
+    kAttestationVerification,
+    kCSR,
+    kNOC,
+    kTransportLayer,
+    kTransportSetup,
+    kFindOperational,
+    kCaseSession,
+    kSigma1,
+    kSigma2,
+    kSigma3,
+    kOTA,
+    kImageUpload,
+    kImageVerification,
+    kAppApplyTime,
+    kBootup,
+    kSilabsInit,
+    kMatterInit,
+    kAppInit,
+    kBufferFull,
+    kNumTraces,
+};
+
+enum class OperationType : uint8_t
+{
+    kBegin,
+    kEnd,
+    kInstant,
+};
+
+} // namespace Silabs
+} // namespace Tracing
+} // namespace chip

--- a/src/tracing/silabs/include/matter/tracing/macros_impl.h
+++ b/src/tracing/silabs/include/matter/tracing/macros_impl.h
@@ -22,4 +22,4 @@
 #error "Tracing macros seem to be double defined"
 #endif
 
-#include <platform/silabs/tracing/BackendImpl.h>
+#include <platform/silabs/tracing/SilabsTracingMacros.h>


### PR DESCRIPTION
Wrapped calls to the tracer instance  methods with macros to reduce the amount of #if in the code by providing stubs when building without tracing like with MATTER_TRACE_...

