### PR TITLE
[SL-TEMP] Add clean argument to NCP builds to avoid hidden failures

### DIFF
--- a/.github/silabs-builds-mg24.json
+++ b/.github/silabs-builds-mg24.json
@@ -6,15 +6,15 @@
         },
         {
             "boards": ["BRD4187C"],
-            "arguments": ["--docker", "--wifi wf200"]
+            "arguments": ["--docker", "--wifi wf200", "--clean"]
         },
         {
             "boards": ["BRD4187C"],
-            "arguments": ["--docker", "--wifi rs9116"]
+            "arguments": ["--docker", "--wifi rs9116", "--clean"]
         },
         {
             "boards": ["BRD4187C"],
-            "arguments": ["--docker", "--wifi SiWx917"]
+            "arguments": ["--docker", "--wifi SiWx917", "--clean"]
         }
     ]
 }


### PR DESCRIPTION
### Description
In the release branch, all builds for a board (thread + ncp) are built in the same directory so gn only detects a rebuild.
In certain cases, this can lead to failures being hidden because files don't get rebuilt with the correct defines / configurations.

See https://github.com/SiliconLabsSoftware/matter_sdk/actions/runs/12983608812/job/36205134063?pr=245 as example. A clean build of a NCP fails while this CI passes. This is due to the build not being "clean".

This isn't an issue for `main` or `csa` because the build script was changed to generate different paths for ncp builds.

### Tests
CI
