### PR TITLE
[SL-UP] Added a function that can empty the uart in a blocking manner for ins…

### DIFF
--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -583,6 +583,19 @@ void uartSendBytes(uint8_t * buffer, uint16_t nbOfBytes)
 #endif // SLI_SI91X_MCU_INTERFACE
 }
 
+/**
+ * @brief Flush the UART TX queue in a blocking manner.
+ */
+void uartFlushTxQueue(void)
+{
+    UartTxStruct_t workBuffer;
+
+    while (osMessageQueueGet(sUartTxQueue, &workBuffer, nullptr, 0) == osOK)
+    {
+        UARTDRV_ForceTransmit(vcom_handle, workBuffer.data, workBuffer.length);
+    }
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/examples/platform/silabs/uart.h
+++ b/examples/platform/silabs/uart.h
@@ -28,6 +28,7 @@ void uartConsoleInit(void);
 int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength);
 int16_t uartLogWrite(const char * log, uint16_t length);
 int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead);
+void uartFlushTxQueue(void);
 
 void uartMainLoop(void * args);
 


### PR DESCRIPTION
#### Testing

Tested by placing buffer flush before reboot and removing the os delays, the reboot will be delayed until the logging is done.

Was tested with Silabs Tracing for OTA as well but this will be in an SL-TEMP PR.
