### PR TITLE
[SL-TEMP] Fixing scan networks code.

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -625,9 +625,9 @@ sl_status_t show_scan_results(sl_wifi_scan_result_t * scan_result)
                                    (char *) scan_result->scan_info[idx].ssid); // +1 for null termination
 
         // if user has provided ssid, then check if the current scan result ssid matches the user provided ssid
-        if (wfx_rsi.scan_ssid != nullptr &&
-            (strncmp(wfx_rsi.scan_ssid, cur_scan_result.ssid, std::min(strlen(wfx_rsi.scan_ssid), strlen(cur_scan_result.ssid))) ==
-             0))
+        if (wfx_rsi.scan_ssid != nullptr && 
+            (strlen(wfx_rsi.scan_ssid) != strlen(cur_scan_result.ssid) || 
+             strncmp(wfx_rsi.scan_ssid, cur_scan_result.ssid, strlen(wfx_rsi.scan_ssid)) != 0))
         {
             continue;
         }

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
@@ -321,12 +321,13 @@ bool wfx_start_scan(char * ssid, void (*callback)(wfx_wifi_scan_result_t *))
     VerifyOrReturnError(wfx_rsi.scan_cb == nullptr, false);
     wfx_rsi.scan_cb = callback;
 
-    if (ssid != nullptr)
+    // if SSID is provided to scan only that SSID
+    if(ssid) 
     {
         wfx_rsi.scan_ssid_length = strnlen(ssid, std::min<size_t>(sizeof(ssid), WFX_MAX_SSID_LENGTH));
-        wfx_rsi.scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length));
+        wfx_rsi.scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length + 1));
         VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, false);
-        chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length, ssid);
+        chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length + 1, ssid);
     }
 
     WifiEvent event = WifiEvent::kScan;


### PR DESCRIPTION
JIRA : [MATTER-4465](https://jira.silabs.com/browse/MATTER-4465)

Issue : While scanning network with a random SSID, the details of current network are being returned.

Fix : Fixed the string comparison code. These changes are picked up from the release_2.4-1.4 branch ([PR](https://github.com/SiliconLabsSoftware/matter_sdk/pull/81/files))