### PR TITLE
[SL-UP] Fix Wi-Fi Sleep Manager commissioning progress check from clean boot

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -931,7 +931,7 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 #if SL_WIFI
             chip::app::DnssdServer::Instance().StartServer();
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-            WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
+            WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kConnectivityChange);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #endif // SL_WIFI
 
@@ -946,7 +946,7 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 
     case DeviceEventType::kCommissioningComplete: {
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
-        WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode();
+        WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kCommissioningComplete);
 #endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 
 // SL-Only

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
@@ -43,17 +43,17 @@ CHIP_ERROR ApplicationSleepManager::Init()
 void ApplicationSleepManager::OnCommissioningWindowOpened()
 {
     mIsCommissionningWindowOpen = true;
-#if ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) )
+#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
-#endif  // ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) )
+#endif // (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
 }
 
 void ApplicationSleepManager::OnCommissioningWindowClosed()
 {
     mIsCommissionningWindowOpen = false;
-#if ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) )
+#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
-#endif  // ( ( defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) )
+#endif // (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
 }
 
 void ApplicationSleepManager::OnSubscriptionEstablished(chip::app::ReadHandler & aReadHandler)
@@ -103,7 +103,7 @@ bool ApplicationSleepManager::CanGoToLIBasedSleep()
                 canGoToLIBasedSleep = false;
                 break;
             }
-            ChipLogProgress(AppServer, "All Fabrics have at least 1 active subscription!");
+            ChipLogProgress(AppServer, "Fabric index %u has an active subscriptions!", it->GetFabricIndex());
         }
     }
 

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.h
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.h
@@ -35,6 +35,13 @@ public:
 
     static WifiSleepManager & GetInstance() { return mInstance; }
 
+    enum class PowerEvent : uint8_t
+    {
+        kGenericEvent          = 0,
+        kCommissioningComplete = 1,
+        kConnectivityChange    = 2,
+    };
+
     /**
      * @brief Class implements the callbacks that the application can implement
      *        to alter the WifiSleepManager behaviors.
@@ -122,14 +129,25 @@ public:
      *        3. If no commissioning is in progress and the device is unprovisioned, configure deep sleep.
      *        4. If the application callback allows, configure LI based sleep; otherwise, configure DTIM based sleep.
      *
+     * @param event PowerEvent triggering the Verify and transition to low power mode processing
+     *
      * @return CHIP_ERROR CHIP_NO_ERROR if the device was transitionned to low power
      *         CHIP_ERROR_INTERNAL if an error occured
      */
-    CHIP_ERROR VerifyAndTransitionToLowPowerMode();
+    CHIP_ERROR VerifyAndTransitionToLowPowerMode(PowerEvent event = PowerEvent::kGenericEvent);
 
 private:
     WifiSleepManager()  = default;
     ~WifiSleepManager() = default;
+
+    /**
+     * @brief Function to handle the power events before transitionning the device to the appropriate low power mode.
+     *
+     * @param event PowerEvent to handle
+     * @return CHIP_ERROR CHIP_NO_ERROR if the event was handled successfully
+     *         CHIP_ERROR_INVALID_ARGUMENT if the event is not supported
+     */
+    CHIP_ERROR HandlePowerEvent(PowerEvent event);
 
     static WifiSleepManager mInstance;
 


### PR DESCRIPTION
#### Description
When the commissioning complete event gets called for a succesful commissioning, the commissioning stopped callback doesn't get called. Due to this behavior, the `mIsCommissioningInProgress` member never gets reset which prevents us from ever going to LI based sleep in a standard run.

This was missed because it requires a clean run from commissioning to a subscribe attempt which apperently i missed.

PR adds a the PowerEvent data that can be passed to the WifiSleepManager to update the commissioning state.

#### Tests
Run a full sequence from start to finish without power cycling 