### PR TITLE
[CSA-CP] Fixed RS9116 sleep issue

### DIFF
--- a/src/platform/silabs/wifi/rs911x/rsi_wlan_config.h
+++ b/src/platform/silabs/wifi/rs911x/rsi_wlan_config.h
@@ -38,30 +38,22 @@
 //! opermode command paramaters
 /*=======================================================================*/
 //! To set wlan feature select bit map
-#define RSI_FEATURE_BIT_MAP (FEAT_SECURITY_OPEN)
+#define RSI_FEATURE_BIT_MAP (FEAT_SECURITY_OPEN | FEAT_SECURITY_PSK | FEAT_AGGREGATION | FEAT_ULP_GPIO_BASED_HANDSHAKE)
 
 //! TCP IP BYPASS feature check
 #define RSI_TCP_IP_BYPASS RSI_ENABLE
-#define RSI_TCP_IP_FEATURE_BIT_MAP (TCP_IP_FEAT_BYPASS /*| TCP_IP_FEAT_EXTENSION_VALID*/)
+#define RSI_TCP_IP_FEATURE_BIT_MAP (TCP_IP_FEAT_BYPASS | TCP_IP_FEAT_EXTENSION_VALID)
 
 //! To set Extended custom feature select bit map
 #if WIFI_ENABLE_SECURITY_WPA3_TRANSITION
-#ifdef CHIP_9117
-#define RSI_EXT_CUSTOM_FEATURE_BIT_MAP                                                                                             \
-    (EXT_FEAT_448K_M4SS_256K | EXT_FEAT_LOW_POWER_MODE | EXT_FEAT_XTAL_CLK_ENABLE | EXT_FEAT_IEEE_80211W)
-#else /* !CHIP_9117 */
 #define RSI_EXT_CUSTOM_FEATURE_BIT_MAP (EXT_FEAT_384K_MODE | EXT_FEAT_IEEE_80211W)
-#endif /* CHIP_9117 */
-#else  /* !WIFI_ENABLE_SECURITY_WPA3_TRANSITION */
-#ifdef CHIP_9117
-#define RSI_EXT_CUSTOM_FEATURE_BIT_MAP (EXT_FEAT_448K_M4SS_256K | EXT_FEAT_LOW_POWER_MODE | EXT_FEAT_XTAL_CLK_ENABLE)
-#else /* !CHIP_9117 */
+#else
 #define RSI_EXT_CUSTOM_FEATURE_BIT_MAP EXT_FEAT_384K_MODE
-#endif /* CHIP_9117 */
-#endif /* WIFI_ENABLE_SECURITY_WPA3_TRANSITION */
+#endif // WIFI_ENABLE_SECURITY_WPA3_TRANSITION
 
 //! To set Extended TCPIP feature select bit map
-#define RSI_EXT_TCPIP_FEATURE_BITMAP (/*EXT_FEAT_HTTP_OTAF_SUPPORT |*/ EXT_TCP_IP_SSL_16K_RECORD)
+#define RSI_EXT_TCPIP_FEATURE_BITMAP (EXT_TCP_IP_SSL_16K_RECORD | CONFIG_FEAT_EXTENTION_VALID)
+#define RSI_CONFIG_FEATURE_BITMAP RSI_FEAT_SLEEP_GPIO_SEL_BITMAP
 //! Extended custom feature is selected internally
 //! CCP         -- EXT_FEAT_256K_MODE
 //! Wiseconnect -- EXT_FEAT_384K_MODE

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -70,7 +70,7 @@ declare_args() {
 }
 
 # TODO - This needs to be removed once multiplexing issues resolved
-if (use_SiWx917) {
+if (use_SiWx917 || use_rs9116) {
   disable_lcd = true
   show_qr_code = false
   use_external_flash = false


### PR DESCRIPTION
#### Description
RS9116 sleep/wakeups are not working due to incorrect configurations of RSI_TCP_IP_FEATURE_BIT_MAP and RSI_FEATURE_BIT_MAP. Added rs9116 configurations in rsi_wlan_config.h

#### Testing
Validated commissioning and commands on EFR + RS9116 board.
Verified power cycle and factory reset.


CSA PR: https://github.com/project-chip/connectedhomeip/pull/38078