### PR TITLE
[SL-UP] Button handling in dimmer-switch app

### DIFF
--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -57,6 +57,29 @@ public:
 
     static AppTask & GetAppTask() { return sAppTask; }
 
+    struct Timer
+    {
+        typedef void (*Callback)(Timer & timer);
+
+        Timer(uint32_t timeoutInMs, Callback callback, void * context);
+        ~Timer();
+
+        void Start();
+        void Stop();
+        void Timeout();
+
+        Callback mCallback = nullptr;
+        void * mContext    = nullptr;
+        bool mIsActive     = false;
+
+        osTimerId_t mHandler = nullptr;
+
+    private:
+        static void TimerCallback(void * timerCbArg);
+    };
+
+    Timer * longPressTimer      = nullptr;
+
     /**
      * @brief AppTask task main loop function
      *
@@ -65,6 +88,19 @@ public:
     static void AppTaskMain(void * pvParameter);
 
     CHIP_ERROR StartAppTask();
+    /**
+     * @brief Event handler when a button is pressed
+     * Function posts an event for button processing
+     *
+     * @param buttonHandle BTN0 or BTN1
+     * @param btnAction button action - SL_SIMPLE_BUTTON_PRESSED,
+     *                  SL_SIMPLE_BUTTON_RELEASED or SL_SIMPLE_BUTTON_DISABLED
+     */
+    static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
+
+    AppEvent CreateNewEvent(AppEvent::AppEventTypes type);
+
+    static void AppEventHandler(AppEvent * aEvent);
 
 private:
     static AppTask sAppTask;
@@ -75,4 +111,20 @@ private:
      * @return CHIP_ERROR
      */
     CHIP_ERROR Init();
+
+    /**
+     * @brief PB1 Button event processing function
+     *        Function triggers a switch action sent to the CHIP task
+     *
+     * @param aEvent button event being processed
+     */
+    static void SwitchActionEventHandler(AppEvent * aEvent);
+
+    static void OnLongPressTimeout(Timer & timer);
+
+    /**
+     * @brief This function will be called when PB1 is
+     *        long-pressed to trigger the level-control action
+     */
+    void HandleLongPress();
 };

--- a/examples/light-switch-app/silabs/include/LightSwitchMgr.h
+++ b/examples/light-switch-app/silabs/include/LightSwitchMgr.h
@@ -52,78 +52,10 @@ public:
         .stepSize = 1, .transitionTime = 0, .optionsMask = 0, .optionsOverride = 0
     };
 
-    struct Timer
-    {
-        typedef void (*Callback)(Timer & timer);
-
-        Timer(uint32_t timeoutInMs, Callback callback, void * context);
-        ~Timer();
-
-        void Start();
-        void Stop();
-        void Timeout();
-
-        Callback mCallback = nullptr;
-        void * mContext    = nullptr;
-        bool mIsActive     = false;
-
-        osTimerId_t mHandler = nullptr;
-
-    private:
-        static void TimerCallback(void * timerCbArg);
-    };
-
     CHIP_ERROR Init(chip::EndpointId lightSwitchEndpoint, chip::EndpointId genericSwitchEndpoint);
 
     void GenericSwitchOnInitialPress();
     void GenericSwitchOnShortRelease();
-
-    void TriggerLightSwitchAction(LightSwitchAction action, bool isGroupCommand = false);
-    void TriggerLevelControlAction(StepModeEnum stepMode, bool isGroupCommand = false);
-
-    StepModeEnum getStepMode();
-
-    AppEvent CreateNewEvent(AppEvent::AppEventTypes type);
-
-    static LightSwitchMgr & GetInstance() { return sSwitch; }
-
-    /**
-     * @brief Event handler when a button is pressed
-     * Function posts an event for button processing
-     *
-     * @param button BUTTON0 or BUTTON1
-     * @param btnAction button action - SL_SIMPLE_BUTTON_PRESSED,
-     *                  SL_SIMPLE_BUTTON_RELEASED
-     */
-    static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
-
-    static void AppEventHandler(AppEvent * aEvent);
-
-private:
-    static LightSwitchMgr sSwitch;
-
-    Timer * mLongPressTimer      = nullptr;
-    bool mFunctionButtonPressed  = false; // True when button0 is pressed, used to trigger factory reset
-    bool mActionButtonPressed    = false; // True when button1 is pressed, used to initiate toggle or level-up/down
-    bool mActionButtonSuppressed = false; // True when both button0 and button1 are pressed, used to switch step direction
-    bool mResetWarning           = false;
-
-    // Default Step direction for Level control
-    StepModeEnum stepDirection = StepModeEnum::kUp;
-
-    static void OnLongPressTimeout(Timer & timer);
-    LightSwitchMgr() = default;
-
-    /**
-     * @brief This function will be called when PB0 is
-     *        long-pressed to trigger the factory-reset
-     */
-    void HandleLongPress();
-
-    static void GenericSwitchWorkerFunction(intptr_t context);
-
-    chip::EndpointId mLightSwitchEndpoint   = chip::kInvalidEndpointId;
-    chip::EndpointId mGenericSwitchEndpoint = chip::kInvalidEndpointId;
 
     /**
      * @brief Button event processing function
@@ -132,4 +64,25 @@ private:
      * @param aEvent button event being processed
      */
     static void SwitchActionEventHandler(AppEvent * aEvent);
