### PR TITLE
[SL-TEMP] Temp-fix for delay 917 NCP sleep till wifi-connection

### DIFF
--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
@@ -170,6 +170,7 @@ bool ApplicationSleepManager::ProcessKeychainEdgeCase()
 void ApplicationSleepManager::OnEnterActiveMode()
 {
     mIsInActiveMode = true;
+// TEMP-fix: Added SLI_SI91X_MCU_INTERFACE to delay 917 NCP sleep till wifi-connection
 #if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
 #endif // (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
@@ -178,6 +179,7 @@ void ApplicationSleepManager::OnEnterActiveMode()
 void ApplicationSleepManager::OnEnterIdleMode()
 {
     mIsInActiveMode = false;
+// TEMP-fix: Added SLI_SI91X_MCU_INTERFACE to delay 917 NCP sleep till wifi-connection
 #if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
 #endif // (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
@@ -170,13 +170,17 @@ bool ApplicationSleepManager::ProcessKeychainEdgeCase()
 void ApplicationSleepManager::OnEnterActiveMode()
 {
     mIsInActiveMode = true;
+#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
+#endif // (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
 }
 
 void ApplicationSleepManager::OnEnterIdleMode()
 {
     mIsInActiveMode = false;
+#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
+#endif // (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
 }
 
 void ApplicationSleepManager::OnTransitionToIdle()


### PR DESCRIPTION
With 917 NCP sleepy apps, if device is allowed to sleep before wifi connection ,it is failing to wakeup in si91x_req_wakeup().So delayed sleep tilll wifi connection. 
Added SLI_SI91X_MCU_INTERFACE macro before verifying the device can sleep, so that NCP will not enter power save mode till wifi-connection.
