### PR TITLE
[SL-UP] Dimmer switch button implementation

### DIFF
--- a/examples/light-switch-app/silabs/include/AppEvent.h
+++ b/examples/light-switch-app/silabs/include/AppEvent.h
@@ -37,6 +37,8 @@ struct AppEvent
         kEventType_UpReleased,
         kEventType_DownPressed,
         kEventType_DownReleased,
+        kEventType_TriggerLevelControlAction,
+        kEventType_TriggerToggle,
     };
 
     uint16_t Type;

--- a/examples/light-switch-app/silabs/include/AppEvent.h
+++ b/examples/light-switch-app/silabs/include/AppEvent.h
@@ -33,10 +33,10 @@ struct AppEvent
         kEventType_ResetWarning,
         kEventType_ResetCanceled,
         // Button events
-        kEventType_UpPressed,
-        kEventType_UpReleased,
-        kEventType_DownPressed,
-        kEventType_DownReleased,
+        kEventType_LevelUpPressed,
+        kEventType_LevelUpReleased,
+        kEventType_LevelDownPressed,
+        kEventType_LevelDownReleased,
         kEventType_TriggerLevelControlAction,
         kEventType_TriggerToggle,
     };

--- a/examples/light-switch-app/silabs/include/AppEvent.h
+++ b/examples/light-switch-app/silabs/include/AppEvent.h
@@ -33,10 +33,10 @@ struct AppEvent
         kEventType_ResetWarning,
         kEventType_ResetCanceled,
         // Button events
-        kEventType_LevelUpPressed,
-        kEventType_LevelUpReleased,
-        kEventType_LevelDownPressed,
-        kEventType_LevelDownReleased,
+        kEventType_ActionButtonPressed,
+        kEventType_ActionButtonReleased,
+        kEventType_FunctionButtonPressed,
+        kEventType_FunctionButtonReleased,
         kEventType_TriggerLevelControlAction,
         kEventType_TriggerToggle,
     };

--- a/examples/light-switch-app/silabs/include/LightSwitchMgr.h
+++ b/examples/light-switch-app/silabs/include/LightSwitchMgr.h
@@ -84,6 +84,8 @@ public:
     void TriggerLightSwitchAction(LightSwitchAction action, bool isGroupCommand = false);
     void TriggerLevelControlAction(StepModeEnum stepMode, bool isGroupCommand = false);
 
+    StepModeEnum getStepMode();
+
     AppEvent CreateNewEvent(AppEvent::AppEventTypes type);
 
     static LightSwitchMgr & GetInstance() { return sSwitch; }
@@ -103,9 +105,12 @@ public:
 private:
     static LightSwitchMgr sSwitch;
 
-    Timer * mLongPressTimer = nullptr;
-    bool mDownPressed       = false;
-    bool mResetWarning      = false;
+    Timer * mLongPressTimer    = nullptr;
+    bool mDownPressed          = false;
+    bool mUpPressed            = false;
+    bool mUpSuppressed         = false;
+    bool mResetWarning         = false;
+    StepModeEnum stepDirection = StepModeEnum::kUp;
 
     static void OnLongPressTimeout(Timer & timer);
     LightSwitchMgr() = default;

--- a/examples/light-switch-app/silabs/include/LightSwitchMgr.h
+++ b/examples/light-switch-app/silabs/include/LightSwitchMgr.h
@@ -105,14 +105,14 @@ public:
 private:
     static LightSwitchMgr sSwitch;
 
-    Timer * mLongPressTimer         = nullptr;
-    bool mLevelDownPressed          = false;    // True when the level-down button (button0) is pressed
-    bool mLevelUpPressed            = false;    // True when the level-up button (button1) is pressed
-    bool mLevelUpSuppressed         = false;    // True when both level-down (button0) and level-up (button1) buttons are pressed
-    bool mResetWarning              = false;
+    Timer * mLongPressTimer      = nullptr;
+    bool mFunctionButtonPressed  = false;    // True when button0 is pressed, used to trigger factory reset
+    bool mActionButtonPressed    = false;    // True when button1 is pressed, used to initiate toggle or level-up/down
+    bool mActionButtonSuppressed = false;    // True when both button0 and button1 are pressed, used to switch step direction
+    bool mResetWarning           = false;
 
     // Default Step direction for Level control
