### PR TITLE
[CSA-CP]Bring matter_support changes to fix 917 NCP build fail in CI

### DIFF
--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -69,6 +69,13 @@ declare_args() {
   chip_enable_ble_rs911x = use_rs9116 || use_SiWx917
 }
 
+# TODO - This needs to be removed once multiplexing issues resolved
+if (use_SiWx917) {
+  disable_lcd = true
+  show_qr_code = false
+  use_external_flash = false
+}
+
 if (silabs_board == "") {
   silabs_board = getenv("SILABS_BOARD")
 }


### PR DESCRIPTION
CI build is failing for 917 NCP boards as it has old matter_support pointer
Here, update matter_support changes to matter_sdk repo release branch

#### Testing

Verified build locally few apps and CI.
Verified commissioning and few commands on 917 NCP  board.
