### PR TITLE
[SL-ONLY] Add workflow to open PR from csa to main after the csa update is completed

### DIFF
--- a/.github/workflows/silabs-open-csa-pr.yaml
+++ b/.github/workflows/silabs-open-csa-pr.yaml
@@ -39,3 +39,16 @@ jobs:
                   token: ${{secrets.GITHUB_TOKEN}}
                   branch-token: ${{secrets.WORKFLOW_TOKEN}}
                   labels: changing-submodules-on-purpose
+
+            - name: Comment on Pull Request
+              uses: actions/github-script@v6
+              with:
+                  github-token: ${{secrets.GITHUB_TOKEN}}
+                  script: |
+                      const pr_number = context.payload.workflow_run.pull_requests[0].number;
+                      github.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: pr_number,
+                        body: "Please merge this PR using **Merge Commit**."
+                      });

--- a/.github/workflows/silabs-open-csa-pr.yaml
+++ b/.github/workflows/silabs-open-csa-pr.yaml
@@ -41,7 +41,7 @@ jobs:
                   labels: changing-submodules-on-purpose
 
             - name: Comment on Pull Request
-              uses: actions/github-script@v6
+              uses: actions/github-script@v7
               with:
                   github-token: ${{secrets.GITHUB_TOKEN}}
                   script: |

--- a/.github/workflows/silabs-open-csa-pr.yaml
+++ b/.github/workflows/silabs-open-csa-pr.yaml
@@ -32,7 +32,10 @@ jobs:
                   branch: automation/update_main
                   base: main
                   title: "Sync csa branch with main"
-                  body: "This PR syncs the csa branch with the main branch."
+                  body: |
+                      This PR syncs the csa branch with the main branch.
+
+                      **PR MUST BE MERGED WITH MERGE COMMIT - ADMIN MUST ENABLE THE OPTION**
                   token: ${{secrets.GITHUB_TOKEN}}
                   branch-token: ${{secrets.WORKFLOW_TOKEN}}
                   labels: changing-submodules-on-purpose

--- a/.github/workflows/silabs-open-csa-pr.yaml
+++ b/.github/workflows/silabs-open-csa-pr.yaml
@@ -1,0 +1,37 @@
+name: Open PR from csa to main
+
+permissions:
+    contents: write
+    pull-requests: write
+
+on:
+    workflow_run:
+        workflows: ["Daily Sync of the csa branch"]
+        types:
+            - completed
+    workflow_dispatch:
+
+jobs:
+    open-pr:
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: main
+                  token: ${{secrets.WORKFLOW_TOKEN}}
+
+            - name: Checkout csa
+              run: |
+                  git fetch origin csa:csa
+                  git reset --hard csa
+
+            - name: Create Pull Request
+              uses: peter-evans/create-pull-request@v7
+              with:
+                  branch: automation/update_main
+                  base: main
+                  title: "Sync csa branch with main"
+                  body: "This PR syncs the csa branch with the main branch."
+                  token: ${{secrets.GITHUB_TOKEN}}
+                  branch-token: ${{secrets.WORKFLOW_TOKEN}}

--- a/.github/workflows/silabs-open-csa-pr.yaml
+++ b/.github/workflows/silabs-open-csa-pr.yaml
@@ -35,3 +35,4 @@ jobs:
                   body: "This PR syncs the csa branch with the main branch."
                   token: ${{secrets.GITHUB_TOKEN}}
                   branch-token: ${{secrets.WORKFLOW_TOKEN}}
+                  labels: changing-submodules-on-purpose


### PR DESCRIPTION
### Description
PR adds a workflow that is triggered after the daily csa update to open a PR from csa to main with the latest CSA changes.

When testing the action I saw an issue with the CI was not being triggered on the PR opened by a Github Action but i think having the PAT token checkout and create the branch fixes the issue. With all the testing i can confirm a 100% this.
We will know tomorrow morning if the full flow works.

### Tests
Check https://github.com/SiliconLabsSoftware/matter_sdk/pull/236 
