### PR TITLE
[CSA-CP] temporary workaround: keeping pygobject==3.50.0 to avoid dependency i…

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -394,7 +394,7 @@ chip_python_wheel_action("chip-repl") {
   } else if (current_os == "linux") {
     py_package_reqs += [
       "dbus-python==1.2.18",
-      "pygobject",
+      "pygobject==3.50.0",
     ]
   }
 


### PR DESCRIPTION
…ssues (#37948)

Update of the pygobject dependencies broke the CSA CI for python builds. This forces a specific version to fix the issue until we update to the latest version.