### PR TITLE
[SL-TEMP] Fix commissioning with test credentials

### DIFF
--- a/examples/platform/silabs/provision/BUILD.gn
+++ b/examples/platform/silabs/provision/BUILD.gn
@@ -25,6 +25,9 @@ if (wifi_soc) {
 # Seperate import since the matter_support_root is defined in the ef32_sdk.gni / SiWx917_sdk.gni
 import("${matter_support_root}/provision/args.gni")
 source_set("storage") {
+  # SL-TEMP: CHIP_DEVICE_CONFIG_ENABLE_EXAMPLE_CREDENTIALS  is required for credentials fallback in ProvisionStorageXXX.
+  # The define is replaced by SL_MATTER_ENABLE_EXAMPLE_CREDENTIALS in matter 1.5.
+  defines = [ "CHIP_DEVICE_CONFIG_ENABLE_EXAMPLE_CREDENTIALS=1" ]
   sources = [ "ProvisionStorageCustom.cpp" ]
 
   if (use_provision_flash_storage) {


### PR DESCRIPTION
### Problem
Devices fail to commission when not provisioned when build with GN
`CHIP_DEVICE_CONFIG_ENABLE_EXAMPLE_CREDENTIALS` was replaced by `SL_MATTER_ENABLE_EXAMPLE_CREDENTIALS` with new matter_support structure within the gn build config. However within matter 1.4 ProvisionStorageDefault.cpp and ProvisionStorageFlash.cpp the #ifdef to enable de example fallback have not being changed. Additionally Matter_Extension 2.5-1.4 and 2.6-1.4 still define `CHIP_DEVICE_CONFIG_ENABLE_EXAMPLE_CREDENTIALS`

### Solution
To minimize the change and upgrade rules with in matter 1.4 release, Re-add CHIP_DEVICE_CONFIG_ENABLE_EXAMPLE_CREDENTIALS in GN build for the provisionStorageXXX sources.

SL_MATTER_ENABLE_EXAMPLE_CREDENTIALS is already present in matter 1.5 and 1 single upgrade rule can be done for matter extension 2.7.0-1.5


#### Testing
Successfully commission BRD4187C without provisioning with fix in place
