### PR TITLE
[SL-UP]Fix SoC build if disable button and led components

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -391,7 +391,9 @@ CHIP_ERROR SilabsMatterConfig::InitWiFi(void)
 extern "C" void vApplicationIdleHook(void)
 {
 #if (SLI_SI91X_MCU_INTERFACE && CHIP_CONFIG_ENABLE_ICD_SERVER)
+#ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
     SiWxPlatformInterface::sl_si91x_btn_event_handler();
+#endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT
     SiWxPlatformInterface::sl_si91x_uart_power_requirement_handler();
 #endif
 }

--- a/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
+++ b/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
@@ -30,8 +30,10 @@ extern "C" {
 #endif
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 #if SLI_SI91X_MCU_INTERFACE
+#ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 #include "sl_si91x_button.h"
 #include "sl_si91x_button_pin_config.h"
+#endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT
 #include "sl_si91x_driver_gpio.h"
 #include "sl_si91x_power_manager.h"
 
@@ -70,6 +72,7 @@ namespace SiWxPlatformInterface {
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 #if SLI_SI91X_MCU_INTERFACE
+#ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 /**
  * @brief      Required to invoke button press event during sleep as falling edge is not detected
  * @param[in]  none.
@@ -81,7 +84,7 @@ inline void sl_si91x_btn_event_handler()
     sl_button_on_change(SL_BUTTON_BTN0_NUMBER,
                         (sl_si91x_gpio_get_uulp_npss_pin(SL_BUTTON_BTN0_PIN) == LOW) ? BUTTON_PRESSED : BUTTON_RELEASED);
 }
-
+#endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT
 /**
  * @brief      Required to enable MATTER shell UART with ICD feature flag
  * @param[in]  none.

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -41,18 +41,6 @@ extern "C" {
 #include "sl_si91x_button_pin_config.h"
 #endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT
 
-#ifdef ENABLE_WSTK_LEDS
-#if defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
-#include "sl_si91x_rgb_led.h"
-#include "sl_si91x_rgb_led_config.h"
-#include "sl_si91x_rgb_led_instances.h"
-#else
-#include "sl_si91x_led.h"
-#include "sl_si91x_led_config.h"
-#include "sl_si91x_led_instances.h"
-#endif // defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
-#endif // ENABLE_WSTK_LEDS
-
 #if CHIP_CONFIG_ENABLE_ICD_SERVER == 0
 void soc_pll_config(void);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -68,6 +56,13 @@ void soc_pll_config(void);
 
 #ifdef ENABLE_WSTK_LEDS
 #if defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
+#include "sl_si91x_rgb_led.h"
+#include "sl_si91x_rgb_led_config.h"
+#include "sl_si91x_rgb_led_instances.h"
+#else
+#include "sl_si91x_led.h"
+#include "sl_si91x_led_config.h"
+#include "sl_si91x_led_instances.h"
 #define SL_LED_COUNT SL_SI91X_RGB_LED_COUNT
 const sl_rgb_led_t * ledPinArray[SL_LED_COUNT] = { &led_led0 };
 #define SL_RGB_LED_INSTANCE(n) (ledPinArray[n])

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
-#include <sl_si91x_button_pin_config.h>
 #include <sl_si91x_common_flash_intf.h>
 
 #include <FreeRTOS.h>
@@ -36,8 +35,13 @@ extern "C" {
 #include "em_core.h"
 #include "rsi_board.h"
 #include "sl_event_handler.h"
+
+#ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 #include "sl_si91x_button.h"
 #include "sl_si91x_button_pin_config.h"
+#endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT
+
+#ifdef ENABLE_WSTK_LEDS
 #if defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
 #include "sl_si91x_rgb_led.h"
 #include "sl_si91x_rgb_led_config.h"
@@ -47,6 +51,7 @@ extern "C" {
 #include "sl_si91x_led_config.h"
 #include "sl_si91x_led_instances.h"
 #endif // defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
+#endif // ENABLE_WSTK_LEDS
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER == 0
 void soc_pll_config(void);
@@ -61,6 +66,7 @@ void soc_pll_config(void);
 #include "uart.h"
 #endif
 
+#ifdef ENABLE_WSTK_LEDS
 #if defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
 #define SL_LED_COUNT SL_SI91X_RGB_LED_COUNT
 const sl_rgb_led_t * ledPinArray[SL_LED_COUNT] = { &led_led0 };
@@ -69,12 +75,17 @@ const sl_rgb_led_t * ledPinArray[SL_LED_COUNT] = { &led_led0 };
 #define SL_LED_COUNT SL_SI91x_LED_COUNT
 uint8_t ledPinArray[SL_LED_COUNT] = { SL_LED_LED0_PIN, SL_LED_LED1_PIN };
 #endif // defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
+#endif // ENABLE_WSTK_LEDS
 
 namespace chip {
 namespace DeviceLayer {
 namespace Silabs {
 namespace {
+
+#ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 uint8_t sButtonStates[SL_SI91x_BUTTON_COUNT] = { 0 };
+#endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT
+
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 bool btn0_pressed = false;
 #endif /* SL_ICD_ENABLED */
@@ -152,6 +163,7 @@ void SilabsPlatform::StartScheduler()
     vTaskStartScheduler();
 }
 
