### PR TITLE
[CSA-CP] Restore restyler automation

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -16,7 +16,9 @@ jobs:
 
       - uses: restyled-io/actions/setup@v4
         with:
-          # Pin the Restyler version to v0.6.0.2
+          # TODO: Pinned to v0.6.0.2 because the latest release does not have a pre-built
+          # 'restyler-linux' asset. This broke our workflow as we rely on the pre-built binary.
+          # Remove this pin once a new release with the 'restyler-linux' asset is available.          
           tag: 'v0.6.0.2'
 
       - id: restyler

--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: restyled-io/actions/setup@v4
+        with:
+          # Pin the Restyler version to v0.6.0.2
+          tag: 'v0.6.0.2'
+
       - id: restyler
         uses: restyled-io/actions/run@v4
         with:

--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,0 +1,35 @@
+name: Restyled
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  restyled:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: restyled-io/actions/setup@v4
+      - id: restyler
+        uses: restyled-io/actions/run@v4
+        with:
+          fail-on-differences: true
+
+      - if: |
+          !cancelled() &&
+          steps.restyler.outputs.success == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: peter-evans/create-pull-request@v6
+        with:
+          base: ${{ steps.restyler.outputs.restyled-base }}
+          branch: ${{ steps.restyler.outputs.restyled-head }}
+          title: ${{ steps.restyler.outputs.restyled-title }}
+          body: ${{ steps.restyler.outputs.restyled-body }}
+          labels: "restyled"
+          reviewers: ${{ github.event.pull_request.user.login }}
+          delete-branch: true

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -8,257 +8,257 @@ github_api_version: "shadow-cat-preview"
 ############################################################
 
 overrides:
-    - if: "'hotfix' in labels"
-      status: success
-      explanation: "Hotfix label added, bypassing reviews"
+  - if: "'hotfix' in labels"
+    status: success
+    explanation: "Hotfix label added, bypassing reviews"
 
-    ############################################################
-    #  Draft PRs
-    ############################################################
-    - if: "draft"
-      status: pending
-      explanation: "PR is draft, pending review"
+  ############################################################
+  #  Draft PRs
+  ############################################################
+  - if: "draft"
+    status: pending
+    explanation: "PR is draft, pending review"
 
-    ############################################################
-    #  License Checks
-    ############################################################
-    - if: "'*license/cla*' not in statuses.successful"
-      status: pending
-      explanation: "CLA must be agreed to by all contributors"
+  ############################################################
+  #  License Checks
+  ############################################################
+  - if: "'*license/cla*' not in statuses.successful"
+    status: pending
+    explanation: "CLA must be agreed to by all contributors"
 
-    ############################################################
-    #  Conditions to Skip Review
-    ############################################################
-    - if: "base.ref != 'master'"
-      status: success
-      explanation: "Review not required unless merging to master"
+  ############################################################
+  #  Conditions to Skip Review
+  ############################################################
+  - if: "base.ref != 'master'"
+    status: success
+    explanation: "Review not required unless merging to master"
 
-    ############################################################
-    #  Required status checks
-    ############################################################
-    - if: "'*restyle*' not in statuses.successful"
-      status: failure
-      explanation: "Style must be inline before reviewing can be complete"
+  ############################################################
+  #  Required status checks
+  ############################################################
+  - if: "'*restyled*' not in statuses.successful"
+    status: failure
+    explanation: "Restyled workflow must be successful"
 
-    ############################################################
-    #  Require Issues
-    ############################################################
-    # disabling until we have PRs up to date
-    #     - if: "'*issue*' not in statuses.successful"
-    #       status: failure
-    #       explanation: "An issue is required for all PRs"
+  ############################################################
+  #  Require Issues
+  ############################################################
+  # disabling until we have PRs up to date
+  #     - if: "'*issue*' not in statuses.successful"
+  #       status: failure
+  #       explanation: "An issue is required for all PRs"
 
-    ############################################################
-    #  Fast tracking
-    ############################################################
-    - if: "'fast track' in labels"
-      status: success
-      explanation: "PR has been fast tracked, bypassing reviews"
+  ############################################################
+  #  Fast tracking
+  ############################################################
+  - if: "'fast track' in labels"
+    status: success
+    explanation: "PR has been fast tracked, bypassing reviews"
 
 ############################################################
 #  Notifications
 ############################################################
 
 notifications:
-    ############################################################
-    #  New contributors
-    ############################################################
-    - when: pull_request.opened
-      if: "author_association == 'FIRST_TIME_CONTRIBUTOR'"
-      comment: |
-          Hey @{{ author }}, thanks for the PR! The review will start once
-          the tests and CI checks have passed. If they don't, please review
-          the logs and try to fix the issues (ask for help if you can't
-          figure it out). A reviewer will be assigned once the tests are
-          passing and they'll walk you through getting the PR finished
-          and merged.
+  ############################################################
+  #  New contributors
+  ############################################################
+  - when: pull_request.opened
+    if: "author_association == 'FIRST_TIME_CONTRIBUTOR'"
+    comment: |
+      Hey @{{ author }}, thanks for the PR! The review will start once
+      the tests and CI checks have passed. If they don't, please review
+      the logs and try to fix the issues (ask for help if you can't
+      figure it out). A reviewer will be assigned once the tests are
+      passing and they'll walk you through getting the PR finished
+      and merged.
 
 groups:
