### PR TITLE
[SL-UP] Tracing gen fix silabs_tracing

### DIFF
--- a/src/tracing/silabs/BUILD.gn
+++ b/src/tracing/silabs/BUILD.gn
@@ -21,5 +21,6 @@ config("tracing") {
 
 source_set("silabs_tracing") {
   public = [ "include/matter/tracing/macros_impl.h" ]
+  public_deps = [ "${chip_root}/src/tracing" ]
   public_configs = [ ":tracing" ]
 }


### PR DESCRIPTION
Add dependencies to fix ncp build when gen_tracing_buildconfig didn't get called in certain conditions.


#### Testing

Built the NCP that were crashing on CI.
