### PR TITLE
[SL-ONLY] [CMP] ZLL not factory new

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -255,7 +255,6 @@ void BaseApplicationDelegate::OnCommissioningWindowClosed()
 #endif // QR_CODE_ENABLED
 #endif // DISPLAY_ENABLED
     }
-
 }
 
 void BaseApplicationDelegate::OnFabricCommitted(const FabricTable & fabricTable, FabricIndex fabricIndex)
@@ -974,6 +973,7 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
         Zigbee::RequestStart(channel);     // leave handle internally
 #elif defined(SL_MATTER_ZIGBEE_SEQUENTIAL) // Matter Zigbee sequential
         Zigbee::RequestLeave();
+        Zigbee::ZLLNotFactoryNew();
 #endif                                     // SL_MATTER_ZIGBEE_CMP
 #endif                                     // SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
     }


### PR DESCRIPTION
Inform the Zigbee stack that the device should not be considered factory-new once the matter commission is completed.

This will stop touch link broadcasts at reboots causing thread issues when concurrent channel listening is not available.


#### Testing
Matter zigbee sequential commission and reboot tests. SRP request at boot up works