+#ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 extern "C" void sl_button_on_change(uint8_t btn, uint8_t btnAction)
 {
 #if SL_ICD_ENABLED
@@ -191,6 +203,12 @@ uint8_t SilabsPlatform::GetButtonState(uint8_t button)
 {
     return (button < SL_SI91x_BUTTON_COUNT) ? sButtonStates[button] : 0;
 }
+#else
+uint8_t SilabsPlatform::GetButtonState(uint8_t button)
+{
+    return 0;
+}
+#endif // SL_CATALOG_SIMPLE_BUTTON_PRESENT
 
 CHIP_ERROR SilabsPlatform::FlashInit()
 {

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -41,6 +41,16 @@ extern "C" {
 #include "sl_si91x_button_pin_config.h"
 #endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT
 
+#if defined(ENABLE_WSTK_LEDS) && defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
+#include "sl_si91x_rgb_led.h"
+#include "sl_si91x_rgb_led_config.h"
+#include "sl_si91x_rgb_led_instances.h"
+#else
+#include "sl_si91x_led.h"
+#include "sl_si91x_led_config.h"
+#include "sl_si91x_led_instances.h"
+#endif  //defined(ENABLE_WSTK_LEDS) && defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
+
 #if CHIP_CONFIG_ENABLE_ICD_SERVER == 0
 void soc_pll_config(void);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -54,23 +64,14 @@ void soc_pll_config(void);
 #include "uart.h"
 #endif
 
-#ifdef ENABLE_WSTK_LEDS
-#if defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
-#include "sl_si91x_rgb_led.h"
-#include "sl_si91x_rgb_led_config.h"
-#include "sl_si91x_rgb_led_instances.h"
-#else
-#include "sl_si91x_led.h"
-#include "sl_si91x_led_config.h"
-#include "sl_si91x_led_instances.h"
+#if defined(ENABLE_WSTK_LEDS) && defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
 #define SL_LED_COUNT SL_SI91X_RGB_LED_COUNT
 const sl_rgb_led_t * ledPinArray[SL_LED_COUNT] = { &led_led0 };
 #define SL_RGB_LED_INSTANCE(n) (ledPinArray[n])
 #else
 #define SL_LED_COUNT SL_SI91x_LED_COUNT
 uint8_t ledPinArray[SL_LED_COUNT] = { SL_LED_LED0_PIN, SL_LED_LED1_PIN };
-#endif // defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
-#endif // ENABLE_WSTK_LEDS
+#endif  //defined(ENABLE_WSTK_LEDS) && defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -41,16 +41,6 @@ extern "C" {
 #include "sl_si91x_button_pin_config.h"
 #endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT
 
-#if defined(ENABLE_WSTK_LEDS) && defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
-#include "sl_si91x_rgb_led.h"
-#include "sl_si91x_rgb_led_config.h"
-#include "sl_si91x_rgb_led_instances.h"
-#else
-#include "sl_si91x_led.h"
-#include "sl_si91x_led_config.h"
-#include "sl_si91x_led_instances.h"
-#endif  //defined(ENABLE_WSTK_LEDS) && defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
-
 #if CHIP_CONFIG_ENABLE_ICD_SERVER == 0
 void soc_pll_config(void);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -64,14 +54,22 @@ void soc_pll_config(void);
 #include "uart.h"
 #endif
 
-#if defined(ENABLE_WSTK_LEDS) && defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
+#ifdef ENABLE_WSTK_LEDS
+#if defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
+#include "sl_si91x_rgb_led.h"
+#include "sl_si91x_rgb_led_config.h"
+#include "sl_si91x_rgb_led_instances.h"
 #define SL_LED_COUNT SL_SI91X_RGB_LED_COUNT
-const sl_rgb_led_t * ledPinArray[SL_LED_COUNT] = { &led_led0 };
+const sl_rgb_led_t *ledPinArray[SL_LED_COUNT] = { &led_led0 };
 #define SL_RGB_LED_INSTANCE(n) (ledPinArray[n])
 #else
-#define SL_LED_COUNT SL_SI91x_LED_COUNT
+#include "sl_si91x_led.h"
+#include "sl_si91x_led_config.h"
+#include "sl_si91x_led_instances.h"
+#define SL_LED_COUNT SL_SI91X_LED_COUNT
 uint8_t ledPinArray[SL_LED_COUNT] = { SL_LED_LED0_PIN, SL_LED_LED1_PIN };
-#endif  //defined(ENABLE_WSTK_LEDS) && defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED
+#endif // SL_MATTER_RGB_LED_ENABLED
+#endif // ENABLE_WSTK_LEDS
 
 namespace chip {
 namespace DeviceLayer {


### PR DESCRIPTION
This PR adds compilation fix with 917 SoC if button/LED components are disabled.

Added proper macros wherever button/led code is present.

Tested build locally with BRD4338A board.
