### PR TITLE
[SL-UP] Revert provision keystore to maintain backward compatibility

### DIFF
--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -634,14 +634,7 @@ CHIP_ERROR Storage::GetDeviceAttestationCert(MutableByteSpan & value)
 
 CHIP_ERROR Storage::SetDeviceAttestationKey(const ByteSpan & value)
 {
-#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE)
-    uint8_t temp[kDeviceAttestationKeySizeMax] = { 0 };
-    MutableByteSpan private_key(temp);
-    AttestationKey::Unwrap(value.data(), value.size(), private_key);
-    return Flash::Set(Parameters::ID::kDacKey, private_key.data(), private_key.size());
-#else
     return Flash::Set(Parameters::ID::kDacKey, value.data(), value.size());
-#endif // SLI_SI91X_MCU_INTERFACE
 }
 
 CHIP_ERROR Storage::GetDeviceAttestationCSR(uint16_t vid, uint16_t pid, const CharSpan & cn, MutableCharSpan & csr)
@@ -668,7 +661,10 @@ CHIP_ERROR Storage::SignWithDeviceAttestationKey(const ByteSpan & message, Mutab
 #endif // CHIP_DEVICE_CONFIG_ENABLE_EXAMPLE_CREDENTIALS
     ReturnErrorOnFailure(err);
 #if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE)
-    return AttestationKey::SignMessageWithKey(temp, message, signature);
+    uint8_t key_buffer[kDeviceAttestationKeySizeMax] = { 0 };
+    MutableByteSpan private_key(key_buffer);
+    AttestationKey::Unwrap(temp, size, private_key);
+    return AttestationKey::SignMessageWithKey(private_key, message, signature);
 #else
     AttestationKey key;
     ReturnErrorOnFailure(key.Import(temp, size));

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -664,7 +664,7 @@ CHIP_ERROR Storage::SignWithDeviceAttestationKey(const ByteSpan & message, Mutab
     uint8_t key_buffer[kDeviceAttestationKeySizeMax] = { 0 };
     MutableByteSpan private_key(key_buffer);
     AttestationKey::Unwrap(temp, size, private_key);
-    return AttestationKey::SignMessageWithKey(private_key, message, signature);
+    return AttestationKey::SignMessageWithKey((const uint8_t *) key_buffer, message, signature);
 #else
     AttestationKey key;
     ReturnErrorOnFailure(key.Import(temp, size));


### PR DESCRIPTION
Fixes MATTER-4490

Reverts change in logic of storage of private key to maintain backward compatibility