### PR TITLE
[SL-UP] Fix test event trigger enable validation

### DIFF
--- a/examples/platform/silabs/SilabsTestEventTriggerDelegate.cpp
+++ b/examples/platform/silabs/SilabsTestEventTriggerDelegate.cpp
@@ -18,6 +18,7 @@
 
 #include "SilabsTestEventTriggerDelegate.h"
 #include <ProvisionManager.h>
+#include <lib/core/ErrorStr.h>
 
 using namespace ::chip::DeviceLayer;
 
@@ -25,14 +26,19 @@ namespace chip {
 
 bool SilabsTestEventTriggerDelegate::DoesEnableKeyMatch(const ByteSpan & enableKey) const
 {
-    uint8_t storedEnableKey[TestEventTriggerDelegate::kEnableKeyLength];
-    MutableByteSpan enableKeySpan(storedEnableKey);
+    uint8_t storedEnableKey[TestEventTriggerDelegate::kEnableKeyLength] = { 0 };
+    MutableByteSpan storedEnableKeySpan(storedEnableKey);
 
-    // Return false if we were not able to get the enableKey
-    VerifyOrReturnValue(
-        Silabs::Provision::Manager::GetInstance().GetStorage().GetTestEventTriggerKey(enableKeySpan) == CHIP_NO_ERROR, false);
+    CHIP_ERROR error = Silabs::Provision::Manager::GetInstance().GetStorage().GetTestEventTriggerKey(storedEnableKeySpan);
+    if (error != CHIP_NO_ERROR)
+    {
+        // If we fail to the read the enableKey from storage, the MutableByteSpan will be empty to a zero bytespan.
+        // This garantees that we will be able to inform the stack that the test event trigger is not enabled when the stack tries
+        // to match the zero bytespan to our enableKey.
+        ChipLogError(DeviceLayer, "Failed to get test event trigger key: %s", ErrorStr(error));
+    }
 
-    return (!enableKeySpan.empty() && enableKeySpan.data_equal(enableKey));
+    return storedEnableKeySpan.data_equal(enableKey);
 }
 
 } // namespace chip

--- a/examples/platform/silabs/SilabsTestEventTriggerDelegate.cpp
+++ b/examples/platform/silabs/SilabsTestEventTriggerDelegate.cpp
@@ -33,7 +33,7 @@ bool SilabsTestEventTriggerDelegate::DoesEnableKeyMatch(const ByteSpan & enableK
     if (error != CHIP_NO_ERROR)
     {
         // If we fail to read the enableKey from storage, the MutableByteSpan is not modified by the getter which leaves the span equal to a zero bytepsan (size = 0).
-        // This garantees that we will be able to inform the stack that the test event trigger is not enabled when the stack tries
+        // This guarantees that we will be able to inform the stack that the test event trigger is not enabled when the stack tries
         // to match the zero bytespan to our enableKey.
         ChipLogError(DeviceLayer, "Failed to get test event trigger key: %s", ErrorStr(error));
     }

--- a/examples/platform/silabs/SilabsTestEventTriggerDelegate.cpp
+++ b/examples/platform/silabs/SilabsTestEventTriggerDelegate.cpp
@@ -32,7 +32,7 @@ bool SilabsTestEventTriggerDelegate::DoesEnableKeyMatch(const ByteSpan & enableK
     CHIP_ERROR error = Silabs::Provision::Manager::GetInstance().GetStorage().GetTestEventTriggerKey(storedEnableKeySpan);
     if (error != CHIP_NO_ERROR)
     {
-        // If we fail to the read the enableKey from storage, the MutableByteSpan will be empty to a zero bytespan.
+        // If we fail to read the enableKey from storage, the MutableByteSpan is not modified by the getter which leaves the span equal to a zero bytepsan (size = 0).
         // This garantees that we will be able to inform the stack that the test event trigger is not enabled when the stack tries
         // to match the zero bytespan to our enableKey.
         ChipLogError(DeviceLayer, "Failed to get test event trigger key: %s", ErrorStr(error));

--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -85,7 +85,7 @@ CHIP_ERROR WritePage(uint32_t addr, const uint8_t * data, size_t size, size_t ma
     // The flash driver fails if the size is not a multiple of 4 (32-bits)
     size_t size_32 = RoundNearest(size, 4);
     // If the input data is smaller than the 32-bit size, pad the buffer with "0xff"
-    if(size_32 != size)
+    if (size_32 != size)
     {
         uint8_t * p = (uint8_t *) data;
         VerifyOrReturnError(size_32 <= max, CHIP_ERROR_BUFFER_TOO_SMALL);
@@ -666,12 +666,7 @@ CHIP_ERROR Storage::SetOtaTlvEncryptionKey(const ByteSpan & value)
 }
 #endif // OTA_ENCRYPTION_ENABLE
 
-/**
- * @brief Reads the test event trigger key from NVM. If the key isn't present, returns default value if defined.
- *
- * @param[out] keySpan output buffer. Must be at least large enough for 16 bytes (ken length)
- * @return CHIP_ERROR
- */
+#ifdef SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
 CHIP_ERROR Storage::GetTestEventTriggerKey(MutableByteSpan & keySpan)
 {
     constexpr size_t kEnableKeyLength = 16; // Expected byte size of the EnableKey
@@ -683,7 +678,7 @@ CHIP_ERROR Storage::GetTestEventTriggerKey(MutableByteSpan & keySpan)
     err = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_Test_Event_Trigger_Key, keySpan.data(), kEnableKeyLength,
                                            keyLength);
 #ifndef NDEBUG
-#ifdef SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
+#ifdef SL_MATTER_TEST_EVENT_TRIGGER_ENABLE_KEY
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
 
@@ -696,12 +691,13 @@ CHIP_ERROR Storage::GetTestEventTriggerKey(MutableByteSpan & keySpan)
         }
         err = CHIP_NO_ERROR;
     }
-#endif // SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
+#endif // SL_MATTER_TEST_EVENT_TRIGGER_ENABLE_KEY
 #endif // NDEBUG
 
     keySpan.reduce_size(kEnableKeyLength);
     return err;
 }
+#endif // SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
 
 } // namespace Provision
 

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -719,10 +719,12 @@ CHIP_ERROR Storage::SetOtaTlvEncryptionKey(const ByteSpan & value)
 }
 #endif // OTA_ENCRYPTION_ENABLE
 
