### PR TITLE
[SL-TEMP] Temp-fix for 917 NCP sleep

### DIFF
--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
@@ -43,13 +43,17 @@ CHIP_ERROR ApplicationSleepManager::Init()
 void ApplicationSleepManager::OnCommissioningWindowOpened()
 {
     mIsCommissionningWindowOpen = true;
+#if ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) )
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
+#endif
 }
 
 void ApplicationSleepManager::OnCommissioningWindowClosed()
 {
     mIsCommissionningWindowOpen = false;
+#if ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) )
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
+#endif
 }
 
 void ApplicationSleepManager::OnSubscriptionEstablished(chip::app::ReadHandler & aReadHandler)

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
@@ -45,7 +45,7 @@ void ApplicationSleepManager::OnCommissioningWindowOpened()
     mIsCommissionningWindowOpen = true;
 #if ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) )
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
-#endif
+#endif  // ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) )
 }
 
 void ApplicationSleepManager::OnCommissioningWindowClosed()
@@ -53,7 +53,7 @@ void ApplicationSleepManager::OnCommissioningWindowClosed()
     mIsCommissionningWindowOpen = false;
 #if ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) )
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
-#endif
+#endif  // ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) )
 }
 
 void ApplicationSleepManager::OnSubscriptionEstablished(chip::app::ReadHandler & aReadHandler)


### PR DESCRIPTION
**Problem**
With 917 NCP sleepy apps, if device is allowed to sleep at the time of commissioning window opened , it is failing with timeout at `sl_wifi_filter_broadcast` and returning there.
With 9116 sleepy apps, if  if device is allowed to sleep at the time of commissioning window opened , it is crashing at `rsi_bt_power_save_profile`.
**Temp-Fix**
Disabled sleep till wifi connection completed only for NCP devices.

