### PR TITLE
[SL-ONLY] Refactor Selective Listening vendor exception handling

### DIFF
--- a/examples/lock-app/silabs/build_for_wifi_args.gni
+++ b/examples/lock-app/silabs/build_for_wifi_args.gni
@@ -32,3 +32,5 @@ sl_use_subscription_syncing = true
 sl_idle_mode_duration_s = 600  # 10min Idle Mode Duration
 sl_active_mode_duration_ms = 10000  # 10s Active Mode Duration
 sl_active_mode_threshold_ms = 1000  # 1s Active Mode Threshold
+
+sl_transport_idle_interval_ms = 3000  # 3s Transport Idle Interval

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
@@ -104,7 +104,7 @@ bool ApplicationSleepManager::CanGoToLIBasedSleep()
             if (!mSubscriptionsInfoProvider->FabricHasAtLeastOneActiveSubscription(it->GetFabricIndex()))
             {
                 ChipLogProgress(AppServer, "Fabric index %u has no active subscriptions", it->GetFabricIndex());
-                canGoToLIBasedSleep = ProcessSpecialVendorIDCase(it->GetVendorId());
+                canGoToLIBasedSleep = ProcessVendorIdExceptions(it->GetVendorId());
 
                 if (canGoToLIBasedSleep)
                 {
@@ -124,7 +124,7 @@ bool ApplicationSleepManager::CanGoToLIBasedSleep()
     return canGoToLIBasedSleep;
 }
 
-bool ApplicationSleepManager::ProcessSpecialVendorIDCase(chip::VendorId vendorId)
+bool ApplicationSleepManager::ProcessVendorIdExceptions(chip::VendorId vendorId)
 {
     // Add new handlers here for them to be processed by the factory
     using Factory = VendorHandlerFactory<AppleKeychainHandler>;

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.h
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.h
@@ -157,22 +157,6 @@ private:
      */
     bool ProcessVendorIdExceptions(chip::VendorId vendorId);
 
-    /**
-     * @brief Processes the Apple Keychain edge case.
-     *
-     * Apple, when commissioning, adds two fabric to the device. One for Apple Home and one for the Appley Keychain.
-     * Apple Home is the active fabric which is used to communication with the device. The associated fabric also has the active
-     * subcription. Applye Keychain fabric acts as a safety and doesn't have an active fabric with the device. As such, we need an
-     * alternate method to check if the device can go to LI based sleep.
-     *
-     * This method checks if there is any fabric with the Apple Home vendor ID that
-     * has at least one active subscription. If such a fabric is found, it allows
-     * the device to go to LI based sleep.
-     *
-     * @return true if the Apple Keychain edge case allows low-power mode, false otherwise.
-     */
-    bool ProcessKeychainEdgeCase();
-
     static ApplicationSleepManager mInstance;
     chip::FabricTable * mFabricTable                                  = nullptr;
     chip::app::SubscriptionsInfoProvider * mSubscriptionsInfoProvider = nullptr;

--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.h
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.h
@@ -155,7 +155,7 @@ private:
      * @param vendorId The vendor ID to check for special cases.
      * @return true if the vendor ID has a special case that allows LI based sleep, false otherwise.
      */
-    bool ProcessSpecialVendorIDCase(chip::VendorId vendorId);
+    bool ProcessVendorIdExceptions(chip::VendorId vendorId);
 
     /**
      * @brief Processes the Apple Keychain edge case.

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/AppleKeychainHandler.h
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/AppleKeychainHandler.h
@@ -25,10 +25,16 @@ namespace app {
 namespace Silabs {
 
 /**
- * @brief Apple Keychain edge-case processing handler.
- *        Handler is called when we validate if the Apple Keychain fabric has an active subscription which it never does.
- *        In this case, we validate if the main Apple fabric has an active subscription.
+ * @brief Processes the Apple Keychain edge case.
  *
+ * Apple, when commissioning, adds two fabric to the device. One for Apple Home and one for the Apple Keychain.
+ * Apple Home is the active fabric which is used to communication with the device. The associated fabric also has the active
+ * subcription. The Apple Keychain fabric acts as a safety and doesn't have an active fabric with the device. As such, we need an
+ * alternate method to check if the device can go to LI based sleep.
+ *
+ * This method checks if there is any fabric with the Apple Home vendor ID that
+ * has at least one active subscription. If such a fabric is found, it allows
+ * the device to go to LI based sleep.
  */
 class AppleKeychainHandler : public VendorHandler<AppleKeychainHandler>
 {

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/AppleKeychainHandler.h
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/AppleKeychainHandler.h
@@ -33,8 +33,8 @@ namespace Silabs {
 class AppleKeychainHandler : public VendorHandler<AppleKeychainHandler>
 {
 public:
-    bool ProcessVendorCaseImpl(chip::app::SubscriptionsInfoProvider * subscriptionsInfoProvider,
-                               chip::FabricTable * fabricTable) const
+    static bool ProcessVendorCaseImpl(chip::app::SubscriptionsInfoProvider * subscriptionsInfoProvider,
+                                      chip::FabricTable * fabricTable)
     {
         VerifyOrReturnValue(subscriptionsInfoProvider != nullptr && fabricTable != nullptr, false);
 
@@ -53,7 +53,7 @@ public:
         return hasValidException;
     }
 
-    static bool IsMatchingVendorID(uint16_t vendorId) { return vendorId == kAppleKeychainVendorId; }
+    static bool IsMatchingVendorID(chip::VendorId vendorId) { return vendorId == kAppleKeychainVendorId; }
 
 private:
     // Official Apple Keychain vendor ID from the CSA database

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/AppleKeychainHandler.h
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/AppleKeychainHandler.h
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * @file AppleKeychainHandler.h
+ * @brief Handler for the Apple Keychain edge-case processing logic.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2025 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <VendorHandler.h>
+#include <lib/core/DataModelTypes.h>
+
+namespace chip {
+namespace app {
+namespace Silabs {
+
+/**
+ * @brief Apple Keychain edge-case processing handler.
+ *        Handler is called when we validate if the Apple Keychain fabric has an active subscription which it never does.
+ *        In this case, we validate if the main Apple fabric has an active subscription.
+ *
+ */
+class AppleKeychainHandler : public VendorHandler<AppleKeychainHandler>
+{
+public:
+    bool ProcessVendorCaseImpl(chip::app::SubscriptionsInfoProvider * subscriptionsInfoProvider,
+                               chip::FabricTable * fabricTable) const
+    {
+        VerifyOrReturnValue(subscriptionsInfoProvider != nullptr && fabricTable != nullptr, false);
+
+        bool hasValidException = false;
+
+        for (auto it = fabricTable->begin(); it != fabricTable->end(); ++it)
+        {
+            if ((it->GetVendorId() == chip::VendorId::Apple) &&
+                subscriptionsInfoProvider->FabricHasAtLeastOneActiveSubscription(it->GetFabricIndex()))
+            {
+                hasValidException = true;
+                break;
+            }
+        }
+
+        return hasValidException;
+    }
+
+    static bool IsMatchingVendorID(uint16_t vendorId) { return vendorId == kAppleKeychainVendorId; }
+
+private:
+    // Official Apple Keychain vendor ID from the CSA database
+    static constexpr uint16_t kAppleKeychainVendorId = 4996;
+};
+
+} // namespace Silabs
+} // namespace app
+} // namespace chip

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/BUILD.gn
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/BUILD.gn
@@ -1,6 +1,6 @@
 #******************************************************************************
 # @file BUILD.gn
-# @brief BUILD.gn to build the Application Sleep Manager implementation
+# @brief BUILD.gn to build the vendor-specific handlers
 #******************************************************************************
 # # License
 # <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
@@ -17,24 +17,18 @@
 
 import("//build_overrides/chip.gni")
 
-config("app-sleep-manager-config") {
+config("vendor-handlers-config") {
   include_dirs = [ "." ]
-  defines = [ "SL_MATTER_ENABLE_APP_SLEEP_MANAGER=1" ]
 }
 
-source_set("app-sleep-manager") {
+source_set("vendor-handlers") {
   sources = [
-    "ApplicationSleepManager.cpp",
-    "ApplicationSleepManager.h",
+    "AppleKeychainHandler.h",
+    "VendorHandler.h",
+    "VendorHandlerFactory.h",
   ]
 
-  deps = [
-    "${chip_root}/examples/platform/silabs/wifi/icd/vendor-handlers",
-    "${chip_root}/src/app",
-    "${chip_root}/src/app/server:server",
-    "${chip_root}/src/lib/core",
-    "${chip_root}/src/platform/silabs/wifi:wifi-platform",
-  ]
+  public_deps = [ "${chip_root}/src/app" ]
 
-  public_configs = [ ":app-sleep-manager-config" ]
+  public_configs = [ ":vendor-handlers-config" ]
 }

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/VendorHandler.h
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/VendorHandler.h
@@ -27,6 +27,7 @@ namespace Silabs {
 /**
  * @brief Delegate innterface class that defines edge-case processing logic.
  *
+ * @tparam VendorHandlerImpl The derived class that implements the edge-case processing logic.
  */
 template <typename VendorHandlerImpl>
 class VendorHandler
@@ -42,9 +43,9 @@ public:
      * @return true, if the device can go to LI based sleep.
      *         false, if the device cannot go to LI based sleep.
      */
-    bool ProcessVendorCase(chip::app::SubscriptionsInfoProvider * subscriptionsInfoProvider, chip::FabricTable * fabricTable) const
+    static bool ProcessVendorCase(chip::app::SubscriptionsInfoProvider * subscriptionsInfoProvider, chip::FabricTable * fabricTable)
     {
-        return static_cast<const VendorHandlerImpl *>(this)->ProcessVendorCaseImpl(subscriptionsInfoProvider, fabricTable);
+        return VendorHandlerImpl::ProcessVendorCaseImpl(subscriptionsInfoProvider, fabricTable);
     }
 
     /**
@@ -55,7 +56,7 @@ public:
      * @return true, if the vendor ID matches the derived class vendor ID.
      *         false, if the vendor ID does not match the derived class vendor ID.
      */
-    static bool IsMatchingVendorID(uint16_t vendorId) { return VendorHandlerImpl::IsMatchingVendorIDImpl(vendorId); }
+    static bool IsMatchingVendorID(chip::VendorId vendorId) { return VendorHandlerImpl::IsMatchingVendorIDImpl(vendorId); }
 };
 
 } // namespace Silabs

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/VendorHandler.h
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/VendorHandler.h
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * @file VendorHandler.h
+ * @brief Header for the Vendor ID edge-case processing logic.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2025 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <app/SubscriptionsInfoProvider.h>
+#include <credentials/FabricTable.h>
+
+namespace chip {
+namespace app {
+namespace Silabs {
+
+/**
+ * @brief Delegate innterface class that defines edge-case processing logic.
+ *
+ */
+template <typename VendorHandlerImpl>
+class VendorHandler
+{
+public:
+    /**
+     * @brief Function to process the vendor ID edge-case.
+     *        This function is called to dermine if the device can go to LI based sleep.
+     *
+     * @param[in] subscriptionsInfoProvider Validation of the pointer is left to the derived class if they require the object.
+     * @param[in] fabricTable Validation of the pointer is left to the derived class if they require the object.
+     *
+     * @return true, if the device can go to LI based sleep.
+     *         false, if the device cannot go to LI based sleep.
+     */
+    bool ProcessVendorCase(chip::app::SubscriptionsInfoProvider * subscriptionsInfoProvider, chip::FabricTable * fabricTable) const
+    {
+        return static_cast<const VendorHandlerImpl *>(this)->ProcessVendorCaseImpl(subscriptionsInfoProvider, fabricTable);
+    }
+
+    /**
+     * @brief Function call the derived class function to check if the vendor ID is the supported special case.
+     *
+     * @param vendorId The vendor ID to check agaisnt the supported derived class vendor ID.
+     *
+     * @return true, if the vendor ID matches the derived class vendor ID.
+     *         false, if the vendor ID does not match the derived class vendor ID.
+     */
+    static bool IsMatchingVendorID(uint16_t vendorId) { return VendorHandlerImpl::IsMatchingVendorIDImpl(vendorId); }
+};
+
+} // namespace Silabs
+} // namespace app
+} // namespace chip

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/VendorHandlerFactory.h
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/VendorHandlerFactory.h
@@ -34,7 +34,7 @@ public:
                                   chip::FabricTable * fabricTable)
     {
         // Iterate over all handlers and process the applicable one
-        return ((Handlers::IsMatchingVendorID(vendorId) && Handlers().ProcessVendorCase(subscriptionsInfoProvider, fabricTable)) ||
+        return ((Handlers::IsMatchingVendorID(vendorId) && Handlers::ProcessVendorCase(subscriptionsInfoProvider, fabricTable)) ||
                 ...);
     }
 };

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/VendorHandlerFactory.h
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/VendorHandlerFactory.h
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * @file VendorHandlerFactory.h
+ * @brief Factory class to call the correct vendor handler based on the vendor ID.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2025 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <AppleKeychainHandler.h>
+#include <app/SubscriptionsInfoProvider.h>
+#include <credentials/FabricTable.h>
+#include <lib/core/DataModelTypes.h>
+
+namespace chip {
+namespace app {
+namespace Silabs {
+
+template <typename... Handlers>
+class VendorHandlerFactory
+{
+public:
+    static bool ProcessVendorCase(chip::VendorId vendorId, chip::app::SubscriptionsInfoProvider * subscriptionsInfoProvider,
+                                  chip::FabricTable * fabricTable)
+    {
+        // Iterate over all handlers and process the applicable one
+        return ((Handlers::IsMatchingVendorID(vendorId) && Handlers().ProcessVendorCase(subscriptionsInfoProvider, fabricTable)) ||
+                ...);
+    }
+};
+
+} // namespace Silabs
+} // namespace app
+} // namespace chip

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/tests/BUILD.gn
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/tests/BUILD.gn
@@ -1,0 +1,44 @@
+#******************************************************************************
+# @file BUILD.gn
+# @brief BUILD.gn to build the vendor-specific handlers tests
+#******************************************************************************
+# # License
+# <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
+#******************************************************************************
+#
+# The licensor of this software is Silicon Laboratories Inc. Your use of this
+# software is governed by the terms of Silicon Labs Master Software License
+# Agreement (MSLA) available at
+# www.silabs.com/about-us/legal/master-software-license-agreement. This
+# software is distributed to you in Source Code format and is governed by the
+# sections of the MSLA applicable to Source Code.
+#
+#*****************************************************************************/
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+import("${chip_root}/build/chip/chip_test_group.gni")
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("vendor_handlers_tests") {
+  output_name = "libSilabsVendorHandlerTests"
+
+  test_sources = [
+    "TestAppleKeychainHandler.cpp",
+    "TestVendorHandler.cpp",
+    "TestVendorHandlerFactory.cpp",
+  ]
+
+  public_deps = [
+    "${chip_root}/examples/platform/silabs/wifi/icd/vendor-handlers",
+    "${chip_root}/src/credentials",
+    "${chip_root}/src/credentials/tests:cert_test_vectors",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/lib/support:testing",
+  ]
+
+  cflags = [ "-Wconversion" ]
+}

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/tests/TestAppleKeychainHandler.cpp
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/tests/TestAppleKeychainHandler.cpp
@@ -1,0 +1,271 @@
+/*******************************************************************************
+ * @file TestAppleKeychainHandler.cpp
+ * @brief Unit Test File for the AppleKeychainHandler source file
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2025 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <pw_unit_test/framework.h>
+
+#include <AppleKeychainHandler.h>
+
+#include <app/SubscriptionsInfoProvider.h>
+#include <credentials/FabricTable.h>
+#include <credentials/PersistentStorageOpCertStore.h>
+#include <credentials/TestOnlyLocalCertificateAuthority.h>
+#include <credentials/tests/CHIPCert_test_vectors.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <crypto/PersistentStorageOperationalKeystore.h>
+#include <lib/asn1/ASN1.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+#include <platform/ConfigurationManager.h>
+
+#include <map>
+#include <set>
+
+using namespace chip;
+using namespace chip::app::Silabs;
+
+namespace {
+
+// Official Apple Keychain vendor ID from the CSA database
+static constexpr uint16_t kAppleKeychainVendorId = 4996;
+
+class MockSubscriptionsInfoProvider : public chip::app::SubscriptionsInfoProvider
+{
+public:
+    bool FabricHasAtLeastOneActiveSubscription(FabricIndex fabricIndex)
+    {
+        return activeSubscriptions.find(fabricIndex) != activeSubscriptions.end();
+    }
+
+    bool SubjectHasActiveSubscription(FabricIndex aFabricIndex, NodeId subjectID)
+    {
+        return activeSubscriptions.find(aFabricIndex) != activeSubscriptions.end() &&
+            activeSubscriptions.at(aFabricIndex).find(subjectID) != activeSubscriptions.at(aFabricIndex).end();
+    }
+
+    bool SubjectHasPersistedSubscription(FabricIndex aFabricIndex, NodeId subjectID)
+    {
+        return persistedSubscriptions.find(aFabricIndex) != persistedSubscriptions.end() &&
+            persistedSubscriptions.at(aFabricIndex).find(subjectID) != persistedSubscriptions.at(aFabricIndex).end();
+    }
+
+    void AddActiveSubscription(FabricIndex fabricIndex, NodeId subjectID) { activeSubscriptions[fabricIndex].insert(subjectID); }
+
+    void AddPersistedSubscription(FabricIndex fabricIndex, NodeId subjectID)
+    {
+        persistedSubscriptions[fabricIndex].insert(subjectID);
+    }
+
+private:
+    std::map<FabricIndex, std::set<NodeId>> activeSubscriptions;
+    std::map<FabricIndex, std::set<NodeId>> persistedSubscriptions;
+};
+
+class ScopedFabricTable
+{
+public:
+    ScopedFabricTable() {}
+    ~ScopedFabricTable()
+    {
+        mFabricTable.Shutdown();
+        mOpCertStore.Finish();
+        mOpKeyStore.Finish();
+    }
+
+    CHIP_ERROR Init(chip::TestPersistentStorageDelegate * storage)
+    {
+        chip::FabricTable::InitParams initParams;
+        initParams.storage             = storage;
+        initParams.operationalKeystore = &mOpKeyStore;
+        initParams.opCertStore         = &mOpCertStore;
+
+        ReturnErrorOnFailure(mOpKeyStore.Init(storage));
+        ReturnErrorOnFailure(mOpCertStore.Init(storage));
+        return mFabricTable.Init(initParams);
+    }
+
+    CHIP_ERROR ReinitFabricTable(chip::TestPersistentStorageDelegate * storage)
+    {
+        chip::FabricTable::InitParams initParams;
+        initParams.storage             = storage;
+        initParams.operationalKeystore = &mOpKeyStore;
+        initParams.opCertStore         = &mOpCertStore;
+
+        return mFabricTable.Init(initParams);
+    }
+
+    FabricTable & GetFabricTable() { return mFabricTable; }
+
+private:
+    chip::FabricTable mFabricTable;
+    chip::PersistentStorageOperationalKeystore mOpKeyStore;
+    chip::Credentials::PersistentStorageOpCertStore mOpCertStore;
+};
+
+CHIP_ERROR LoadAppleFabric(FabricTable & fabricTable)
+{
+    Crypto::P256SerializedKeypair opKeysSerialized;
+    static Crypto::P256Keypair opKey_Node01_01;
+
+    FabricIndex fabricIndex;
+    memcpy(opKeysSerialized.Bytes(), TestCerts::sTestCert_Node01_01_PublicKey.data(),
+           TestCerts::sTestCert_Node01_01_PublicKey.size());
+    memcpy(opKeysSerialized.Bytes() + TestCerts::sTestCert_Node01_01_PublicKey.size(),
+           TestCerts::sTestCert_Node01_01_PrivateKey.data(), TestCerts::sTestCert_Node01_01_PrivateKey.size());
+
+    ByteSpan rcacSpan(TestCerts::sTestCert_Root01_Chip);
+    ByteSpan icacSpan(TestCerts::sTestCert_ICA01_Chip);
+    ByteSpan nocSpan(TestCerts::sTestCert_Node01_01_Chip);
+
+    ReturnErrorOnFailure(opKeysSerialized.SetLength(TestCerts::sTestCert_Node01_01_PublicKey.size() +
+                                                    TestCerts::sTestCert_Node01_01_PrivateKey.size()));
+    ReturnErrorOnFailure(opKey_Node01_01.Deserialize(opKeysSerialized));
+    ReturnErrorOnFailure(fabricTable.AddNewPendingTrustedRootCert(rcacSpan));
+
+    ReturnErrorOnFailure(fabricTable.AddNewPendingFabricWithProvidedOpKey(nocSpan, icacSpan, VendorId::Apple, &opKey_Node01_01,
+                                                                          /*isExistingOpKeyExternallyOwned =*/true, &fabricIndex));
+    ReturnErrorOnFailure(fabricTable.CommitPendingFabricData());
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LoadAppleKeychainFabric(FabricTable & fabricTable)
+{
+    Crypto::P256SerializedKeypair opKeysSerialized;
+    FabricIndex fabricIndex;
+    static Crypto::P256Keypair opKey_Node02_01;
+
+    memcpy(opKeysSerialized.Bytes(), TestCerts::sTestCert_Node02_01_PublicKey.data(),
+           TestCerts::sTestCert_Node02_01_PublicKey.size());
+    memcpy(opKeysSerialized.Bytes() + TestCerts::sTestCert_Node02_01_PublicKey.size(),
+           TestCerts::sTestCert_Node02_01_PrivateKey.data(), TestCerts::sTestCert_Node02_01_PrivateKey.size());
+
+    ByteSpan rcacSpan(TestCerts::sTestCert_Root02_Chip);
+    ByteSpan icacSpan(TestCerts::sTestCert_ICA02_Chip);
+    ByteSpan nocSpan(TestCerts::sTestCert_Node02_01_Chip);
+
+    ReturnErrorOnFailure(opKeysSerialized.SetLength(TestCerts::sTestCert_Node02_01_PublicKey.size() +
+                                                    TestCerts::sTestCert_Node02_01_PrivateKey.size()));
+    ReturnErrorOnFailure(opKey_Node02_01.Deserialize(opKeysSerialized));
+
+    ReturnErrorOnFailure(fabricTable.AddNewPendingTrustedRootCert(rcacSpan));
+
+    ReturnErrorOnFailure(fabricTable.AddNewPendingFabricWithProvidedOpKey(nocSpan, icacSpan, VendorId(kAppleKeychainVendorId),
+                                                                          &opKey_Node02_01,
+                                                                          /*isExistingOpKeyExternallyOwned =*/true, &fabricIndex));
+
+    ReturnErrorOnFailure(fabricTable.CommitPendingFabricData());
+
+    return CHIP_NO_ERROR;
+}
+
+class TestAppleKeychainHandler : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite()
+    {
+        DeviceLayer::SetConfigurationMgr(&DeviceLayer::ConfigurationManagerImpl::GetDefaultInstance());
+        ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
+#if CHIP_CRYPTO_PSA
+        ASSERT_EQ(psa_crypto_init(), PSA_SUCCESS);
+#endif
+    }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+TEST_F(TestAppleKeychainHandler, ProcessVendorCaseImpl_ValidExceptionBothFabrics)
+{
+    MockSubscriptionsInfoProvider subscriptionsInfoProvider;
+
+    chip::TestPersistentStorageDelegate testStorage;
+    ScopedFabricTable fabricTableHolder;
+    EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
+    FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
+
+    EXPECT_EQ(CHIP_NO_ERROR, LoadAppleFabric(fabricTable));
+    EXPECT_EQ(CHIP_NO_ERROR, LoadAppleKeychainFabric(fabricTable));
+
+    // Add subscription for the Apple Fabric
+    subscriptionsInfoProvider.AddActiveSubscription(1, 1);
+
+    EXPECT_TRUE(AppleKeychainHandler::ProcessVendorCaseImpl(&subscriptionsInfoProvider, &fabricTable));
+}
+
+TEST_F(TestAppleKeychainHandler, ProcessVendorCaseImpl_NoValidExceptionBothFabrics)
+{
+    MockSubscriptionsInfoProvider subscriptionsInfoProvider;
+
+    chip::TestPersistentStorageDelegate testStorage;
+    ScopedFabricTable fabricTableHolder;
+    EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
+    FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
+
+    EXPECT_EQ(CHIP_NO_ERROR, LoadAppleFabric(fabricTable));
+    EXPECT_EQ(CHIP_NO_ERROR, LoadAppleKeychainFabric(fabricTable));
+
+    EXPECT_FALSE(AppleKeychainHandler::ProcessVendorCaseImpl(&subscriptionsInfoProvider, &fabricTable));
+}
+
+TEST_F(TestAppleKeychainHandler, ProcessVendorCaseImpl_InvalidExceptionNoAppleFabric)
+{
+    MockSubscriptionsInfoProvider subscriptionsInfoProvider;
+
+    chip::TestPersistentStorageDelegate testStorage;
+    ScopedFabricTable fabricTableHolder;
+    EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
+    FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
+
+    EXPECT_EQ(CHIP_NO_ERROR, LoadAppleKeychainFabric(fabricTable));
+    EXPECT_FALSE(AppleKeychainHandler::ProcessVendorCaseImpl(&subscriptionsInfoProvider, &fabricTable));
+}
+
+TEST_F(TestAppleKeychainHandler, ProcessVendorCaseImpl_InvalidExceptionNoFabrics)
+{
+    MockSubscriptionsInfoProvider subscriptionsInfoProvider;
+
+    chip::TestPersistentStorageDelegate testStorage;
+    ScopedFabricTable fabricTableHolder;
+    EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
+    FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
+
+    EXPECT_FALSE(AppleKeychainHandler::ProcessVendorCaseImpl(&subscriptionsInfoProvider, &fabricTable));
+}
+
+TEST_F(TestAppleKeychainHandler, ProcessVendorCaseImpl_MissingFabricTable)
+{
+    MockSubscriptionsInfoProvider subscriptionsInfoProvider;
+    EXPECT_FALSE(AppleKeychainHandler::ProcessVendorCaseImpl(&subscriptionsInfoProvider, nullptr));
+}
+
+TEST_F(TestAppleKeychainHandler, ProcessVendorCaseImpl_MissingSubscriptionsInfoProvider)
+{
+    chip::TestPersistentStorageDelegate testStorage;
+    ScopedFabricTable fabricTableHolder;
+    EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
+    FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
+
+    EXPECT_FALSE(AppleKeychainHandler::ProcessVendorCaseImpl(nullptr, &fabricTable));
+}
+
+TEST_F(TestAppleKeychainHandler, IsMatchingVendorID)
+{
+    EXPECT_TRUE(AppleKeychainHandler::IsMatchingVendorID(chip::VendorId(kAppleKeychainVendorId)));
+    EXPECT_FALSE(AppleKeychainHandler::IsMatchingVendorID(chip::VendorId(1234)));
+}
+
+} // namespace

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/tests/TestVendorHandler.cpp
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/tests/TestVendorHandler.cpp
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * @file TestVendorHandler.cpp
+ * @brief Unit Test File for the VendorHandler source file
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2025 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <pw_unit_test/framework.h>
+
+#include <VendorHandler.h>
+
+#include <app/SubscriptionsInfoProvider.h>
+#include <credentials/FabricTable.h>
+#include <lib/core/DataModelTypes.h>
+
+namespace {
+
+bool wasProcessVendorCaseImplCalled = false;
+bool wasIsMatchingVendorIDCalled    = false;
+
+void Reset()
+{
+    wasProcessVendorCaseImplCalled = false;
+    wasIsMatchingVendorIDCalled    = false;
+}
+
+class MockVendorHandler : public chip::app::Silabs::VendorHandler<MockVendorHandler>
+{
+
+public:
+    static bool ProcessVendorCaseImpl(chip::app::SubscriptionsInfoProvider * subscriptionsInfoProvider,
+                                      chip::FabricTable * fabricTable)
+    {
+        wasProcessVendorCaseImplCalled = true;
+        return false;
+    }
+
+    static bool IsMatchingVendorIDImpl(chip::VendorId vendorId)
+    {
+        wasIsMatchingVendorIDCalled = true;
+        return false;
+    }
+};
+
+class TestVendorHandler : public ::testing::Test
+{
+public:
+    void SetUp() override { Reset(); }
+};
+
+TEST_F(TestVendorHandler, ProcessVendorCase)
+{
+    EXPECT_FALSE(chip::app::Silabs::VendorHandler<MockVendorHandler>::ProcessVendorCase(nullptr, nullptr));
+
+    EXPECT_TRUE(wasProcessVendorCaseImplCalled);
+    EXPECT_FALSE(wasIsMatchingVendorIDCalled);
+}
+
+TEST_F(TestVendorHandler, IsMatchingVendorID)
+{
+    EXPECT_FALSE(chip::app::Silabs::VendorHandler<MockVendorHandler>::IsMatchingVendorID(chip::VendorId(1234)));
+
+    EXPECT_FALSE(wasProcessVendorCaseImplCalled);
+    EXPECT_TRUE(wasIsMatchingVendorIDCalled);
+}
+
+} // namespace

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/tests/TestVendorHandlerFactory.cpp
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/tests/TestVendorHandlerFactory.cpp
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * @file TestVendorHandlerFactory.cpp
+ * @brief Unit Test File for the VendorHandlerFactory source file
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2025 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <pw_unit_test/framework.h>
+
+#include <VendorHandlerFactory.h>
+
+namespace {
+
+// Mock implementations for testing
+class MockVendorHandlerA : public chip::app::Silabs::VendorHandler<MockVendorHandlerA>
+{
+public:
+    static bool ProcessVendorCaseImpl(chip::app::SubscriptionsInfoProvider *, chip::FabricTable *)
+    {
+        return true; // Mock logic for VendorHandlerA
+    }
+
+    static bool IsMatchingVendorIDImpl(chip::VendorId vendorId)
+    {
+        return vendorId == chip::VendorId(0x1234); // Mock Vendor ID for VendorHandlerA
+    }
+};
+
+class MockVendorHandlerB : public chip::app::Silabs::VendorHandler<MockVendorHandlerB>
+{
+public:
+    static bool ProcessVendorCaseImpl(chip::app::SubscriptionsInfoProvider *, chip::FabricTable *)
+    {
+        return false; // Mock logic for VendorHandlerB
+    }
+
+    static bool IsMatchingVendorIDImpl(chip::VendorId vendorId)
+    {
+        return vendorId == chip::VendorId(0x5678); // Mock Vendor ID for VendorHandlerB
+    }
+};
+
+// Define the VendorHandlerFactory with mock handlers
+using TestVendorHandlerFactory = chip::app::Silabs::VendorHandlerFactory<MockVendorHandlerA, MockVendorHandlerB>;
+
+// Test cases
+TEST(VendorHandlerFactoryTest, MatchingVendorIDHandlerA)
+{
+    EXPECT_TRUE(TestVendorHandlerFactory::ProcessVendorCase(chip::VendorId(0x1234), nullptr, nullptr));
+}
+
+TEST(VendorHandlerFactoryTest, MatchingVendorIDHandlerB)
+{
+    EXPECT_FALSE(TestVendorHandlerFactory::ProcessVendorCase(chip::VendorId(0x5678), nullptr, nullptr));
+}
+
+TEST(VendorHandlerFactoryTest, NonMatchingVendorID)
+{
+    EXPECT_FALSE(TestVendorHandlerFactory::ProcessVendorCase(chip::VendorId(0x1111), nullptr, nullptr));
+}
+
+} // namespace

--- a/src/platform/silabs/CHIPDevicePlatformConfig.h
+++ b/src/platform/silabs/CHIPDevicePlatformConfig.h
@@ -117,11 +117,6 @@
 #define CHIP_DEVICE_CONFIG_ENABLE_IPV4 0
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 
-#if SL_ICD_ENABLED
-#define CHIP_DEVICE_CONFIG_ICD_SLOW_POLL_INTERVAL chip::System::Clock::Milliseconds32(300)
-#define CHIP_DEVICE_CONFIG_ICD_FAST_POLL_INTERVAL chip::System::Clock::Milliseconds32(10)
-#endif /* SL_ICD_ENABLED */
-
 #endif /* SL_WIFI */
 
 // ========== Platform-specific Configuration =========

--- a/src/platform/silabs/tests/BUILD.gn
+++ b/src/platform/silabs/tests/BUILD.gn
@@ -25,6 +25,7 @@ chip_test_group("silabs_platform_tests") {
   if (sl_build_unit_tests) {
     tests += [
       "${chip_root}/examples/platform/silabs/tests:examples_tests",
+      "${chip_root}/examples/platform/silabs/wifi/icd/vendor-handlers/tests:vendor_handlers_tests",
       "${chip_root}/src/platform/silabs/wifi/icd/tests:wifi_icd_tests",
     ]
   }

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -329,6 +329,8 @@ template("siwx917_sdk") {
         "SL_ACTIVE_MODE_DURATION_MS=${sl_active_mode_duration_ms}",
         "SL_IDLE_MODE_DURATION_S=${sl_idle_mode_duration_s}",
         "SL_ICD_SUPPORTED_CLIENTS_PER_FABRIC=${sl_icd_supported_clients_per_fabric}",
+        "SL_TRANSPORT_IDLE_INTERVAL=${sl_transport_idle_interval_ms}",
+        "SL_TRANSPORT_ACTIVE_INTERVAL=${sl_transport_active_interval_ms}",
         "SL_SI91X_POWER_MANAGER_UC_AVAILABLE=1",
         "SL_SI91X_TICKLESS_MODE=1",
 


### PR DESCRIPTION
#### Description
The goal of the PR is to refactor the Vendor exception processing to make it easier to expand overtime. Instead of having hardcoded logic in ApplicationSleepManager.

The logic used is through the CRTP to avoid using dynamic allocation. The current implementation is resolved at compile time.

- `VendorHandler` : interface class that defines the structure of the handlers
- `VendorHandlerFactory` : interface that calls all the handler defined in the ApplicationSleepManager
- `AppleKeychainHandler` : Exception handler for the apple that uses two fabrics with a single active one

Some configuration changes weren't cherry-pick to the main branch since the PR in question was marked SL-UP but they were changed to SL-ONLY during the development process.

#### Tests
- Manual tests with the BRD4338A with chip-tool and homepod to validate that the device switches between DTIM and LI based sleep
- Unit tests to validate the new classes and the Apple Keychain exception logic