+#ifdef SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
 CHIP_ERROR Storage::GetTestEventTriggerKey(MutableByteSpan & keySpan)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
+#endif // SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
 
 } // namespace Provision
 

--- a/src/platform/silabs/provision/ProvisionStorage.h
+++ b/src/platform/silabs/provision/ProvisionStorage.h
@@ -240,7 +240,7 @@ public:
     /**
      * @brief Reads the test event trigger key from NVM. If the key isn't present, returns default value if defined.
      *
-     * @param[out] keySpan output buffer. Must be at least large enough for 16 bytes (ken length)
+     * @param[out] keySpan output buffer. Must be at least large enough for 16 bytes (key length)
      * @return CHIP_ERROR
      */
     CHIP_ERROR GetTestEventTriggerKey(MutableByteSpan & keySpan);

--- a/src/platform/silabs/provision/ProvisionStorage.h
+++ b/src/platform/silabs/provision/ProvisionStorage.h
@@ -235,7 +235,17 @@ public:
     CHIP_ERROR GetSetupPayload(chip::MutableCharSpan & value);
     CHIP_ERROR SetProvisionRequest(bool value);
     CHIP_ERROR GetProvisionRequest(bool & value);
+
+#ifdef SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
+    /**
+     * @brief Reads the test event trigger key from NVM. If the key isn't present, returns default value if defined.
+     *
+     * @param[out] keySpan output buffer. Must be at least large enough for 16 bytes (ken length)
+     * @return CHIP_ERROR
+     */
     CHIP_ERROR GetTestEventTriggerKey(MutableByteSpan & keySpan);
+#endif // SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
+
     void SetBufferSize(size_t size) { mBufferSize = size > 0 ? size : kArgumentSizeMax; }
     size_t GetBufferSize() { return mBufferSize; }
 


### PR DESCRIPTION
#### Description
When the SDK check if the test event trigger is enabled, it checks if the test event trigger enableKey is equal to a zero Bytespan. If the enableKey matches, returns false that the feature is not enabled.

In the current implementation, if we fail to read the enable key, we immediatly return that the key does not match. If the key we are trying to match was the zero bytespan, this triggers the stack to think the feature is enabled since the platform enable key does not match the zero bytepspan which is incorrect.

The other issue was that we return that the enableKeys don't match if `!enableKeySpan.empty() `. When checking with the zero bytespan, this returns false immediatly without checking the platform enable key,

The PR changes the logic to always check if the data matches or not which, trough the bytespan function, covers all the edge cases.

PR also does a small cleanup of the provisioning test event trigger related code.

#### Tests
Manual tests all the scenarios - we really need a way to unit test stuff in the examples directory.
