### PR TITLE
[SL-UP] Restyling the light switch app

### DIFF
--- a/examples/light-switch-app/silabs/include/AppEvent.h
+++ b/examples/light-switch-app/silabs/include/AppEvent.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 struct AppEvent;
 typedef void (*EventHandler)(AppEvent *);
 

--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -75,5 +75,4 @@ private:
      * @return CHIP_ERROR
      */
     CHIP_ERROR Init();
-
 };

--- a/examples/light-switch-app/silabs/include/BindingHandler.h
+++ b/examples/light-switch-app/silabs/include/BindingHandler.h
@@ -19,8 +19,8 @@
 #include "app-common/zap-generated/ids/Clusters.h"
 #include "app-common/zap-generated/ids/Commands.h"
 #include "lib/core/CHIPError.h"
-#include <platform/CHIPDeviceLayer.h>
 #include <app/clusters/bindings/bindings.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <variant>
 
 using namespace chip;
@@ -31,15 +31,13 @@ CHIP_ERROR InitBindingHandler();
 void SwitchWorkerFunction(intptr_t context);
 void BindingWorkerFunction(intptr_t context);
 
-
 struct CommandBase
 {
     chip::BitMask<OptionsBitmap> optionsMask;
     chip::BitMask<OptionsBitmap> optionsOverride;
 
     // Constructor to initialize the BitMask
-    CommandBase()
-        : optionsMask(0), optionsOverride(0) {}
+    CommandBase() : optionsMask(0), optionsOverride(0) {}
 };
 
 struct BindingCommandData

--- a/examples/light-switch-app/silabs/include/LightSwitchMgr.h
+++ b/examples/light-switch-app/silabs/include/LightSwitchMgr.h
@@ -19,14 +19,14 @@
 
 #pragma once
 
+#include "AppEvent.h"
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/clusters/bindings/bindings.h>
 #include <app/util/basic-types.h>
+#include <cmsis_os2.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
-#include <app/clusters/bindings/bindings.h>
 #include <platform/CHIPDeviceLayer.h>
-#include <app-common/zap-generated/ids/Clusters.h>
-#include "AppEvent.h"
-#include <cmsis_os2.h>
 #include <string>
 
 using namespace chip;
@@ -49,10 +49,7 @@ public:
     };
 
     static constexpr Clusters::LevelControl::Commands::Step::Type stepCommand = {
-        .stepSize = 1,
-        .transitionTime = 0,
-        .optionsMask = 0,
-        .optionsOverride = 0
+        .stepSize = 1, .transitionTime = 0, .optionsMask = 0, .optionsOverride = 0
     };
 
     struct Timer
@@ -106,19 +103,19 @@ private:
     static LightSwitchMgr sSwitch;
 
     Timer * mLongPressTimer      = nullptr;
-    bool mFunctionButtonPressed  = false;    // True when button0 is pressed, used to trigger factory reset
-    bool mActionButtonPressed    = false;    // True when button1 is pressed, used to initiate toggle or level-up/down
-    bool mActionButtonSuppressed = false;    // True when both button0 and button1 are pressed, used to switch step direction
+    bool mFunctionButtonPressed  = false; // True when button0 is pressed, used to trigger factory reset
+    bool mActionButtonPressed    = false; // True when button1 is pressed, used to initiate toggle or level-up/down
+    bool mActionButtonSuppressed = false; // True when both button0 and button1 are pressed, used to switch step direction
     bool mResetWarning           = false;
 
     // Default Step direction for Level control
-    StepModeEnum stepDirection   = StepModeEnum::kUp;
+    StepModeEnum stepDirection = StepModeEnum::kUp;
 
     static void OnLongPressTimeout(Timer & timer);
     LightSwitchMgr() = default;
 
-     /**
-     * @brief This function will be called when PB0 is 
+    /**
+     * @brief This function will be called when PB0 is
      *        long-pressed to trigger the factory-reset
      */
     void HandleLongPress();
@@ -127,8 +124,8 @@ private:
 
     chip::EndpointId mLightSwitchEndpoint   = chip::kInvalidEndpointId;
     chip::EndpointId mGenericSwitchEndpoint = chip::kInvalidEndpointId;
