### PR TITLE
[SL-UP] Silabs BaseApplication Init refactor

### DIFF
--- a/examples/air-quality-sensor-app/silabs/include/AppTask.h
+++ b/examples/air-quality-sensor-app/silabs/include/AppTask.h
@@ -89,11 +89,11 @@ private:
     static AppTask sAppTask;
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 
     /**
      * @brief PB0 Button event processing function

--- a/examples/air-quality-sensor-app/silabs/src/AppTask.cpp
+++ b/examples/air-quality-sensor-app/silabs/src/AppTask.cpp
@@ -68,7 +68,7 @@ using namespace chip::app::Clusters;
 
 AppTask AppTask::sAppTask;
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
@@ -77,12 +77,6 @@ CHIP_ERROR AppTask::Init()
     GetLCD().SetCustomUI(AirQualitySensorUI::DrawUI);
 #endif
 
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogDetail(AppServer, "BaseApplication::Init() failed");
-        appError(err);
-    }
     err = SensorManager::SensorMgr().Init();
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/chef/silabs/include/AppTask.h
+++ b/examples/chef/silabs/include/AppTask.h
@@ -80,11 +80,11 @@ private:
     static AppTask sAppTask;
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 
     /**
      * @brief PB0 Button event processing function

--- a/examples/chef/silabs/src/AppTask.cpp
+++ b/examples/chef/silabs/src/AppTask.cpp
@@ -58,17 +58,10 @@ using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
-
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        SILABS_LOG("BaseApplication::Init() failed");
-        appError(err);
-    }
 
     return err;
 }

--- a/examples/energy-management-app/silabs/include/AppTask.h
+++ b/examples/energy-management-app/silabs/include/AppTask.h
@@ -85,11 +85,11 @@ private:
     static void UpdateClusterState(intptr_t context);
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 
     /**
      * @brief PB0 Button event processing function

--- a/examples/energy-management-app/silabs/src/AppTask.cpp
+++ b/examples/energy-management-app/silabs/src/AppTask.cpp
@@ -163,7 +163,7 @@ void ApplicationShutdown()
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 }
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
@@ -175,13 +175,6 @@ CHIP_ERROR AppTask::Init()
     GetLCD().Init((uint8_t *) "energy-management-App (WaterHeater)");
 #endif
 #endif
-
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        SILABS_LOG("BaseApplication::Init() failed");
-        appError(err);
-    }
 
     ApplicationInit();
 

--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -70,9 +70,9 @@ private:
     static AppTask sAppTask;
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 };

--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -68,7 +68,7 @@ using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(LightSwitchMgr::ButtonEventHandler);
@@ -76,13 +76,6 @@ CHIP_ERROR AppTask::Init()
 #ifdef DISPLAY_ENABLED
     GetLCD().Init((uint8_t *) "Light Switch");
 #endif
-
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        SILABS_LOG("BaseApplication::Init() failed");
-        appError(err);
-    }
 
     err = LightSwitchMgr::GetInstance().Init(kLightSwitchEndpoint, kGenericSwitchEndpoint);
     if (err != CHIP_NO_ERROR)

--- a/examples/lighting-app/silabs/include/AppTask.h
+++ b/examples/lighting-app/silabs/include/AppTask.h
@@ -88,11 +88,11 @@ private:
     static void UpdateClusterState(intptr_t context);
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 
     /**
      * @brief PB0 Button event processing function

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -64,7 +64,7 @@ using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
@@ -74,13 +74,6 @@ CHIP_ERROR AppTask::Init()
 #ifdef DISPLAY_ENABLED
     GetLCD().Init((uint8_t *) "Lighting-App");
 #endif
-
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        SILABS_LOG("BaseApplication::Init() failed");
-        appError(err);
-    }
 
     err = LightMgr().Init();
     if (err != CHIP_NO_ERROR)

--- a/examples/lit-icd-app/silabs/include/AppTask.h
+++ b/examples/lit-icd-app/silabs/include/AppTask.h
@@ -104,11 +104,11 @@ private:
     static AppTask sAppTask;
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 
     /**
      * @brief PB0 Button event processing function

--- a/examples/lit-icd-app/silabs/src/AppTask.cpp
+++ b/examples/lit-icd-app/silabs/src/AppTask.cpp
@@ -68,7 +68,7 @@ using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
@@ -76,13 +76,6 @@ CHIP_ERROR AppTask::Init()
 #ifdef DISPLAY_ENABLED
     GetLCD().Init((uint8_t *) "LIT ICD");
 #endif
-
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        SILABS_LOG("BaseApplication::Init() failed");
-        appError(err);
-    }
 
     return err;
 }

--- a/examples/lock-app/silabs/include/AppTask.h
+++ b/examples/lock-app/silabs/include/AppTask.h
@@ -89,11 +89,11 @@ private:
     static AppTask sAppTask;
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 
     /**
      * @brief PB0 Button event processing function

--- a/examples/lock-app/silabs/src/AppTask.cpp
+++ b/examples/lock-app/silabs/src/AppTask.cpp
@@ -116,7 +116,7 @@ using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -125,13 +125,6 @@ CHIP_ERROR AppTask::Init()
 #ifdef DISPLAY_ENABLED
     GetLCD().Init((uint8_t *) "Lock-App", true);
 #endif
-
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        SILABS_LOG("BaseApplication::Init() failed");
-        appError(err);
-    }
 
 #if defined(ENABLE_CHIP_SHELL)
     err = RegisterLockEvents();

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -301,6 +301,28 @@ CHIP_ERROR BaseApplication::StartAppTask(osThreadFunc_t taskFunction)
 
 CHIP_ERROR BaseApplication::Init()
 {
+    CHIP_ERROR err = BaseInit();
+    if (err != CHIP_NO_ERROR)
+    {
+        SILABS_LOG("BaseInit() failed");
+        appError(err);
+        return err;
+    }
+
+    err = AppInit();
+    if (err != CHIP_NO_ERROR)
+    {
+        SILABS_LOG("AppInit() failed");
+        appError(err);
+        return err;
+    }
+
+    InitCompleteCallback(err);
+    return err;
+}
+
+CHIP_ERROR BaseApplication::BaseInit()
+{
     CHIP_ERROR err = CHIP_NO_ERROR;
 
 #ifdef SL_WIFI

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -178,14 +178,8 @@ public:
 
 protected:
     CHIP_ERROR Init();
-
-    /** @brief
-     * Function to be called at the end of Init to indicate that the application has completed its initialization.
-     * Currently only used for tracing, might want to move logging here as well in the future
-     * @param err CHIP_NO_ERROR on success, corresponding error code on Init failure, note that Init failure leads to an app error
-     * so this is purely to have a trace logged with the error code
-     */
-    void InitCompleteCallback(CHIP_ERROR err);
+    CHIP_ERROR BaseInit();
+    virtual CHIP_ERROR AppInit() { return CHIP_NO_ERROR; }
 
     /**
      * @brief Function called to start the function timer

--- a/examples/pump-app/silabs/include/AppTask.h
+++ b/examples/pump-app/silabs/include/AppTask.h
@@ -75,11 +75,11 @@ private:
     static void UpdateClusterState(intptr_t context);
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 
     /**
      * @brief PB0 Button event processing function

--- a/examples/pump-app/silabs/src/AppTask.cpp
+++ b/examples/pump-app/silabs/src/AppTask.cpp
@@ -71,7 +71,7 @@ using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
@@ -79,13 +79,6 @@ CHIP_ERROR AppTask::Init()
 #ifdef DISPLAY_ENABLED
     GetLCD().Init((uint8_t *) "Pump-App");
 #endif
-
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        SILABS_LOG("BaseApplication::Init() failed");
-        appError(err);
-    }
 
     err = PumpMgr().Init();
     if (err != CHIP_NO_ERROR)

--- a/examples/refrigerator-app/silabs/include/AppTask.h
+++ b/examples/refrigerator-app/silabs/include/AppTask.h
@@ -84,11 +84,11 @@ private:
     static AppTask sAppTask;
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 
     /**
      * @brief PB0 Button event processing function

--- a/examples/refrigerator-app/silabs/src/AppTask.cpp
+++ b/examples/refrigerator-app/silabs/src/AppTask.cpp
@@ -75,7 +75,7 @@ using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
@@ -84,12 +84,6 @@ CHIP_ERROR AppTask::Init()
     GetLCD().Init((uint8_t *) "Refrigrator-App");
 #endif
 
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(AppServer, "BaseApplication::Init() failed");
-        appError(err);
-    }
     err = RefrigeratorMgr().Init();
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/smoke-co-alarm-app/silabs/include/AppTask.h
+++ b/examples/smoke-co-alarm-app/silabs/include/AppTask.h
@@ -79,11 +79,11 @@ private:
     static AppTask sAppTask;
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 
     /**
      * @brief PB0 Button event processing function

--- a/examples/smoke-co-alarm-app/silabs/src/AppTask.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/AppTask.cpp
@@ -54,7 +54,7 @@ using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
@@ -62,13 +62,6 @@ CHIP_ERROR AppTask::Init()
 #ifdef DISPLAY_ENABLED
     GetLCD().Init((uint8_t *) "Smoke-CO-Alarm-App");
 #endif
-
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        SILABS_LOG("BaseApplication::Init() failed");
-        appError(err);
-    }
 
     err = AlarmMgr().Init();
     if (err != CHIP_NO_ERROR)

--- a/examples/thermostat/silabs/include/AppTask.h
+++ b/examples/thermostat/silabs/include/AppTask.h
@@ -91,11 +91,11 @@ private:
     static AppTask sAppTask;
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 
     /**
      * @brief PB0 Button event processing function

--- a/examples/thermostat/silabs/src/AppTask.cpp
+++ b/examples/thermostat/silabs/src/AppTask.cpp
@@ -73,7 +73,7 @@ using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
@@ -83,12 +83,6 @@ CHIP_ERROR AppTask::Init()
     GetLCD().SetCustomUI(ThermostatUI::DrawUI);
 #endif
 
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        SILABS_LOG("BaseApplication::Init() failed");
-        appError(err);
-    }
     err = SensorMgr().Init();
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/window-app/silabs/include/AppTask.h
+++ b/examples/window-app/silabs/include/AppTask.h
@@ -59,9 +59,9 @@ private:
     static AppTask sAppTask;
 
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 };

--- a/examples/window-app/silabs/src/AppTask.cpp
+++ b/examples/window-app/silabs/src/AppTask.cpp
@@ -45,7 +45,7 @@ using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(WindowManager::ButtonEventHandler);
@@ -53,13 +53,6 @@ CHIP_ERROR AppTask::Init()
 #ifdef DISPLAY_ENABLED
     GetLCD().Init((uint8_t *) "Window-App");
 #endif
-
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        SILABS_LOG("BaseApplication::Init() failed");
-        appError(err);
-    }
 
     err = WindowManager::sWindow.Init();
 

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -92,8 +92,6 @@ SilabsPlatform::SilabsButtonCb SilabsPlatform::mButtonCallback = nullptr;
 
 CHIP_ERROR SilabsPlatform::Init(void)
 {
-    mButtonCallback = nullptr;
-
     // TODO: Setting the highest priority for SVCall_IRQn to avoid the HardFault issue
     NVIC_SetPriority(SVCall_IRQn, CORE_INTERRUPT_HIGHEST_PRIORITY);
 


### PR DESCRIPTION
Refactor of BaseApplication Init to reduce the amount of duplicated code across examples

#### Testing

Build and run apps:
CMP -> Series 3
Lighting Series 3 and 2
Lock -> Wifi

The CI will have to do some of the lifting for the other builds.