### PR TITLE
[SL-UP][WiFi] Fixing the rssi value for wf200

### DIFF
--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -301,12 +301,6 @@ void sl_button_on_change(uint8_t btn, uint8_t btnAction);
 #ifdef WF200_WIFI
 void sl_wfx_host_gpio_init(void);
 void wfx_bus_start(void);
-/**
- * @brief Convert RCPI to RSSI
- * @param[in]  rcpi: Received Channel Power Indicator value
- * @return RSSI value
- */
-inline int32_t ConvertRcpiToRssi(int32_t rcpi) { return (rcpi / 2) - 110; }
 #endif /* WF200_WIFI */
 
 #ifdef __cplusplus

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -301,6 +301,12 @@ void sl_button_on_change(uint8_t btn, uint8_t btnAction);
 #ifdef WF200_WIFI
 void sl_wfx_host_gpio_init(void);
 void wfx_bus_start(void);
+/**
+ * @brief Convert RCPI to RSSI
+ * @param[in]  rcpi: Received Channel Power Indicator value
+ * @return RSSI value
+ */
+inline int32_t ConvertRcpiToRssi(int32_t rcpi) { return (rcpi / 2) - 110; }
 #endif /* WF200_WIFI */
 
 #ifdef __cplusplus

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -479,7 +479,7 @@ static void sl_wfx_scan_result_callback(sl_wfx_scan_result_ind_body_t * scan_res
             ap->scan.security = WFX_SEC_NONE;
         }
         ap->scan.chan = scan_result->channel;
-        ap->scan.rssi = scan_result->rcpi;
+        ap->scan.rssi = (scan_result->rcpi)/2 - 110;
         memcpy(&ap->scan.bssid[0], &scan_result->mac[0], BSSID_LEN);
         scan_count++;
     }

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -913,7 +913,7 @@ int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap)
     sl_status_t status = sl_wfx_get_signal_strength((uint32_t *) &signal_strength);
     VerifyOrReturnError(status == SL_STATUS_OK, status);
     ChipLogDetail(DeviceLayer, "signal_strength: %ld", signal_strength);
-    ap->rssi = (signal_strength - 220) / 2;
+    ap->rssi = (signal_strength / 2) - 110;
     return status;
 }
 

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -300,7 +300,7 @@ error_handler:
  */
 inline int16_t ConvertRcpiToRssi(uint32_t rcpi) {
     int64_t rssi = (rcpi / 2) - 110;
-    // Checking for the overflows
+    // Checking for overflows
     VerifyOrReturnValue(rssi < std::numeric_limits<int16_t>::max(), std::numeric_limits<int16_t>::max());
     VerifyOrReturnValue(rssi > std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::min());
     return rssi;

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -292,6 +292,15 @@ error_handler:
 
     return result;
 }
+
+/**
+ * @brief Convert RCPI to RSSI
+ * @param[in]  rcpi: Received Channel Power Indicator value
+ * @return RSSI value
+ */
+int32_t ConvertRcpiToRssi(int32_t rcpi) {
+    return (rcpi / 2) - 110;
+}
 } // namespace
 
 /***************************************************************************

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -298,7 +298,7 @@ error_handler:
  * @param[in]  rcpi: Received Channel Power Indicator value
  * @return RSSI value
  */
-int32_t ConvertRcpiToRssi(int32_t rcpi) {
+int16_t ConvertRcpiToRssi(uint16_t rcpi) {
     return (rcpi / 2) - 110;
 }
 } // namespace
@@ -904,7 +904,7 @@ static void wfx_wifi_hw_start(void)
  **************************************************************************/
 int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap)
 {
-    int32_t signal_strength;
+    uint16_t signal_strength;
 
     ap->ssid_length = strnlen(ap_info.ssid, chip::min<size_t>(sizeof(ap_info.ssid), WFX_MAX_SSID_LENGTH));
     // ap->ssid is of size WFX_MAX_SSID_LENGTH+1, we are safe with the ap->ssid_length calculated above

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -298,11 +298,12 @@ error_handler:
  * @param[in]  rcpi: Received Channel Power Indicator value
  * @return RSSI value
  */
-int16_t ConvertRcpiToRssi(uint32_t rcpi) {
+inline int16_t ConvertRcpiToRssi(uint32_t rcpi) {
+    int16_t rssi = (rcpi / 2) - 110;
     // Checking for the overflows
-    // If rcpi is greater than or equal to INT16_MAX, return INT16_MIN to indicate an error
-    VerifyOrReturnValue(rcpi < INT16_MAX, INT16_MIN);
-    return (rcpi / 2) - 110;
+    VerifyOrReturnValue(rssi < std::numeric_limits<int16_t>::max(), std::numeric_limits<int16_t>::max());
+    VerifyOrReturnValue(rssi > std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::min());
+    return rssi;
 }
 } // namespace
 

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -299,7 +299,7 @@ error_handler:
  * @return RSSI value
  */
 inline int16_t ConvertRcpiToRssi(uint32_t rcpi) {
-    int16_t rssi = (rcpi / 2) - 110;
+    int64_t rssi = (rcpi / 2) - 110;
     // Checking for the overflows
     VerifyOrReturnValue(rssi < std::numeric_limits<int16_t>::max(), std::numeric_limits<int16_t>::max());
     VerifyOrReturnValue(rssi > std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::min());

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -920,7 +920,7 @@ int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap)
 
     sl_status_t status = sl_wfx_get_signal_strength((uint32_t *) &signal_strength);
     VerifyOrReturnError(status == SL_STATUS_OK, status);
-    ChipLogDetail(DeviceLayer, "signal_strength: %ld", signal_strength);
+    ChipLogDetail(DeviceLayer, "signal_strength: %d", signal_strength);
     ap->rssi = ConvertRcpiToRssi(signal_strength);
     return status;
 }

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -295,6 +295,10 @@ error_handler:
 
 /**
  * @brief Convert RCPI to RSSI
+ * This function converts the Received Channel Power Indicator (RCPI) value to
+ * the Received Signal Strength Indicator (RSSI) value. If the result of the
+ * conversion exceeds the range of int16_t, it will be clamped to the maximum
+ * or minimum value of int16_t.
  * @param[in]  rcpi: Received Channel Power Indicator value
  * @return RSSI value
  */

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -292,7 +292,6 @@ error_handler:
 
     return result;
 }