-   
-     /**
+
+    /**
      * @brief Button event processing function
      *        Function triggers a switch action sent to the CHIP task
      *

--- a/examples/light-switch-app/silabs/src/BindingHandler.cpp
+++ b/examples/light-switch-app/silabs/src/BindingHandler.cpp
@@ -101,8 +101,7 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
 
     switch (data->commandId)
     {
-    case Clusters::LevelControl::Commands::MoveToLevel::Id:
-    {
+    case Clusters::LevelControl::Commands::MoveToLevel::Id: {
         Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
         if (auto moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
         {
@@ -110,14 +109,13 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             moveToLevelCommand.transitionTime  = moveToLevel->transitionTime;
             moveToLevelCommand.optionsMask     = moveToLevel->optionsMask;
             moveToLevelCommand.optionsOverride = moveToLevel->optionsOverride;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                         moveToLevelCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(),
+                                             binding.remote, moveToLevelCommand, onSuccess, onFailure);
         }
         break;
     }
 
-    case Clusters::LevelControl::Commands::Move::Id:
-    {
+    case Clusters::LevelControl::Commands::Move::Id: {
         Clusters::LevelControl::Commands::Move::Type moveCommand;
         if (auto move = std::get_if<BindingCommandData::Move>(&data->commandData))
         {
@@ -125,14 +123,13 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             moveCommand.rate            = move->rate;
             moveCommand.optionsMask     = move->optionsMask;
             moveCommand.optionsOverride = move->optionsOverride;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                         moveCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(),
+                                             binding.remote, moveCommand, onSuccess, onFailure);
         }
         break;
     }
 
-    case Clusters::LevelControl::Commands::Step::Id:
-    {
+    case Clusters::LevelControl::Commands::Step::Id: {
         Clusters::LevelControl::Commands::Step::Type stepCommand;
         if (auto step = std::get_if<BindingCommandData::Step>(&data->commandData))
         {
@@ -141,27 +138,25 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             stepCommand.transitionTime  = step->transitionTime;
             stepCommand.optionsMask     = step->optionsMask;
             stepCommand.optionsOverride = step->optionsOverride;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                         stepCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(),
+                                             binding.remote, stepCommand, onSuccess, onFailure);
         }
         break;
     }
 
-    case Clusters::LevelControl::Commands::Stop::Id:
-    {
+    case Clusters::LevelControl::Commands::Stop::Id: {
         Clusters::LevelControl::Commands::Stop::Type stopCommand;
         if (auto stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
         {
             stopCommand.optionsMask     = stop->optionsMask;
             stopCommand.optionsOverride = stop->optionsOverride;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                         stopCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(),
+                                             binding.remote, stopCommand, onSuccess, onFailure);
         }
         break;
     }
 
-    case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id:
-    {
+    case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id: {
         Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type moveToLevelWithOnOffCommand;
         if (auto moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
         {
@@ -169,14 +164,13 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             moveToLevelWithOnOffCommand.transitionTime  = moveToLevel->transitionTime;
             moveToLevelWithOnOffCommand.optionsMask     = moveToLevel->optionsMask;
             moveToLevelWithOnOffCommand.optionsOverride = moveToLevel->optionsOverride;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                         moveToLevelWithOnOffCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(),
+                                             binding.remote, moveToLevelWithOnOffCommand, onSuccess, onFailure);
         }
         break;
     }
 
-    case Clusters::LevelControl::Commands::MoveWithOnOff::Id:
-    {
+    case Clusters::LevelControl::Commands::MoveWithOnOff::Id: {
         Clusters::LevelControl::Commands::MoveWithOnOff::Type moveWithOnOffCommand;
         if (auto move = std::get_if<BindingCommandData::Move>(&data->commandData))
         {
@@ -184,14 +178,13 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             moveWithOnOffCommand.rate            = move->rate;
             moveWithOnOffCommand.optionsMask     = move->optionsMask;
             moveWithOnOffCommand.optionsOverride = move->optionsOverride;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                         moveWithOnOffCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(),
+                                             binding.remote, moveWithOnOffCommand, onSuccess, onFailure);
         }
         break;
     }
 
-    case Clusters::LevelControl::Commands::StepWithOnOff::Id:
-    {
+    case Clusters::LevelControl::Commands::StepWithOnOff::Id: {
         Clusters::LevelControl::Commands::StepWithOnOff::Type stepWithOnOffCommand;
         if (auto step = std::get_if<BindingCommandData::Step>(&data->commandData))
         {
@@ -200,21 +193,20 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
             stepWithOnOffCommand.transitionTime  = step->transitionTime;
             stepWithOnOffCommand.optionsMask     = step->optionsMask;
             stepWithOnOffCommand.optionsOverride = step->optionsOverride;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                         stepWithOnOffCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(),
+                                             binding.remote, stepWithOnOffCommand, onSuccess, onFailure);
         }
         break;
     }
 
-    case Clusters::LevelControl::Commands::StopWithOnOff::Id:
-    {
+    case Clusters::LevelControl::Commands::StopWithOnOff::Id: {
         Clusters::LevelControl::Commands::StopWithOnOff::Type stopWithOnOffCommand;
         if (auto stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
         {
             stopWithOnOffCommand.optionsMask     = stop->optionsMask;
             stopWithOnOffCommand.optionsOverride = stop->optionsOverride;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                         stopWithOnOffCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(),
+                                             binding.remote, stopWithOnOffCommand, onSuccess, onFailure);
         }
         break;
     }
@@ -229,8 +221,7 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
 
     switch (data->commandId)
     {
-    case Clusters::LevelControl::Commands::MoveToLevel::Id:
-    {
+    case Clusters::LevelControl::Commands::MoveToLevel::Id: {
         Clusters::LevelControl::Commands::MoveToLevel::Type moveToLevelCommand;
         if (auto moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
         {
@@ -243,8 +234,7 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
     }
 
-    case Clusters::LevelControl::Commands::Move::Id:
-    {
+    case Clusters::LevelControl::Commands::Move::Id: {
         Clusters::LevelControl::Commands::Move::Type moveCommand;
         if (auto move = std::get_if<BindingCommandData::Move>(&data->commandData))
         {
@@ -257,8 +247,7 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
     }
 
-    case Clusters::LevelControl::Commands::Step::Id:
-    {
+    case Clusters::LevelControl::Commands::Step::Id: {
         Clusters::LevelControl::Commands::Step::Type stepCommand;
         if (auto step = std::get_if<BindingCommandData::Step>(&data->commandData))
         {
@@ -272,8 +261,7 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
     }
 
-    case Clusters::LevelControl::Commands::Stop::Id:
-    {
+    case Clusters::LevelControl::Commands::Stop::Id: {
         Clusters::LevelControl::Commands::Stop::Type stopCommand;
         if (auto stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
         {
@@ -284,8 +272,7 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
     }
 
-    case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id:
-    {
+    case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id: {
         Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type moveToLevelWithOnOffCommand;
         if (auto moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
         {
@@ -298,8 +285,7 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
     }
 
-    case Clusters::LevelControl::Commands::MoveWithOnOff::Id:
-    {
+    case Clusters::LevelControl::Commands::MoveWithOnOff::Id: {
         Clusters::LevelControl::Commands::MoveWithOnOff::Type moveWithOnOffCommand;
         if (auto move = std::get_if<BindingCommandData::Move>(&data->commandData))
         {
@@ -312,8 +298,7 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
     }
 
-    case Clusters::LevelControl::Commands::StepWithOnOff::Id:
-    {
+    case Clusters::LevelControl::Commands::StepWithOnOff::Id: {
         Clusters::LevelControl::Commands::StepWithOnOff::Type stepWithOnOffCommand;
         if (auto step = std::get_if<BindingCommandData::Step>(&data->commandData))
         {
@@ -327,8 +312,7 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
         break;
     }
 
-    case Clusters::LevelControl::Commands::StopWithOnOff::Id:
-    {
+    case Clusters::LevelControl::Commands::StopWithOnOff::Id: {
         Clusters::LevelControl::Commands::StopWithOnOff::Type stopWithOnOffCommand;
         if (auto stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
         {

--- a/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
+++ b/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
@@ -31,8 +31,8 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/clusters/switch-server/switch-server.h>
-#include <platform/CHIPDeviceLayer.h>
 #include <cmsis_os2.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
 
 using namespace chip;
@@ -46,10 +46,10 @@ LightSwitchMgr LightSwitchMgr::sSwitch;
 AppEvent LightSwitchMgr::CreateNewEvent(AppEvent::AppEventTypes type)
 {
     AppEvent aEvent;
-    aEvent.Type                      = type;
-    aEvent.Handler                   = LightSwitchMgr::AppEventHandler;
-    LightSwitchMgr * lightSwitch         = &LightSwitchMgr::GetInstance();
-    aEvent.LightSwitchEvent.Context  = lightSwitch;
+    aEvent.Type                     = type;
+    aEvent.Handler                  = LightSwitchMgr::AppEventHandler;
+    LightSwitchMgr * lightSwitch    = &LightSwitchMgr::GetInstance();
+    aEvent.LightSwitchEvent.Context = lightSwitch;
     return aEvent;
 }
 
@@ -77,9 +77,9 @@ void LightSwitchMgr::Timer::Timeout()
 void LightSwitchMgr::HandleLongPress()
 {
     AppEvent event;
-    event.Handler             = AppEventHandler;
-    LightSwitchMgr * lightSwitch  = &LightSwitchMgr::GetInstance();
-    event.LightSwitchEvent.Context  = lightSwitch;
+    event.Handler                  = AppEventHandler;
+    LightSwitchMgr * lightSwitch   = &LightSwitchMgr::GetInstance();
+    event.LightSwitchEvent.Context = lightSwitch;
     if (mFunctionButtonPressed)
     {
         if (!mResetWarning)
@@ -114,7 +114,7 @@ LightSwitchMgr::Timer::Timer(uint32_t timeoutInMs, Callback callback, void * con
                           this,          // pass the app task obj context
                           NULL           // No osTimerAttr_t to provide.
     );
-    
+
     if (mHandler == NULL)
     {
         SILABS_LOG("Timer create failed");
@@ -208,7 +208,8 @@ void LightSwitchMgr::GenericSwitchOnShortRelease()
     DeviceLayer::PlatformMgr().ScheduleWork(GenericSwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
 }
 
-StepModeEnum LightSwitchMgr::getStepMode(){
+StepModeEnum LightSwitchMgr::getStepMode()
+{
     return stepDirection;
 }
 
@@ -250,11 +251,9 @@ void LightSwitchMgr::TriggerLevelControlAction(LevelControl::StepModeEnum stepMo
     data->clusterId = chip::app::Clusters::LevelControl::Id;
     data->isGroup   = isGroupCommand;
     data->commandId = LevelControl::Commands::StepWithOnOff::Id;
-    BindingCommandData::Step stepData{
-        .stepMode = stepMode,
-        .stepSize = LightSwitchMgr::stepCommand.stepSize,
-        .transitionTime = LightSwitchMgr::stepCommand.transitionTime
-    };
+    BindingCommandData::Step stepData{ .stepMode       = stepMode,
+                                       .stepSize       = LightSwitchMgr::stepCommand.stepSize,
+                                       .transitionTime = LightSwitchMgr::stepCommand.transitionTime };
     stepData.optionsMask.Set(LightSwitchMgr::stepCommand.optionsMask);
     stepData.optionsOverride.Set(LightSwitchMgr::stepCommand.optionsOverride);
     data->commandData = stepData;
@@ -301,11 +300,13 @@ void LightSwitchMgr::ButtonEventHandler(uint8_t button, uint8_t btnAction)
     AppEvent event = {};
     if (btnAction == to_underlying(SilabsPlatform::ButtonAction::ButtonPressed))
     {
-        event = LightSwitchMgr::GetInstance().CreateNewEvent(button ? AppEvent::kEventType_ActionButtonPressed : AppEvent::kEventType_FunctionButtonPressed);
+        event = LightSwitchMgr::GetInstance().CreateNewEvent(button ? AppEvent::kEventType_ActionButtonPressed
+                                                                    : AppEvent::kEventType_FunctionButtonPressed);
     }
     else
     {
-        event = LightSwitchMgr::GetInstance().CreateNewEvent(button ? AppEvent::kEventType_ActionButtonReleased : AppEvent::kEventType_FunctionButtonReleased);
+        event = LightSwitchMgr::GetInstance().CreateNewEvent(button ? AppEvent::kEventType_ActionButtonReleased
+                                                                    : AppEvent::kEventType_FunctionButtonReleased);
     }
     AppTask::GetAppTask().PostEvent(&event);
 }
@@ -313,7 +314,7 @@ void LightSwitchMgr::ButtonEventHandler(uint8_t button, uint8_t btnAction)
 void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
 {
     LightSwitchMgr * lightSwitch = static_cast<LightSwitchMgr *>(aEvent->LightSwitchEvent.Context);
-    switch(aEvent->Type)
+    switch (aEvent->Type)
     {
     case AppEvent::kEventType_ResetWarning:
         lightSwitch->mResetWarning = true;
@@ -332,8 +333,10 @@ void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
         if (lightSwitch->mActionButtonPressed)
         {
             lightSwitch->mActionButtonSuppressed = true;
-            lightSwitch->stepDirection = (lightSwitch->stepDirection == StepModeEnum::kUp) ? StepModeEnum::kDown : StepModeEnum::kUp;
-            ChipLogProgress(AppServer, "Step direction changed. Current Step Direction : %s", ((lightSwitch->stepDirection == StepModeEnum::kUp) ? "kUp" : "kDown"));
+            lightSwitch->stepDirection =
+                (lightSwitch->stepDirection == StepModeEnum::kUp) ? StepModeEnum::kDown : StepModeEnum::kUp;
+            ChipLogProgress(AppServer, "Step direction changed. Current Step Direction : %s",
+                            ((lightSwitch->stepDirection == StepModeEnum::kUp) ? "kUp" : "kDown"));
         }
         break;
     case AppEvent::kEventType_FunctionButtonReleased:
@@ -350,7 +353,7 @@ void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
         break;
     case AppEvent::kEventType_ActionButtonPressed:
         lightSwitch->mActionButtonPressed = true;
-        aEvent->Handler = LightSwitchMgr::SwitchActionEventHandler;
+        aEvent->Handler                   = LightSwitchMgr::SwitchActionEventHandler;
         AppTask::GetAppTask().PostEvent(aEvent);
         if (lightSwitch->mLongPressTimer)
         {
@@ -359,8 +362,10 @@ void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
         if (lightSwitch->mFunctionButtonPressed)
         {
             lightSwitch->mActionButtonSuppressed = true;
-            lightSwitch->stepDirection = (lightSwitch->stepDirection == StepModeEnum::kUp) ? StepModeEnum::kDown : StepModeEnum::kUp;
-            ChipLogProgress(AppServer, "Step direction changed. Current Step Direction : %s", ((lightSwitch->stepDirection == StepModeEnum::kUp) ? "kUp" : "kDown"));
+            lightSwitch->stepDirection =
+                (lightSwitch->stepDirection == StepModeEnum::kUp) ? StepModeEnum::kDown : StepModeEnum::kUp;
+            ChipLogProgress(AppServer, "Step direction changed. Current Step Direction : %s",
+                            ((lightSwitch->stepDirection == StepModeEnum::kUp) ? "kUp" : "kDown"));
         }
         break;
     case AppEvent::kEventType_ActionButtonReleased:
@@ -375,11 +380,11 @@ void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
         }
         else
         {
-            aEvent->Type = AppEvent::kEventType_TriggerToggle;
+            aEvent->Type    = AppEvent::kEventType_TriggerToggle;
             aEvent->Handler = LightSwitchMgr::SwitchActionEventHandler;
             AppTask::GetAppTask().PostEvent(aEvent);
         }
-        aEvent->Type = AppEvent::kEventType_ActionButtonReleased;
+        aEvent->Type    = AppEvent::kEventType_ActionButtonReleased;
         aEvent->Handler = LightSwitchMgr::SwitchActionEventHandler;
         AppTask::GetAppTask().PostEvent(aEvent);
         break;
@@ -393,7 +398,7 @@ void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
 
 void LightSwitchMgr::SwitchActionEventHandler(AppEvent * aEvent)
 {
-    switch(aEvent->Type)
+    switch (aEvent->Type)
     {
     case AppEvent::kEventType_ActionButtonPressed:
         LightSwitchMgr::GetInstance().GenericSwitchOnInitialPress();

--- a/examples/light-switch-app/silabs/src/ShellCommands.cpp
+++ b/examples/light-switch-app/silabs/src/ShellCommands.cpp
@@ -7,7 +7,7 @@
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- *
+ *'
  *        http://www.apache.org/licenses/LICENSE-2.0
  *
  *    Unless required by applicable law or agreed to in writing, software
@@ -270,13 +270,13 @@ CHIP_ERROR MoveToLevelSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevel::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->commandData = BindingCommandData::MoveToLevel{};
+    data->commandData         = BindingCommandData::MoveToLevel{};
     char * endPtr;
-    if (auto *moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
+    if (auto * moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
     {
-        moveToLevel->level = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
-        moveToLevel->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
-        moveToLevel->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        moveToLevel->level           = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
+        moveToLevel->transitionTime  = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
+        moveToLevel->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
         moveToLevel->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -293,13 +293,13 @@ CHIP_ERROR MoveSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Move::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->commandData = BindingCommandData::Move{};
+    data->commandData         = BindingCommandData::Move{};
     char * endPtr;
-    if (auto *move = std::get_if<BindingCommandData::Move>(&data->commandData))
+    if (auto * move = std::get_if<BindingCommandData::Move>(&data->commandData))
     {
-        move->moveMode = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
-        move->rate = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
-        move->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        move->moveMode        = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
+        move->rate            = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
+        move->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
         move->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
 
@@ -319,12 +319,12 @@ CHIP_ERROR StepSwitchCommandHandler(int argc, char ** argv)
     data->clusterId           = Clusters::LevelControl::Id;
     char * endPtr;
     data->commandData = BindingCommandData::Step{};
-    if (auto *step = std::get_if<BindingCommandData::Step>(&data->commandData))
+    if (auto * step = std::get_if<BindingCommandData::Step>(&data->commandData))
     {
-        step->stepMode = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
-        step->stepSize = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
-        step->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
-        step->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
+        step->stepMode        = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
+        step->stepSize        = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
+        step->transitionTime  = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
+        step->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
         step->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[4], &endPtr, 10));
     }
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -343,9 +343,9 @@ CHIP_ERROR StopSwitchCommandHandler(int argc, char ** argv)
     data->clusterId           = Clusters::LevelControl::Id;
     char * endPtr;
     data->commandData = BindingCommandData::Stop{};
-    if (auto *stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
+    if (auto * stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
     {
-        stop->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
+        stop->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
         stop->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[1], &endPtr, 10));
     }
 
@@ -363,13 +363,13 @@ CHIP_ERROR MoveToLevelWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->commandData = BindingCommandData::MoveToLevel{};
+    data->commandData         = BindingCommandData::MoveToLevel{};
     char * endPtr;
-    if (auto *moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
+    if (auto * moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
     {
-        moveToLevel->level = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
-        moveToLevel->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
-        moveToLevel->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        moveToLevel->level           = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
+        moveToLevel->transitionTime  = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
+        moveToLevel->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
         moveToLevel->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
 
@@ -387,13 +387,13 @@ CHIP_ERROR MoveWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->commandData = BindingCommandData::Move{};
+    data->commandData         = BindingCommandData::Move{};
     char * endPtr;
-    if (auto *move = std::get_if<BindingCommandData::Move>(&data->commandData))
+    if (auto * move = std::get_if<BindingCommandData::Move>(&data->commandData))
     {
-        move->moveMode = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
-        move->rate = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
-        move->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        move->moveMode        = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
+        move->rate            = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
+        move->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
         move->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
 
@@ -413,12 +413,12 @@ CHIP_ERROR StepWithOnOffSwitchCommandHandler(int argc, char ** argv)
     data->clusterId           = Clusters::LevelControl::Id;
     char * endPtr;
     data->commandData = BindingCommandData::Step{};
-    if (auto *step = std::get_if<BindingCommandData::Step>(&data->commandData))
+    if (auto * step = std::get_if<BindingCommandData::Step>(&data->commandData))
     {
-        step->stepMode = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
-        step->stepSize = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
-        step->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
-        step->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
+        step->stepMode        = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
+        step->stepSize        = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
+        step->transitionTime  = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
+        step->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
         step->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[4], &endPtr, 10));
     }
 
@@ -438,9 +438,9 @@ CHIP_ERROR StopWithOnOffSwitchCommandHandler(int argc, char ** argv)
     data->clusterId           = Clusters::LevelControl::Id;
     char * endPtr;
     data->commandData = BindingCommandData::Stop{};
-    if (auto *stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
+    if (auto * stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
     {
-        stop->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
+        stop->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
         stop->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[1], &endPtr, 10));
     }
 
@@ -666,16 +666,16 @@ CHIP_ERROR GroupsMoveToLevelSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevel::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->commandData = BindingCommandData::MoveToLevel{};
+    data->commandData         = BindingCommandData::MoveToLevel{};
     char * endPtr;
-    if (auto *moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
+    if (auto * moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
     {
-        moveToLevel->level = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
-        moveToLevel->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
-        moveToLevel->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        moveToLevel->level           = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
+        moveToLevel->transitionTime  = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
+        moveToLevel->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
         moveToLevel->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
-    data->isGroup             = true;
+    data->isGroup = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -691,16 +691,16 @@ CHIP_ERROR GroupsMoveSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::Move::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->commandData = BindingCommandData::Move{};
+    data->commandData         = BindingCommandData::Move{};
     char * endPtr;
-    if (auto *move = std::get_if<BindingCommandData::Move>(&data->commandData))
+    if (auto * move = std::get_if<BindingCommandData::Move>(&data->commandData))
     {
-        move->moveMode = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
-        move->rate = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
-        move->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        move->moveMode        = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
+        move->rate            = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
+        move->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
         move->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
-    data->isGroup             = true;
+    data->isGroup = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -718,15 +718,15 @@ CHIP_ERROR GroupsStepSwitchCommandHandler(int argc, char ** argv)
     data->clusterId           = Clusters::LevelControl::Id;
     char * endPtr;
     data->commandData = BindingCommandData::Step{};
-    if (auto *step = std::get_if<BindingCommandData::Step>(&data->commandData))
+    if (auto * step = std::get_if<BindingCommandData::Step>(&data->commandData))
     {
-        step->stepMode = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
-        step->stepSize = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
-        step->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
-        step->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
+        step->stepMode        = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
+        step->stepSize        = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
+        step->transitionTime  = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
+        step->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
         step->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[4], &endPtr, 10));
     }
-    data->isGroup             = true;
+    data->isGroup = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -744,12 +744,12 @@ CHIP_ERROR GroupsStopSwitchCommandHandler(int argc, char ** argv)
     data->clusterId           = Clusters::LevelControl::Id;
     char * endPtr;
     data->commandData = BindingCommandData::Stop{};
-    if (auto *stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
+    if (auto * stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
     {
-        stop->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
+        stop->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
         stop->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[1], &endPtr, 10));
     }
-    data->isGroup             = true;
+    data->isGroup = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -765,16 +765,16 @@ CHIP_ERROR GroupsMoveToLevelWithOnOffSwitchCommandHandler(int argc, char ** argv
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->commandData = BindingCommandData::MoveToLevel{};
+    data->commandData         = BindingCommandData::MoveToLevel{};
     char * endPtr;
-    if (auto *moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
+    if (auto * moveToLevel = std::get_if<BindingCommandData::MoveToLevel>(&data->commandData))
     {
-        moveToLevel->level = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
-        moveToLevel->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
-        moveToLevel->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        moveToLevel->level           = static_cast<uint8_t>(strtol(argv[0], &endPtr, 10));
+        moveToLevel->transitionTime  = DataModel::Nullable<uint16_t>(strtol(argv[1], &endPtr, 10));
+        moveToLevel->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
         moveToLevel->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
-    data->isGroup             = true;
+    data->isGroup = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -790,16 +790,16 @@ CHIP_ERROR GroupsMoveWithOnOffSwitchCommandHandler(int argc, char ** argv)
     BindingCommandData * data = Platform::New<BindingCommandData>();
     data->commandId           = Clusters::LevelControl::Commands::MoveWithOnOff::Id;
     data->clusterId           = Clusters::LevelControl::Id;
-    data->commandData = BindingCommandData::Move{};
+    data->commandData         = BindingCommandData::Move{};
     char * endPtr;
-    if (auto *move = std::get_if<BindingCommandData::Move>(&data->commandData))
+    if (auto * move = std::get_if<BindingCommandData::Move>(&data->commandData))
     {
-        move->moveMode = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
-        move->rate = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
-        move->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
+        move->moveMode        = static_cast<Clusters::LevelControl::MoveModeEnum>(strtol(argv[0], &endPtr, 10));
+        move->rate            = static_cast<DataModel::Nullable<uint8_t>>(strtol(argv[1], &endPtr, 10));
+        move->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[2], &endPtr, 10));
         move->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
     }
-    data->isGroup             = true;
+    data->isGroup = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -817,15 +817,15 @@ CHIP_ERROR GroupsStepWithOnOffSwitchCommandHandler(int argc, char ** argv)
     data->clusterId           = Clusters::LevelControl::Id;
     char * endPtr;
     data->commandData = BindingCommandData::Step{};
-    if (auto *step = std::get_if<BindingCommandData::Step>(&data->commandData))
+    if (auto * step = std::get_if<BindingCommandData::Step>(&data->commandData))
     {
-        step->stepMode = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
-        step->stepSize = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
-        step->transitionTime = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
-        step->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
+        step->stepMode        = static_cast<Clusters::LevelControl::StepModeEnum>(strtol(argv[0], &endPtr, 10));
+        step->stepSize        = static_cast<uint8_t>(strtol(argv[1], &endPtr, 10));
+        step->transitionTime  = DataModel::Nullable<uint16_t>(strtol(argv[2], &endPtr, 10));
+        step->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[3], &endPtr, 10));
         step->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[4], &endPtr, 10));
     }
-    data->isGroup             = true;
+    data->isGroup = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -843,12 +843,12 @@ CHIP_ERROR GroupsStopWithOnOffSwitchCommandHandler(int argc, char ** argv)
     data->clusterId           = Clusters::LevelControl::Id;
     char * endPtr;
     data->commandData = BindingCommandData::Stop{};
-    if (auto *stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
+    if (auto * stop = std::get_if<BindingCommandData::Stop>(&data->commandData))
     {
-        stop->optionsMask = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
+        stop->optionsMask     = chip::BitMask<OptionsBitmap>(strtol(argv[0], &endPtr, 10));
         stop->optionsOverride = chip::BitMask<OptionsBitmap>(strtol(argv[1], &endPtr, 10));
     }
-    data->isGroup             = true;
+    data->isGroup = true;
 
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
@@ -878,8 +878,7 @@ void RegisterSwitchCommands()
         { &LevelControlHelpHandler, "help", "Usage: switch levelcontrol <subcommand>" },
         { &MoveToLevelSwitchCommandHandler, "move-to-level",
           "Usage: switch levelcontrol move-to-level <level> <transitiontime> <optionsmask> <optionsoverride>" },
-        { &MoveSwitchCommandHandler, "move",
-          "Usage: switch levelcontrol move <movemode> <rate> <optionsmask> <optionsoverride>" },
+        { &MoveSwitchCommandHandler, "move", "Usage: switch levelcontrol move <movemode> <rate> <optionsmask> <optionsoverride>" },
         { &StepSwitchCommandHandler, "step",
           "Usage: switch levelcontrol step <stepmode> <stepsize> <transitiontime> <optionsmask> <optionsoverride>" },
         { &StopSwitchCommandHandler, "stop", "step Usage: switch levelcontrol stop <optionsmask> <optionsoverride>" },
@@ -915,7 +914,8 @@ void RegisterSwitchCommands()
           "Usage: switch groups levelcontrol step <stepmode> <stepsize> <transitiontime> <optionsmask> <optionsoverride>" },
         { &GroupsStopSwitchCommandHandler, "stop", "step Usage: switch groups levelcontrol stop <optionsmask> <optionsoverride>" },
         { &GroupsMoveToLevelWithOnOffSwitchCommandHandler, "move-to-level-with-on-off",
-          "Usage: switch groups levelcontrol move-with-to-level-with-on-off <level> <transitiontime> <optionsmask> <optionsoverride>" },
+          "Usage: switch groups levelcontrol move-with-to-level-with-on-off <level> <transitiontime> <optionsmask> "
+          "<optionsoverride>" },
         { &GroupsMoveWithOnOffSwitchCommandHandler, "move-with-on-off",
           "Usage: switch groups levelcontrol move-with-on-off <movemode> <rate> <optionsmask> <optionsoverride>" },
         { &GroupsStepWithOnOffSwitchCommandHandler, "step-with-on-off",
@@ -935,7 +935,8 @@ void RegisterSwitchCommands()
                                                     "Light-switch commands. Usage: switch <subcommand>" };
 
     sShellSwitchGroupsOnOffSubCommands.RegisterCommands(sSwitchGroupsOnOffSubCommands, ArraySize(sSwitchGroupsOnOffSubCommands));
-    sShellSwitchGroupsLevelControlSubCommands.RegisterCommands(sSwitchGroupsLevelControlSubCommands, ArraySize(sSwitchGroupsLevelControlSubCommands));
+    sShellSwitchGroupsLevelControlSubCommands.RegisterCommands(sSwitchGroupsLevelControlSubCommands,
+                                                               ArraySize(sSwitchGroupsLevelControlSubCommands));
     sShellSwitchOnOffSubCommands.RegisterCommands(sSwitchOnOffSubCommands, ArraySize(sSwitchOnOffSubCommands));
     sShellSwitchLevelControlSubCommands.RegisterCommands(sSwitchLevelControlSubCommands, ArraySize(sSwitchLevelControlSubCommands));
     sShellSwitchGroupsSubCommands.RegisterCommands(sSwitchGroupsSubCommands, ArraySize(sSwitchGroupsSubCommands));


### PR DESCRIPTION
The files in the light-switch-app were not restyled causing the restyler to fail.

Broken from the PR
https://github.com/SiliconLabsSoftware/matter_sdk/pull/227
https://github.com/SiliconLabsSoftware/matter_sdk/pull/148

Restyler fixed can be seen in the CSA PR: https://github.com/project-chip/connectedhomeip/pull/37448 
[Cherry-picked the commits for this PR]