### PR TITLE
[SL-TEMP] Fix for the Amazon ecosystem's scan all networks issue

### DIFF
--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
@@ -318,14 +318,16 @@ int32_t wfx_reset_counts(void)
 bool wfx_start_scan(char * ssid, void (*callback)(wfx_wifi_scan_result_t *))
 {
     // check if already in progress
-    VerifyOrReturnError(wfx_rsi.scan_cb != nullptr, false);
+    VerifyOrReturnError(wfx_rsi.scan_cb == nullptr, false);
     wfx_rsi.scan_cb = callback;
 
-    VerifyOrReturnError(ssid != nullptr, false);
-    wfx_rsi.scan_ssid_length = strnlen(ssid, std::min<size_t>(sizeof(ssid), WFX_MAX_SSID_LENGTH));
-    wfx_rsi.scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length));
-    VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, false);
-    chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length, ssid);
+    if (ssid != nullptr)
+    {
+        wfx_rsi.scan_ssid_length = strnlen(ssid, std::min<size_t>(sizeof(ssid), WFX_MAX_SSID_LENGTH));
+        wfx_rsi.scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length));
+        VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, false);
+        chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length, ssid);
+    }
 
     WifiEvent event = WifiEvent::kScan;
     sl_matter_wifi_post_event(event);


### PR DESCRIPTION
Description of Problem:
The scan fails when both the SSID and scan callback are empty.

Description of Solution:
Enable scanning of all networks when the SSID is empty

Fixes: https://jira.silabs.com/browse/MATTER-4296