-    StepModeEnum stepDirection      = StepModeEnum::kUp;
+    StepModeEnum stepDirection   = StepModeEnum::kUp;
 
     static void OnLongPressTimeout(Timer & timer);
     LightSwitchMgr() = default;

--- a/examples/light-switch-app/silabs/include/LightSwitchMgr.h
+++ b/examples/light-switch-app/silabs/include/LightSwitchMgr.h
@@ -105,12 +105,14 @@ public:
 private:
     static LightSwitchMgr sSwitch;
 
-    Timer * mLongPressTimer    = nullptr;
-    bool mDownPressed          = false;
-    bool mUpPressed            = false;
-    bool mUpSuppressed         = false;
-    bool mResetWarning         = false;
-    StepModeEnum stepDirection = StepModeEnum::kUp;
+    Timer * mLongPressTimer         = nullptr;
+    bool mLevelDownPressed          = false;    // True when the level-down button (button0) is pressed
+    bool mLevelUpPressed            = false;    // True when the level-up button (button1) is pressed
+    bool mLevelUpSuppressed         = false;    // True when both level-down (button0) and level-up (button1) buttons are pressed
+    bool mResetWarning              = false;
+
+    // Default Step direction for Level control
+    StepModeEnum stepDirection      = StepModeEnum::kUp;
 
     static void OnLongPressTimeout(Timer & timer);
     LightSwitchMgr() = default;

--- a/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
+++ b/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
@@ -324,8 +324,6 @@ void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
         AppTask::GetAppTask().CancelFactoryResetSequence();
         break;
     case AppEvent::kEventType_DownPressed:
