### PR TITLE
[SL-ONLY] Add require admin check workflow

### DIFF
--- a/.github/workflows/silabs-open-csa-pr.yaml
+++ b/.github/workflows/silabs-open-csa-pr.yaml
@@ -36,7 +36,8 @@ jobs:
 
                       **PR MUST BE MERGED WITH MERGE COMMIT - ADMIN MUST ENABLE THE OPTION**
                   token: ${{secrets.GITHUB_TOKEN}}
-                  labels: changing-submodules-on-purpose
+                  labels:
+                      changing-submodules-on-purpose, sl-require-admin-action
 
             # The next step is necessary to force the CI to be executed when a PR is opened by the github-bot.
             # The PR event isn't triggered when the bot opens the PR and as such doesn't trigger the workflows that use the event as their trigger.

--- a/.github/workflows/silabs-require-admin-action-check.yaml
+++ b/.github/workflows/silabs-require-admin-action-check.yaml
@@ -46,7 +46,10 @@ jobs:
                   REMOVED_LABEL=${{ github.event.label.name }}
                   if [ "$REMOVED_LABEL" == "sl-require-admin-action" ]; then
                     echo "The sl-require-admin-action label cannot be removed. Failing the job."
-                    gh pr comment $PR_NUMBER --repo ${{ github.repository }} --body "The sl-require-admin-action label cannot be removed once it has been added."
+                    COMMENTS=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json comments --jq '.comments[].body')
+                    if ! echo "$COMMENTS" | grep -q "The sl-require-admin-action label cannot be removed once it has been added."; then
+                      gh pr comment $PR_NUMBER --repo ${{ github.repository }} --body "The sl-require-admin-action label cannot be removed once it has been added."
+                    fi
                     exit 1
                   else
                     echo "A different label was removed. Passing the job."

--- a/.github/workflows/silabs-require-admin-action-check.yaml
+++ b/.github/workflows/silabs-require-admin-action-check.yaml
@@ -1,0 +1,37 @@
+name: Check for sl-require-admin-action label
+
+on:
+    pull_request:
+        branches:
+            - main
+            - release_*
+        types:
+            - opened
+            - reopened
+            - synchronize
+            - labeled
+            - unlabeled
+
+permissions:
+    pull-requests: write
+
+jobs:
+    check-label:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check for sl-require-admin-action label
+              run: |
+                  PR_NUMBER=${{ github.event.pull_request.number }}
+                  LABELS=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json labels --jq '.labels[].name')
+                  if echo "$LABELS" | grep -q "sl-require-admin-action"; then
+                    echo "The sl-require-admin-action label is present. Failing the job."
+                    COMMENTS=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json comments --jq '.comments[].body')
+                    if ! echo "$COMMENTS" | grep -q "The CI failure for this job is normal. An admin must do the merge."; then
+                      gh pr comment $PR_NUMBER --repo ${{ github.repository }} --body "The CI failure for this job is normal. An admin must do the merge."
+                    fi
+                    exit 1
+                  else
+                    echo "The sl-require-admin-action label is not present. Passing the job."
+                  fi
+              env:
+                  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/silabs-require-admin-action-check.yaml
+++ b/.github/workflows/silabs-require-admin-action-check.yaml
@@ -35,3 +35,21 @@ jobs:
                   fi
               env:
                   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+    prevent-label-removal:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Prevent sl-require-admin-action label removal
+              if: github.event.action == 'unlabeled'
+              run: |
+                  PR_NUMBER=${{ github.event.pull_request.number }}
+                  REMOVED_LABEL=${{ github.event.label.name }}
+                  if [ "$REMOVED_LABEL" == "sl-require-admin-action" ]; then
+                    echo "The sl-require-admin-action label cannot be removed. Failing the job."
+                    gh pr comment $PR_NUMBER --repo ${{ github.repository }} --body "The sl-require-admin-action label cannot be removed once it has been added."
+                    exit 1
+                  else
+                    echo "A different label was removed. Passing the job."
+                  fi
+              env:
+                  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### Description
PR adds a workflow that checks if the `sl-require-admin-action` label is present. If the label is present, the workflow fails to force admin action.

PR adds two jobs, one to check if the label is present and a second that checks if the label was removed.

The goal of this action is to force an admin validation on certain situations like the update of main from csa that requires a special merge strategy.

### CI
