### PR TITLE
[SL-ONLY] Tracing in CI

### DIFF
--- a/.github/silabs-builds-mg26.json
+++ b/.github/silabs-builds-mg26.json
@@ -4,5 +4,11 @@
             "boards": ["BRD4116A", "BRD4117A", "BRD4118A", "BRD2608A"],
             "arguments": ["--docker"]
         }
+    ],
+    "lighting-app":[
+        {
+            "boards": ["BRD2608A"],
+            "arguments": ["--docker", "chip_build_libshell=true", "matter_enable_tracing_support=true", "--clean"]
+        }
     ]
 }

--- a/src/platform/silabs/tracing/BUILD.gn
+++ b/src/platform/silabs/tracing/BUILD.gn
@@ -24,7 +24,6 @@ static_library("SilabsTracing") {
     "BackendImpl.h",
     "SilabsTracing.cpp",
     "SilabsTracing.h",
-    "SilabsTracingMacros.h",
     "SilabsTracingTypes.h",
   ]
 


### PR DESCRIPTION
Fixed tracing build and add tracing build option to CI to prevent future breakage


#### Testing

Built efr32 NCP apps, efr32 mg24 appps and efr32 mg26 apps with and without tracing enabled.

CI will tell if I enabled it properly.
