### PR TITLE
[SL-TEMP] Modified scan networks code to use ByteSpan in place of pointer.

### DIFF
--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -263,17 +263,10 @@ chip::BitFlags<WiFiSecurity> SlWiFiDriver::ConvertSecuritytype(wfx_sec_t securit
     return securityType;
 }
 
-bool SlWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)
+CHIP_ERROR SlWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)
 {
     ChipLogProgress(DeviceLayer, "Start Scan WiFi Networks");
-
-    CHIP_ERROR err = wfx_start_scan(ssid, OnScanWiFiNetworkDone);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "wfx_start_scan failed : %s", chip::ErrorStr(err));
-        return false;
-    }
-    return true;
+    return wfx_start_scan(ssid, OnScanWiFiNetworkDone);
 }
 
 void SlWiFiDriver::OnScanWiFiNetworkDone(wfx_wifi_scan_result_t * aScanResult)
@@ -318,7 +311,7 @@ void SlWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callba
     if (callback != nullptr)
     {
         mpScanCallback = callback;
-        if (!StartScanWiFiNetworks(ssid))
+        if (StartScanWiFiNetworks(ssid) != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "ScanWiFiNetworks failed to start");
             mpScanCallback = nullptr;

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -265,19 +265,15 @@ chip::BitFlags<WiFiSecurity> SlWiFiDriver::ConvertSecuritytype(wfx_sec_t securit
 
 bool SlWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)
 {
-    bool scanStarted = false;
     ChipLogProgress(DeviceLayer, "Start Scan WiFi Networks");
-    if (!ssid.empty()) // ssid is given, only scan this network
+
+    CHIP_ERROR err = wfx_start_scan(ssid, OnScanWiFiNetworkDone);
+    if (err != CHIP_NO_ERROR)
     {
-        char cSsid[DeviceLayer::Internal::kMaxWiFiSSIDLength] = {};
-        memcpy(cSsid, ssid.data(), ssid.size());
-        scanStarted = wfx_start_scan(cSsid, OnScanWiFiNetworkDone);
+        ChipLogError(DeviceLayer, "wfx_start_scan failed : %s", chip::ErrorStr(err));
+        return false;
     }
-    else // scan all networks
-    {
-        scanStarted = wfx_start_scan(nullptr, OnScanWiFiNetworkDone);
-    }
-    return scanStarted;
+    return true;
 }
 
 void SlWiFiDriver::OnScanWiFiNetworkDone(wfx_wifi_scan_result_t * aScanResult)

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.h
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.h
@@ -134,7 +134,7 @@ public:
 
 private:
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
-    bool StartScanWiFiNetworks(ByteSpan ssid);
+    CHIP_ERROR StartScanWiFiNetworks(ByteSpan ssid);
     static void OnScanWiFiNetworkDone(wfx_wifi_scan_result_t * aScanResult);
 
     WiFiNetwork mSavedNetwork   = {};

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -24,6 +24,8 @@
 
 #include "sl_status.h"
 #include <stdbool.h>
+#include "CHIPError.h"
+#include <lib/support/Span.h>
 
 /* LwIP includes. */
 #include "lwip/ip_addr.h"
@@ -65,6 +67,8 @@
 
 // TASK and Interrupt Macros
 #define SUCCESS_STATUS (1)
+
+using namespace ::chip;
 
 enum class WifiState : uint16_t
 {

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -24,7 +24,7 @@
 
 #include "sl_status.h"
 #include <stdbool.h>
-#include "CHIPError.h"
+#include <lib/core/CHIPError.h>
 #include <lib/support/Span.h>
 
 /* LwIP includes. */

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -211,7 +211,7 @@ bool wfx_have_ipv4_addr(sl_wfx_interface_t);
 
 bool wfx_have_ipv6_addr(sl_wfx_interface_t);
 wifi_mode_t wfx_get_wifi_mode(void);
-bool wfx_start_scan(char * ssid, void (*scan_cb)(wfx_wifi_scan_result_t *)); /* true returned if successfully started */
+CHIP_ERROR wfx_start_scan(chip::ByteSpan ssid, void (*scan_cb)(wfx_wifi_scan_result_t *)); /* true returned if successfully started */
 void wfx_cancel_scan(void);
 
 /*

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -1245,7 +1245,7 @@ CHIP_ERROR wfx_start_scan(chip::ByteSpan ssid, void (*callback)(wfx_wifi_scan_re
     VerifyOrReturnError(scan_cb == nullptr, CHIP_ERROR_IN_PROGRESS);
 
     // Validate SSID length
-    VerifyOrReturnError(ssid.size() <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_INVALID_STRING_LENGTH);
+    VerifyOrReturnError(ssid.size() <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_BUFFER_TOO_SMALL);
     // Handle scan based on whether SSID is empty or not
     if (ssid.empty()) 
     {

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
@@ -308,32 +308,44 @@ int32_t wfx_reset_counts(void)
 
 #ifdef SL_WFX_CONFIG_SCAN
 /*******************************************************************************
- * @fn   bool wfx_start_scan(char *ssid, void (*callback)(wfx_wifi_scan_result_t *))
+ * @fn   CHIP_ERROR wfx_start_scan(char *ssid, void (*callback)(wfx_wifi_scan_result_t *))
  * @brief
  *       called fuction when driver start scaning
  * @param[in]  ssid:
  * @return returns ture if successful,
  *          false otherwise
  *******************************************************************************/
-bool wfx_start_scan(char * ssid, void (*callback)(wfx_wifi_scan_result_t *))
+CHIP_ERROR wfx_start_scan(chip::ByteSpan ssid, void (*callback)(wfx_wifi_scan_result_t *))
 {
-    // check if already in progress
-    VerifyOrReturnError(wfx_rsi.scan_cb == nullptr, false);
+    // Check if a scan is already in progress
+    VerifyOrReturnError(wfx_rsi.scan_cb == nullptr, CHIP_ERROR_IN_PROGRESS);
     wfx_rsi.scan_cb = callback;
 
-    // if SSID is provided to scan only that SSID
-    if(ssid) 
+    // Validate SSID length
+    VerifyOrReturnError(ssid.size() <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_INVALID_STRING_LENGTH);
+
+    // Handle scan based on whether SSID is empty or not
+    if (ssid.empty()) 
     {
-        wfx_rsi.scan_ssid_length = strnlen(ssid, std::min<size_t>(sizeof(ssid), WFX_MAX_SSID_LENGTH));
-        wfx_rsi.scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length + 1));
-        VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, false);
+        // Scan all networks
+        wfx_rsi.scan_ssid        = nullptr;
+        wfx_rsi.scan_ssid_length = 0;
+    } 
+    else 
+    {
+        // Allocate memory for SSID and copy data
+        wfx_rsi.scan_ssid_length = ssid.size();
+        wfx_rsi.scan_ssid = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length + 1));
+        VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        // Copy the SSID with null-termination
         chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length + 1, ssid);
     }
 
     WifiEvent event = WifiEvent::kScan;
     sl_matter_wifi_post_event(event);
 
