### PR TITLE
[SL-ONLY] Change workflow token to use the PAT token with additionnal worklfow permissions

### DIFF
--- a/.github/workflows/silabs-update-csa.yaml
+++ b/.github/workflows/silabs-update-csa.yaml
@@ -31,4 +31,4 @@ jobs:
 
             - name: Push the update csa branch to the remote
               run: |
-                  git push https://github.com/SiliconLabsSoftware/matter_sdk.git csa
+                  git push origin csa

--- a/.github/workflows/silabs-update-csa.yaml
+++ b/.github/workflows/silabs-update-csa.yaml
@@ -6,6 +6,7 @@ permissions:
 on:
     schedule:
         - cron: "0 0 * * *" # Runs once a day at midnight
+    workflow_dispatch: # Allows manual triggering of the workflow
 
 jobs:
     sync:
@@ -18,6 +19,7 @@ jobs:
               with:
                   repository: SiliconLabsSoftware/matter_sdk
                   ref: csa
+                  token: ${{ secrets.WORKFLOW_TOKEN }}
 
             - name: Add CSA repository remote
               run:
@@ -29,6 +31,4 @@ jobs:
 
             - name: Push the update csa branch to the remote
               run: |
-                  git push origin csa
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  git push https://github.com/SiliconLabsSoftware/matter_sdk.git csa


### PR DESCRIPTION
### Description
For security reasons, the github token has no permissions to create or update workflows in a github action and there is no way to configure a workflow to give those permissions.

To do this, we had to create a PAT (Personnal access token) with the right permissions in the SiliconLabsSoftware org and use that token as a repository secret. The PAT can be re-used for multiple secrets. 

### Tests
Manual test