-        // aEvent->Handler = LightSwitchMgr::SwitchActionEventHandler;
-        // AppTask::GetAppTask().PostEvent(aEvent);
         lightSwitch->mDownPressed = true;
         if (lightSwitch->mLongPressTimer)
         {

--- a/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
+++ b/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
@@ -80,7 +80,7 @@ void LightSwitchMgr::HandleLongPress()
     event.Handler             = AppEventHandler;
     LightSwitchMgr * lightSwitch  = &LightSwitchMgr::GetInstance();
     event.LightSwitchEvent.Context  = lightSwitch;
-    if (mDownPressed)
+    if (mLevelDownPressed)
     {
         if (!mResetWarning)
         {
@@ -89,9 +89,9 @@ void LightSwitchMgr::HandleLongPress()
             AppTask::GetAppTask().PostEvent(&event);
         }
     }
-    else if (mUpPressed)
+    else if (mLevelUpPressed)
     {
-        mUpSuppressed = true;
+        mLevelUpSuppressed = true;
         // Long press button up : Trigger Level Control Action
         event.Type = AppEvent::kEventType_TriggerLevelControlAction;
         AppTask::GetAppTask().PostEvent(&event);
@@ -301,11 +301,11 @@ void LightSwitchMgr::ButtonEventHandler(uint8_t button, uint8_t btnAction)
     AppEvent event = {};
     if (btnAction == to_underlying(SilabsPlatform::ButtonAction::ButtonPressed))
     {
-        event = LightSwitchMgr::GetInstance().CreateNewEvent(button ? AppEvent::kEventType_UpPressed : AppEvent::kEventType_DownPressed);
+        event = LightSwitchMgr::GetInstance().CreateNewEvent(button ? AppEvent::kEventType_LevelUpPressed : AppEvent::kEventType_LevelDownPressed);
     }
     else
     {
-        event = LightSwitchMgr::GetInstance().CreateNewEvent(button ? AppEvent::kEventType_UpReleased : AppEvent::kEventType_DownReleased);
+        event = LightSwitchMgr::GetInstance().CreateNewEvent(button ? AppEvent::kEventType_LevelUpReleased : AppEvent::kEventType_LevelDownReleased);
     }
     AppTask::GetAppTask().PostEvent(&event);
 }
@@ -323,21 +323,21 @@ void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
         lightSwitch->mResetWarning = false;
         AppTask::GetAppTask().CancelFactoryResetSequence();
         break;
-    case AppEvent::kEventType_DownPressed:
-        lightSwitch->mDownPressed = true;
+    case AppEvent::kEventType_LevelDownPressed:
+        lightSwitch->mLevelDownPressed = true;
         if (lightSwitch->mLongPressTimer)
         {
             lightSwitch->mLongPressTimer->Start();
         }
-        if (lightSwitch->mUpPressed)
+        if (lightSwitch->mLevelUpPressed)
         {
-            lightSwitch->mUpSuppressed = true;
+            lightSwitch->mLevelUpSuppressed = true;
             lightSwitch->stepDirection = (lightSwitch->stepDirection == StepModeEnum::kUp) ? StepModeEnum::kDown : StepModeEnum::kUp;
             ChipLogProgress(AppServer, "Step direction changed. Current Step Direction : %s", ((lightSwitch->stepDirection == StepModeEnum::kUp) ? "kUp" : "kDown"));
         }
         break;
-    case AppEvent::kEventType_DownReleased:
-        lightSwitch->mDownPressed = false;
+    case AppEvent::kEventType_LevelDownReleased:
+        lightSwitch->mLevelDownPressed = false;
         if (lightSwitch->mLongPressTimer)
         {
             lightSwitch->mLongPressTimer->Stop();
@@ -348,30 +348,30 @@ void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
             AppTask::GetAppTask().PostEvent(aEvent);
         }
         break;
-    case AppEvent::kEventType_UpPressed:
-        lightSwitch->mUpPressed = true;
+    case AppEvent::kEventType_LevelUpPressed:
+        lightSwitch->mLevelUpPressed = true;
         aEvent->Handler = LightSwitchMgr::SwitchActionEventHandler;
         AppTask::GetAppTask().PostEvent(aEvent);
         if (lightSwitch->mLongPressTimer)
         {
             lightSwitch->mLongPressTimer->Start();
         }
-        if (lightSwitch->mDownPressed)
+        if (lightSwitch->mLevelDownPressed)
         {
-            lightSwitch->mUpSuppressed = true;
+            lightSwitch->mLevelUpSuppressed = true;
             lightSwitch->stepDirection = (lightSwitch->stepDirection == StepModeEnum::kUp) ? StepModeEnum::kDown : StepModeEnum::kUp;
             ChipLogProgress(AppServer, "Step direction changed. Current Step Direction : %s", ((lightSwitch->stepDirection == StepModeEnum::kUp) ? "kUp" : "kDown"));
         }
         break;
-    case AppEvent::kEventType_UpReleased:
-        lightSwitch->mUpPressed = false;
+    case AppEvent::kEventType_LevelUpReleased:
+        lightSwitch->mLevelUpPressed = false;
         if (lightSwitch->mLongPressTimer)
         {
             lightSwitch->mLongPressTimer->Stop();
         }
-        if (lightSwitch->mUpSuppressed)
+        if (lightSwitch->mLevelUpSuppressed)
         {
-            lightSwitch->mUpSuppressed = false;
+            lightSwitch->mLevelUpSuppressed = false;
         }
         else
         {
@@ -379,7 +379,7 @@ void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
             aEvent->Handler = LightSwitchMgr::SwitchActionEventHandler;
             AppTask::GetAppTask().PostEvent(aEvent);
         }
-        aEvent->Type = AppEvent::kEventType_UpReleased;
+        aEvent->Type = AppEvent::kEventType_LevelUpReleased;
         aEvent->Handler = LightSwitchMgr::SwitchActionEventHandler;
         AppTask::GetAppTask().PostEvent(aEvent);
         break;
@@ -395,10 +395,10 @@ void LightSwitchMgr::SwitchActionEventHandler(AppEvent * aEvent)
 {
     switch(aEvent->Type)
     {
-    case AppEvent::kEventType_UpPressed:
+    case AppEvent::kEventType_LevelUpPressed:
         LightSwitchMgr::GetInstance().GenericSwitchOnInitialPress();
         break;
-    case AppEvent::kEventType_UpReleased:
+    case AppEvent::kEventType_LevelUpReleased:
         LightSwitchMgr::GetInstance().GenericSwitchOnShortRelease();
         break;
     case AppEvent::kEventType_TriggerLevelControlAction:


### PR DESCRIPTION
Description : This PR extends the button implementation in dimmer switch app by adding level control actions on button sequences. Below are the implementation details : 

Default Step direction - Up
Button1 short press - light toggle
Button1 long press - Level up/down as per direction
Button1 shortpress + Button0 shortpress - reverse the direction (down to up or up to down)
Button0 longpress - Factory reset

Testing : Tested the button sequences on SOC manually.