### PR TITLE
[SL-ONLY] Add workflow to update the CSA branch daily

### DIFF
--- a/.github/workflows/silabs-update-csa.yaml
+++ b/.github/workflows/silabs-update-csa.yaml
@@ -1,0 +1,37 @@
+name: Daily Sync of the csa branch
+
+permissions:
+    contents: write
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: "0 0 * * *" # Runs once a day at midnight
+
+jobs:
+    sync:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout matter_sdk::csa branch
+              uses: actions/checkout@v2
+              with:
+                  repository: SiliconLabsSoftware/matter_sdk
+                  ref: csa
+
+            - name: Add CSA repository remote
+              run:
+                  git remote add csa
+                  https://github.com/project-chip/connectedhomeip.git
+
+            - name: Fetch master branch from CSA repository
+              run: git fetch csa master
+
+            - name: Checkout master branch from CSA repository
+              run: git checkout csa/master
+
+            - name: Push csa::master to matter_sdk::csa
+              run: |
+                  git push origin csa
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/silabs-update-csa.yaml
+++ b/.github/workflows/silabs-update-csa.yaml
@@ -4,6 +4,7 @@ permissions:
     contents: write
 
 on:
+    push:
     schedule:
         - cron: "0 0 * * *" # Runs once a day at midnight
 
@@ -21,16 +22,13 @@ jobs:
 
             - name: Add CSA repository remote
               run:
-                  git remote add csa
+                  git remote add upstream
                   https://github.com/project-chip/connectedhomeip.git
 
-            - name: Fetch master branch from CSA repository
-              run: git fetch csa master
+            - name: Update the csa branch locally
+              run: git pull upstream master
 
-            - name: Checkout master branch from CSA repository
-              run: git checkout csa/master
-
-            - name: Push csa::master to matter_sdk::csa
+            - name: Push the update csa branch to the remote
               run: |
                   git push origin csa
               env:

--- a/.github/workflows/silabs-update-csa.yaml
+++ b/.github/workflows/silabs-update-csa.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     sync:
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/silabs-update-csa.yaml
+++ b/.github/workflows/silabs-update-csa.yaml
@@ -4,12 +4,12 @@ permissions:
     contents: write
 
 on:
-    workflow_dispatch:
     schedule:
         - cron: "0 0 * * *" # Runs once a day at midnight
 
 jobs:
     sync:
+        if: github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/silabs-update-csa.yaml
+++ b/.github/workflows/silabs-update-csa.yaml
@@ -4,13 +4,12 @@ permissions:
     contents: write
 
 on:
-    push:
     schedule:
         - cron: "0 0 * * *" # Runs once a day at midnight
 
 jobs:
     sync:
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
 
         steps:


### PR DESCRIPTION
### Description
PR adds a cron job that will push the latest csa::master commit to the matter_sdk::csa branch.
The workflow succesfully ran on the test setup but there were no changes to process since the branch was already up to date.

We will need to validate tomorrow once this is merged that it worked

### Testing
https://github.com/SiliconLabsSoftware/matter_sdk/actions/runs/12874387207/job/35893812596