-
 } // namespace
 
 /***************************************************************************
@@ -436,7 +435,7 @@ static void sl_wfx_scan_result_callback(sl_wfx_scan_result_ind_body_t * scan_res
     struct scan_result_holder * ap;
 
     ChipLogDetail(DeviceLayer, "# %2d %2d  %03d %02X:%02X:%02X:%02X:%02X:%02X  %s", scan_count, scan_result->channel,
-                  ((int16_t) (scan_result->rcpi - 220) / 2), scan_result->mac[0], scan_result->mac[1], scan_result->mac[2],
+                  ((int16_t) (ConvertRcpiToRssi(scan_result->rcpi))), scan_result->mac[0], scan_result->mac[1], scan_result->mac[2],
                   scan_result->mac[3], scan_result->mac[4], scan_result->mac[5], scan_result->ssid_def.ssid);
     /* Report one AP information */
     /* don't save if filter only wants specific ssid */
@@ -479,7 +478,7 @@ static void sl_wfx_scan_result_callback(sl_wfx_scan_result_ind_body_t * scan_res
             ap->scan.security = WFX_SEC_NONE;
         }
         ap->scan.chan = scan_result->channel;
-        ap->scan.rssi = (scan_result->rcpi)/2 - 110;
+        ap->scan.rssi = ConvertRcpiToRssi(scan_result->rcpi);
         memcpy(&ap->scan.bssid[0], &scan_result->mac[0], BSSID_LEN);
         scan_count++;
     }
@@ -913,7 +912,7 @@ int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap)
     sl_status_t status = sl_wfx_get_signal_strength((uint32_t *) &signal_strength);
     VerifyOrReturnError(status == SL_STATUS_OK, status);
     ChipLogDetail(DeviceLayer, "signal_strength: %ld", signal_strength);
-    ap->rssi = (signal_strength / 2) - 110;
+    ap->rssi = ConvertRcpiToRssi(signal_strength);
     return status;
 }
 

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -302,7 +302,8 @@ error_handler:
  * @param[in]  rcpi: Received Channel Power Indicator value
  * @return RSSI value
  */
-inline int16_t ConvertRcpiToRssi(uint32_t rcpi) {
+inline int16_t ConvertRcpiToRssi(uint32_t rcpi)
+{
     int64_t rssi = (rcpi / 2) - 110;
     // Checking for overflows
     VerifyOrReturnValue(rssi < std::numeric_limits<int16_t>::max(), std::numeric_limits<int16_t>::max());
@@ -1226,7 +1227,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) & 0xFF;
+    ip4_addr[0] = (ip) &0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;
@@ -1263,13 +1264,13 @@ CHIP_ERROR wfx_start_scan(chip::ByteSpan ssid, void (*callback)(wfx_wifi_scan_re
     // Validate SSID length
     VerifyOrReturnError(ssid.size() <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_BUFFER_TOO_SMALL);
     // Handle scan based on whether SSID is empty or not
-    if (ssid.empty()) 
+    if (ssid.empty())
     {
         // Scan all networks
         scan_ssid        = nullptr;
         scan_ssid_length = 0;
-    } 
-    else 
+    }
+    else
     {
         scan_ssid_length = ssid.size();
         scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(scan_ssid_length + 1));


### PR DESCRIPTION
WF200 scan was sending RCPI value rather than the RSSI value. Fixing it so that the send value is RSSI

Formula for the RSSI
```
The following equation can be used to convert the RCPI value to corresponding dBm value.
[signal level in dBm] = (RCPI / 2) - 110
```
https://docs.silabs.com/wifi/wf200/rtos/latest/group-w-f-m-g-r-o-u-p-c-o-n-c-e-p-t-s

Tested on WF200