-    return true;
+    return CHIP_NO_ERROR;
 }
 
 /***************************************************************************

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
@@ -308,7 +308,7 @@ int32_t wfx_reset_counts(void)
 
 #ifdef SL_WFX_CONFIG_SCAN
 /*******************************************************************************
- * @fn   CHIP_ERROR wfx_start_scan(char *ssid, void (*callback)(wfx_wifi_scan_result_t *))
+ * @fn   CHIP_ERROR wfx_start_scan(chip::ByteSpan ssid, void (*callback)(wfx_wifi_scan_result_t *))
  * @brief
  *       called fuction when driver start scaning
  * @param[in]  ssid:

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
@@ -322,7 +322,7 @@ CHIP_ERROR wfx_start_scan(chip::ByteSpan ssid, void (*callback)(wfx_wifi_scan_re
     wfx_rsi.scan_cb = callback;
 
     // Validate SSID length
-    VerifyOrReturnError(ssid.size() <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_INVALID_STRING_LENGTH);
+    VerifyOrReturnError(ssid.size() <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // Handle scan based on whether SSID is empty or not
     if (ssid.empty()) 


### PR DESCRIPTION
This PR fixes the Scan Networks issue mentioned in [MATTER-4650](https://jira.silabs.com/browse/MATTER-4650)

**Description of issue** : While scanning for a particular SSID(string), the size of the pointer to this string is taken as length of the string instead of the actual length.

**Description of Fix** : Replaced the pointer with Bytespan so that the length of the input SSID is calculated correctly.

