### PR TITLE
[SL-TEMP] Fixed length comparision while returning the details of current network

### DIFF
--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -330,7 +330,7 @@ CHIP_ERROR GetConnectedNetwork(Network & network)
     VerifyOrReturnError(wfx_is_sta_connected(), CHIP_ERROR_NOT_CONNECTED);
     network.connected = true;
     uint8_t length    = strnlen(wifiConfig.ssid, DeviceLayer::Internal::kMaxWiFiSSIDLength);
-    VerifyOrReturnError(length < sizeof(network.networkID), CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(length <= sizeof(network.networkID), CHIP_ERROR_BUFFER_TOO_SMALL);
     memcpy(network.networkID, wifiConfig.ssid, length);
     network.networkIDLen = length;
 


### PR DESCRIPTION
#### Description

Fixes [MATTER-4789](https://jira.silabs.com/browse/MATTER-4789)

Issue : When the length of connected SSID is 32, observing NetworkID as False during read network. While returning the connected network details, error is being returned if the length of SSID is <32, but it should be <=32 since the maximum allowed length of SSID is 32. Added this small fix in length comparision.

#### Testing

Tested locally by commissioning to a network with SSID of length 32, the read networks command is successful.