+
+    void TriggerLightSwitchAction(LightSwitchAction action, bool isGroupCommand = false);
+    void TriggerLevelControlAction(StepModeEnum stepMode, bool isGroupCommand = false);
+
+    StepModeEnum getStepMode();
+    void changeStepMode();
+
+    static LightSwitchMgr & GetInstance() { return sSwitch; }
+
+private:
+    static LightSwitchMgr sSwitch;
+
+    // Default Step direction for Level control
+    StepModeEnum stepDirection = StepModeEnum::kUp;
+    LightSwitchMgr() = default;
+
+    static void GenericSwitchWorkerFunction(intptr_t context);
+
+    chip::EndpointId mLightSwitchEndpoint   = chip::kInvalidEndpointId;
+    chip::EndpointId mGenericSwitchEndpoint = chip::kInvalidEndpointId;
+
 };

--- a/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
+++ b/examples/light-switch-app/silabs/src/LightSwitchMgr.cpp
@@ -43,113 +43,6 @@ using namespace chip::DeviceLayer::Silabs;
 
 LightSwitchMgr LightSwitchMgr::sSwitch;
 
-AppEvent LightSwitchMgr::CreateNewEvent(AppEvent::AppEventTypes type)
-{
-    AppEvent aEvent;
-    aEvent.Type                     = type;
-    aEvent.Handler                  = LightSwitchMgr::AppEventHandler;
-    LightSwitchMgr * lightSwitch    = &LightSwitchMgr::GetInstance();
-    aEvent.LightSwitchEvent.Context = lightSwitch;
-    return aEvent;
-}
-
-void LightSwitchMgr::Timer::Start()
-{
-    // Starts or restarts the function timer
-    if (osTimerStart(mHandler, pdMS_TO_TICKS(LONG_PRESS_TIMEOUT)) != osOK)
-    {
-        SILABS_LOG("Timer start() failed");
-        appError(CHIP_ERROR_INTERNAL);
-    }
-
-    mIsActive = true;
-}
-
-void LightSwitchMgr::Timer::Timeout()
-{
-    mIsActive = false;
-    if (mCallback)
-    {
-        mCallback(*this);
-    }
-}
-
-void LightSwitchMgr::HandleLongPress()
-{
-    AppEvent event;
-    event.Handler                  = AppEventHandler;
-    LightSwitchMgr * lightSwitch   = &LightSwitchMgr::GetInstance();
-    event.LightSwitchEvent.Context = lightSwitch;
-    if (mFunctionButtonPressed)
-    {
-        if (!mResetWarning)
-        {
-            // Long press button down: Reset warning!
-            event.Type = AppEvent::kEventType_ResetWarning;
-            AppTask::GetAppTask().PostEvent(&event);
-        }
-    }
-    else if (mActionButtonPressed)
-    {
-        mActionButtonSuppressed = true;
-        // Long press button up : Trigger Level Control Action
-        event.Type = AppEvent::kEventType_TriggerLevelControlAction;
-        AppTask::GetAppTask().PostEvent(&event);
-    }
-}
-
-void LightSwitchMgr::OnLongPressTimeout(LightSwitchMgr::Timer & timer)
-{
-    LightSwitchMgr * app = static_cast<LightSwitchMgr *>(timer.mContext);
-    if (app)
-    {
-        app->HandleLongPress();
-    }
-}
-
-LightSwitchMgr::Timer::Timer(uint32_t timeoutInMs, Callback callback, void * context) : mCallback(callback), mContext(context)
-{
-    mHandler = osTimerNew(TimerCallback, // timer callback handler
-                          osTimerOnce,   // no timer reload (one-shot timer)
-                          this,          // pass the app task obj context
-                          NULL           // No osTimerAttr_t to provide.
-    );
-
-    if (mHandler == NULL)
-    {
-        SILABS_LOG("Timer create failed");
-        appError(CHIP_ERROR_INTERNAL);
-    }
-}
-
-LightSwitchMgr::Timer::~Timer()
-{
-    if (mHandler)
-    {
-        osTimerDelete(mHandler);
-        mHandler = nullptr;
-    }
-}
-
-void LightSwitchMgr::Timer::Stop()
-{
-    mIsActive = false;
-    if (osTimerStop(mHandler) == osError)
-    {
-        SILABS_LOG("Timer stop() failed");
-        appError(CHIP_ERROR_INTERNAL);
-    }
-}
-
-void LightSwitchMgr::Timer::TimerCallback(void * timerCbArg)
-{
-    Timer * timer = reinterpret_cast<Timer *>(timerCbArg);
-    if (timer)
-    {
-        timer->Timeout();
-    }
-}
-
 /**
  * @brief Configures LightSwitchMgr
  *        This function needs to be call before using the LightSwitchMgr
@@ -164,8 +57,6 @@ CHIP_ERROR LightSwitchMgr::Init(EndpointId lightSwitchEndpoint, chip::EndpointId
 
     mLightSwitchEndpoint   = lightSwitchEndpoint;
     mGenericSwitchEndpoint = genericSwitchEndpoint;
-
-    mLongPressTimer = new Timer(LONG_PRESS_TIMEOUT, OnLongPressTimeout, this);
 
     // Configure Bindings
     CHIP_ERROR error = InitBindingHandler();
@@ -213,8 +104,14 @@ StepModeEnum LightSwitchMgr::getStepMode()
     return stepDirection;
 }
 
+void LightSwitchMgr::changeStepMode()
+{
+    stepDirection = (stepDirection==StepModeEnum::kUp) ? StepModeEnum::kDown : StepModeEnum::kUp;
+}
+
 void LightSwitchMgr::TriggerLightSwitchAction(LightSwitchAction action, bool isGroupCommand)
 {
+    ChipLogProgress(AppServer, "1");
     BindingCommandData * data = Platform::New<BindingCommandData>();
 
     data->clusterId = chip::app::Clusters::OnOff::Id;
@@ -246,6 +143,7 @@ void LightSwitchMgr::TriggerLightSwitchAction(LightSwitchAction action, bool isG
 
 void LightSwitchMgr::TriggerLevelControlAction(LevelControl::StepModeEnum stepMode, bool isGroupCommand)
 {
+    ChipLogProgress(AppServer, "2");
     BindingCommandData * data = Platform::New<BindingCommandData>();
 
     data->clusterId = chip::app::Clusters::LevelControl::Id;
@@ -295,109 +193,9 @@ void LightSwitchMgr::GenericSwitchWorkerFunction(intptr_t context)
     Platform::Delete(data);
 }
 
-void LightSwitchMgr::ButtonEventHandler(uint8_t button, uint8_t btnAction)
-{
-    AppEvent event = {};
-    if (btnAction == to_underlying(SilabsPlatform::ButtonAction::ButtonPressed))
-    {
-        event = LightSwitchMgr::GetInstance().CreateNewEvent(button ? AppEvent::kEventType_ActionButtonPressed
-                                                                    : AppEvent::kEventType_FunctionButtonPressed);
-    }
-    else
-    {
-        event = LightSwitchMgr::GetInstance().CreateNewEvent(button ? AppEvent::kEventType_ActionButtonReleased
-                                                                    : AppEvent::kEventType_FunctionButtonReleased);
-    }
-    AppTask::GetAppTask().PostEvent(&event);
-}
-
-void LightSwitchMgr::AppEventHandler(AppEvent * aEvent)
-{
-    LightSwitchMgr * lightSwitch = static_cast<LightSwitchMgr *>(aEvent->LightSwitchEvent.Context);
-    switch (aEvent->Type)
-    {
-    case AppEvent::kEventType_ResetWarning:
-        lightSwitch->mResetWarning = true;
-        AppTask::GetAppTask().StartFactoryResetSequence();
-        break;
-    case AppEvent::kEventType_ResetCanceled:
-        lightSwitch->mResetWarning = false;
-        AppTask::GetAppTask().CancelFactoryResetSequence();
-        break;
-    case AppEvent::kEventType_FunctionButtonPressed:
-        lightSwitch->mFunctionButtonPressed = true;
-        if (lightSwitch->mLongPressTimer)
-        {
-            lightSwitch->mLongPressTimer->Start();
-        }
-        if (lightSwitch->mActionButtonPressed)
-        {
-            lightSwitch->mActionButtonSuppressed = true;
-            lightSwitch->stepDirection =
-                (lightSwitch->stepDirection == StepModeEnum::kUp) ? StepModeEnum::kDown : StepModeEnum::kUp;
-            ChipLogProgress(AppServer, "Step direction changed. Current Step Direction : %s",
-                            ((lightSwitch->stepDirection == StepModeEnum::kUp) ? "kUp" : "kDown"));
-        }
-        break;
-    case AppEvent::kEventType_FunctionButtonReleased:
-        lightSwitch->mFunctionButtonPressed = false;
-        if (lightSwitch->mLongPressTimer)
-        {
-            lightSwitch->mLongPressTimer->Stop();
-        }
-        if (lightSwitch->mResetWarning)
-        {
-            aEvent->Type = AppEvent::kEventType_ResetCanceled;
-            AppTask::GetAppTask().PostEvent(aEvent);
-        }
-        break;
-    case AppEvent::kEventType_ActionButtonPressed:
-        lightSwitch->mActionButtonPressed = true;
-        aEvent->Handler                   = LightSwitchMgr::SwitchActionEventHandler;
-        AppTask::GetAppTask().PostEvent(aEvent);
-        if (lightSwitch->mLongPressTimer)
-        {
-            lightSwitch->mLongPressTimer->Start();
-        }
-        if (lightSwitch->mFunctionButtonPressed)
-        {
-            lightSwitch->mActionButtonSuppressed = true;
-            lightSwitch->stepDirection =
-                (lightSwitch->stepDirection == StepModeEnum::kUp) ? StepModeEnum::kDown : StepModeEnum::kUp;
-            ChipLogProgress(AppServer, "Step direction changed. Current Step Direction : %s",
-                            ((lightSwitch->stepDirection == StepModeEnum::kUp) ? "kUp" : "kDown"));
-        }
-        break;
-    case AppEvent::kEventType_ActionButtonReleased:
-        lightSwitch->mActionButtonPressed = false;
-        if (lightSwitch->mLongPressTimer)
-        {
-            lightSwitch->mLongPressTimer->Stop();
-        }
-        if (lightSwitch->mActionButtonSuppressed)
-        {
-            lightSwitch->mActionButtonSuppressed = false;
-        }
-        else
-        {
-            aEvent->Type    = AppEvent::kEventType_TriggerToggle;
-            aEvent->Handler = LightSwitchMgr::SwitchActionEventHandler;
-            AppTask::GetAppTask().PostEvent(aEvent);
-        }
-        aEvent->Type    = AppEvent::kEventType_ActionButtonReleased;
-        aEvent->Handler = LightSwitchMgr::SwitchActionEventHandler;
-        AppTask::GetAppTask().PostEvent(aEvent);
-        break;
-    case AppEvent::kEventType_TriggerLevelControlAction:
-        aEvent->Handler = LightSwitchMgr::SwitchActionEventHandler;
-        AppTask::GetAppTask().PostEvent(aEvent);
-    default:
-        break;
-    }
-}
-
 void LightSwitchMgr::SwitchActionEventHandler(AppEvent * aEvent)
 {
+    ChipLogProgress(AppServer, "0");
     switch (aEvent->Type)
     {
     case AppEvent::kEventType_ActionButtonPressed:


### PR DESCRIPTION
#### Description

Issue : [MATTER-4819](https://jira.silabs.com/browse/MATTER-4819)

This PR fixes the button handling issues seen in light-switch application. When the light-switch app has been extended as dimmer-switch app by adding level control cluster, the button functionality was changed. Button0 handling was moved from baseApplication to LightSwitchMgr. Due to this, a few features on Button0 short-press are missed.
In this PR, moved the button handling from LightSwitchMgr to AppTask (similar to all the apps) and added the logic to invoke BaseApplication::ButtonHandler on Buton0 short press.

#### Testing

Tested the button events manually on 917SOC board.
