### PR TITLE
[CSA-CP] Fix Null Pointer Dereference in TCP Packet Handling

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -343,7 +343,15 @@ CHIP_ERROR TCPBase::ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const Pe
             // We have not yet received the complete message.
             return CHIP_NO_ERROR;
         }
+
         state->mReceived.Consume(kPacketSizeBytes);
+
+        if (messageSize == 0)
+        {
+            // No payload but considered a valid message. Return success to keep the connection alive.
+            return CHIP_NO_ERROR;
+        }
+
         ReturnErrorOnFailure(ProcessSingleMessage(peerAddress, state, messageSize));
     }
 

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -64,7 +64,8 @@ constexpr NodeId kSourceNodeId      = 123654;
 constexpr NodeId kDestinationNodeId = 111222333;
 constexpr uint32_t kMessageCounter  = 18;
 
-const char PAYLOAD[] = "Hello!";
+const char PAYLOAD[]          = "Hello!";
+const char messageSize_TEST[] = "\x00\x00\x00\x00";
 
 class MockTransportMgrDelegate : public chip::TransportMgrDelegate
 {
@@ -632,6 +633,12 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
     CHIP_ERROR err = CHIP_NO_ERROR;
     TestData testData[2];
     gMockTransportMgrDelegate.SetCallback(TestDataCallbackCheck, testData);
+
+    // Test a single packet buffer with zero message size.
+    System::PacketBufferHandle buf = System::PacketBufferHandle::NewWithData(messageSize_TEST, 4);
+    ASSERT_NE(&buf, nullptr);
+    err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Test a single packet buffer.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;


### PR DESCRIPTION
* Fix Null Pointer Dereference in TCP Packet Handling

* Fix handle zero messageSize in TCP packet processing

* Add test for TCP MessageSize

* Modify test

* Restyled by clang-format

* Modify the position of an if statement

* Modify test


#### Testing
No specific test done on my end.
CI validate everything builds. This has been on main for a while now.
