### PR TITLE
[SL-UP] Resolve build errors for custom board

### DIFF
--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -37,7 +37,9 @@ extern "C" {
 
 #if SLI_SI91X_MCU_INTERFACE
 #include "USART.h"
+#if defined(SL_SI91X_BOARD_INIT)
 #include "rsi_board.h"
+#endif // SL_SI91X_BOARD_INIT
 #include "rsi_debug.h"
 #include "rsi_rom_egpio.h"
 #else // For EFR32

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -33,7 +33,9 @@
 // TODO add includes ?
 extern "C" {
 #include "em_core.h"
+#if defined(SL_SI91X_BOARD_INIT)
 #include "rsi_board.h"
+#endif // SL_SI91X_BOARD_INIT
 #include "sl_event_handler.h"
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
@@ -119,7 +121,9 @@ CHIP_ERROR SilabsPlatform::Init(void)
 void SilabsPlatform::InitLed(void)
 {
     // TODO
+#if defined(SL_SI91X_BOARD_INIT)
     RSI_Board_Init();
+#endif // SL_SI91X_BOARD_INIT
     SilabsPlatformAbstractionBase::InitLed();
 }
 


### PR DESCRIPTION
Description : This PR fixes the build for custom 917SOC boards

Issue : If a project is built for custom board, build errors are seen as a few board related header files are being included.

Fix : Wrapped such board specific headers with a macro.

Testing : With these changes, created a matter_extension for studio and checked the build for custom board in studio.