### PR TITLE
[SL-ONLY] Fix build when logging is didisabled

### DIFF
--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -196,7 +196,7 @@ extern "C" void silabsLog(const char * aFormat, ...)
     va_end(v);
 }
 
-#ifdef SILABS_LOG_ENABLED
+#if SILABS_LOG_ENABLED
 bool isLogInitialized()
 {
     return sLogInitialized;


### PR DESCRIPTION
#### Testing

The build was failing when `SILABS_LOG_ENABLED` was defined to 0 

Correcting the condition to fix the build