### PR TITLE
[CSA-CP]Fix GFW image build with ProvisionStorageFlash option

### DIFF
--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -29,7 +29,7 @@
 #include <platform/silabs/multi-ota/OtaTlvEncryptionKey.h>
 #endif // OTA_ENCRYPTION_ENABLE
 
-#if !SL_MATTER_GN_BUILD
+#if !(SL_MATTER_GN_BUILD || defined(SL_PROVISION_GENERATOR))
 #include <sl_matter_provision_config.h>
 #endif
 


### PR DESCRIPTION
#### Problem
GN-built apps and the external project Provision Generator app do not generate thesl_matter_provision_config.hheader

Solution
Add compilation directive condition so the Provision Generator app builds with ProvisionStorageFlash.cpp option as it does with ProvisionStorage Default.cpp

#### Testing
No change for standard apps Validated build and commissioning.
