### PR TITLE
[CSA-CP]  Added 917 NCP wakeup source config

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -134,7 +134,8 @@ const sl_wifi_device_configuration_t config = {
 #ifdef SLI_SI91X_MCU_INTERFACE
                          (SL_SI91X_FEAT_SECURITY_OPEN | SL_SI91X_FEAT_WPS_DISABLE),
 #else
-                         (SL_SI91X_FEAT_SECURITY_OPEN | SL_SI91X_FEAT_AGGREGATION),
+                         (SL_SI91X_FEAT_SECURITY_OPEN | SL_SI91X_FEAT_AGGREGATION | SL_SI91X_FEAT_ULP_GPIO_BASED_HANDSHAKE |
+                          SL_SI91X_FEAT_DEV_TO_HOST_ULP_GPIO_1),
 #endif
                      .tcp_ip_feature_bit_map = (SL_SI91X_TCP_IP_FEAT_DHCPV4_CLIENT | SL_SI91X_TCP_IP_FEAT_DNS_CLIENT |
                                                 SL_SI91X_TCP_IP_FEAT_SSL | SL_SI91X_TCP_IP_FEAT_BYPASS


### PR DESCRIPTION
**Cherry Pick of** https://github.com/project-chip/connectedhomeip/pull/38011
#### Description 
Added GPIO_BASED_HANDSHAKE Wifi configurations for 917 NCP. This bit is enables GPIO-based handshake for low power mode and here ULP GPIO 1 is for wake-up indication. If this bit is not enabled before wifi connection , then sl_si91x_req_wakeup  will be failed in SPI re-initialization whenever host tries to wakeup 917 NCP module for Tx/Rx events.

#### Testing

Tested sleepy app commissioning on 917 NCP and commands
