### PR TITLE
[SL-TEMP] Remove sl_net_down workaround after calling the sl_net_up API

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -476,13 +476,6 @@ sl_status_t JoinWifiNetwork(void)
     // failure only happens when the firmware returns an error
     ChipLogError(DeviceLayer, "sl_net_up failed: 0x%lx", static_cast<uint32_t>(status));
 
-    // Deactivate the network interface before activating it on the next retry.
-    if ((status == SL_STATUS_SI91X_SCAN_ISSUED_IN_ASSOCIATED_STATE) || (status == SL_STATUS_SI91X_COMMAND_GIVEN_IN_INVALID_STATE))
-    {
-        status = sl_net_down((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE);
-        ChipLogProgress(DeviceLayer, "sl_net_down status 0x%lx", static_cast<uint32_t>(status));
-    }
-
     wfx_rsi.dev_state.Clear(WifiState::kStationConnecting).Clear(WifiState::kStationConnected);
 
     ChipLogProgress(DeviceLayer, "Connection retry attempt %d", wfx_rsi.join_retries);


### PR DESCRIPTION
Description:
The sl_net_up() API occasionally returns a timeout error (0x07) due to timeout is set to 5 seconds in wiseconnect.
From the next retry onward, the ScanCallback and sl_net_up() are returning SL_STATUS_SI91X_SCAN_ISSUED_IN_ASSOCIATED_STATE or SL_STATUS_SI91X_COMMAND_GIVEN_IN_INVALID_STATE.

Fix:
Timeout for the sl_wifi_connect() has been increased to 18 seconds similar to internal stack timeout in wiseconnect.

Testing:
Tested commissioning and power cycling locally with the 917 SoC.
