### PR TITLE
[SL-UP] Raise TimerTask to the highest prio

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -174,11 +174,8 @@ extern uint32_t SystemCoreClock;
 
 /* Software timer related definitions. */
 #define configUSE_TIMERS (1)
-#ifdef SLI_SI917
+// Keep the timerTask at the highest prio as some of our stacks tasks leverage eventing with timers.
 #define configTIMER_TASK_PRIORITY (55) /* Highest priority */
-#else
-#define configTIMER_TASK_PRIORITY (40) /* Highest priority */
-#endif                                 // SLI_SI917
 #define configTIMER_QUEUE_LENGTH (10)
 #define configTIMER_TASK_STACK_DEPTH (1024)
 
@@ -313,16 +310,16 @@ standard names. */
 /* Thread local storage pointers used by the SDK */
 
 #ifndef configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS
-#define configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS 2
+#define configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS 0
 #endif
 
 #ifndef configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS
-#define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 2
+#define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 0
 #endif
 
 #ifndef configNUM_THREAD_LOCAL_STORAGE_POINTERS
 #define configNUM_THREAD_LOCAL_STORAGE_POINTERS                                                                                    \
-    (configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS + configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS + 1)
+    (configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS + configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS)
 #endif
 
 #if defined(__GNUC__)

--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -314,12 +314,12 @@ standard names. */
 #endif
 
 #ifndef configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS
-#define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 0
+#define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 2
 #endif
 
 #ifndef configNUM_THREAD_LOCAL_STORAGE_POINTERS
 #define configNUM_THREAD_LOCAL_STORAGE_POINTERS                                                                                    \
-    (configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS + configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS)
+    (configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS + configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS + 1)
 #endif
 
 #if defined(__GNUC__)


### PR DESCRIPTION
Raise the timer task to the highest priority. 

some slcc/slcp try to set configTIMER_TASK_PRIORITY for some stacks.
For example 
```
Timer RTOS task priority needs to be one more than SL_BT_RTOS_LINK_LAYER_TASK_PRIORITY
BT uses event flags that require the timer task to be a higher priority than all other RTOS tasks
```
In matter extension, we overwrite the generated freeRTOSConfig but our static config. This PR makes sure this prio is always set.

#### Testing
Manual commissioning and control tests.
