### PR TITLE
[CSA-CP] Update docker image to latest sisdk and wifi sdk

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-81 : [Telink] Update Docker image (Zephyr update)
+114 : [Silabs] Update Silabs sisdk to v2024.12.1-0, Wiseconnect to 2.11.2 and wifisdk to 3.4.1

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -12,9 +12,8 @@ RUN set -x \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line
 
-
-# Download Simplicity SDK v2024.6.1 (a1a37fa)
-RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2024.6.1-0/sisdk-sdk.zip -O /tmp/simplicity_sdk.zip \
+# Download Simplicity SDK v2024.12.1-0 (da66128)
+RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2024.12.1-0/simplicity-sdk.zip -O /tmp/simplicity_sdk.zip \
     && unzip /tmp/simplicity_sdk.zip -d /tmp/simplicity_sdk \
     && rm -rf /tmp/simplicity_sdk.zip \
     # Deleting files that are not needed to save space
@@ -23,14 +22,14 @@ RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2024.6
     && find /tmp/simplicity_sdk/protocol/openthread -name "*efr32mg21*" -delete \
     && : # last line
 
-# Clone WiSeConnect Wi-Fi and Bluetooth Software 2.10.0 (f94b83d)
-RUN git clone --depth=1 --single-branch --branch=2.10.0 https://github.com/SiliconLabs/wiseconnect-wifi-bt-sdk.git /tmp/wiseconnect-wifi-bt-sdk && \
+# Clone WiSeConnect Wi-Fi and Bluetooth Software 2.11.2 (3dbc243)
+RUN git clone --depth=1 --single-branch --branch=2.11.2 https://github.com/SiliconLabs/wiseconnect-wifi-bt-sdk.git /tmp/wiseconnect-wifi-bt-sdk && \
     cd /tmp/wiseconnect-wifi-bt-sdk && \
     rm -rf .git \
     && : # last line
 
-# Clone WiSeConnect SDK v3.3.2 (b5d6422)
-RUN git clone --depth=1 --single-branch --branch=v3.3.2 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
+# Clone WiSeConnect SDK v3.4.1 (f675628)
+RUN git clone --depth=1 --single-branch --branch=v3.4.1 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
     cd /tmp/wifi_sdk && \
     rm -rf .git \
     && : # last line


### PR DESCRIPTION
#### Testing

Updating the silabs docker SDK versions

Simplicity SDK -> v2024.12.1-0
Wifi SDK -> v3.4.1
Wiseconnect-wifi-bt-sdk -> v2.11.2


CSA PR: https://github.com/project-chip/connectedhomeip/pull/37651