-    ############################################################
-    #  Shared Reviewer Groups
-    ############################################################
-    shared-reviewers-amazon:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-amazon]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-apple:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-apple]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-bosch:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-bosch]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-comcast:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-comcast]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-dyson:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-dyson]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-espressif:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-espressif]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-google:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-google]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-grundfos:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-grundfos]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-irobot:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-irobot]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-lg:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-lg]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-logitech:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-logitech]
-        reviews:
-            request: 0 # Requested to be only on demand
-    shared-reviewers-nordic:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-nordic]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-nxp:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-nxp]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-samsung:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-samsung]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-eve:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-eve]
-        reviews:
-            request: 0 # Do not auto-add
-    # shared-reviewers-signify disabled for now, because the reviewers-signify
-    # team is empty and pullapprove seems to mis-handle that badly and treats
-    # _all_ reviewers as being in this group.
-    #
-    # See https://github.com/dropseed/pullapprove/issues/71
-    #
-    # shared-reviewers-signify:
-    #     type: optional
-    #     conditions:
-    #         - files.include('*')
-    #     reviewers:
-    #         teams: [reviewers-signify]
-    #     reviews:
-    #         request: 0 # Do not auto-add
-    shared-reviewers-silabs:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-silabs]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-somfy:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-somfy]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-tcl:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-tcl]
-        reviews:
-            request: 0 # Do not auto-add
-    shared-reviewers-qorvo:
-        type: optional
-        conditions:
-            - files.include('*')
-        reviewers:
-            teams: [reviewers-qorvo]
-        reviews:
-            request: 0 # Do not auto-add
+  ############################################################
+  #  Shared Reviewer Groups
+  ############################################################
+  shared-reviewers-amazon:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-amazon]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-apple:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-apple]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-bosch:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-bosch]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-comcast:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-comcast]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-dyson:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-dyson]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-espressif:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-espressif]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-google:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-google]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-grundfos:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-grundfos]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-irobot:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-irobot]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-lg:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-lg]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-logitech:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-logitech]
+    reviews:
+      request: 0 # Requested to be only on demand
+  shared-reviewers-nordic:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-nordic]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-nxp:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-nxp]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-samsung:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-samsung]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-eve:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-eve]
+    reviews:
+      request: 0 # Do not auto-add
+  # shared-reviewers-signify disabled for now, because the reviewers-signify
+  # team is empty and pullapprove seems to mis-handle that badly and treats
+  # _all_ reviewers as being in this group.
+  #
+  # See https://github.com/dropseed/pullapprove/issues/71
+  #
+  # shared-reviewers-signify:
+  #     type: optional
+  #     conditions:
+  #         - files.include('*')
+  #     reviewers:
+  #         teams: [reviewers-signify]
+  #     reviews:
+  #         request: 0 # Do not auto-add
+  shared-reviewers-silabs:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-silabs]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-somfy:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-somfy]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-tcl:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-tcl]
+    reviews:
+      request: 0 # Do not auto-add
+  shared-reviewers-qorvo:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-qorvo]
+    reviews:
+      request: 0 # Do not auto-add
 
-    ############################################################
-    #  Base Required Reviewers
-    ############################################################
-    required-reviewers:
-        description: >
-            [Required
-            Reviewers](https://github.com/project-chip/connectedhomeip/blob/master/CONTRIBUTING.md#review-requirements)
-            This is the main group of required reviews for general pull
-            requests.
-        type: required
-        requirements:
-            - len(groups.approved.include('shared-reviewers-*')) >= 2
-        reviews:
-            required: 0
-        labels:
-            approved: "review - approved"
-            pending: "review - pending"
-            rejected: "review - changed requested"
+  ############################################################
+  #  Base Required Reviewers
+  ############################################################
+  required-reviewers:
+    description: >
+      [Required
+      Reviewers](https://github.com/project-chip/connectedhomeip/blob/master/CONTRIBUTING.md#review-requirements)
+      This is the main group of required reviews for general pull
+      requests.
+    type: required
+    requirements:
+      - len(groups.approved.include('shared-reviewers-*')) >= 2
+    reviews:
+      required: 0
+    labels:
+      approved: "review - approved"
+      pending: "review - pending"
+      rejected: "review - changed requested"


### PR DESCRIPTION
#### Description
Restyler automation transitionned to using github action and deprecated out the previous method to using the workflow.
The transition was done on CSA after the creation of the release branch so we never pulled in the fix.

PR cherry-picks the CSA PRs that fixed the restyler.

#### Tests
CI
