### PR TITLE
[SL-TEMP] Init the OTA Requestor based on the DNS-SD event

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -980,7 +980,7 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 #if SILABS_OTA_ENABLED
         ChipLogProgress(AppServer, "DNS-SD initialized, scheduling OTA Requestor initialization");
         chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(OTAConfig::kInitOTARequestorDelaySec),
-                                                        InitOTARequestorHandler, nullptr);
+                                                    InitOTARequestorHandler, nullptr);
 #endif // SILABS_OTA_ENABLED
     }
     break;

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -976,6 +976,15 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
     }
     break;
 
+     case DeviceEventType::kDnssdInitialized: {
+#if SILABS_OTA_ENABLED
+            ChipLogProgress(AppServer, "DNS-SD initialized, scheduling OTA Requestor initialization");
+            chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(OTAConfig::kInitOTARequestorDelaySec),
+                                                        InitOTARequestorHandler, nullptr);
+#endif // SILABS_OTA_ENABLED
+     }
+     break;
+
     case DeviceEventType::kCommissioningComplete: {
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
         // DUT is commissioned, removing the High Performance request

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -976,14 +976,14 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
     }
     break;
 
-     case DeviceEventType::kDnssdInitialized: {
+    case DeviceEventType::kDnssdInitialized: {
 #if SILABS_OTA_ENABLED
-            ChipLogProgress(AppServer, "DNS-SD initialized, scheduling OTA Requestor initialization");
-            chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(OTAConfig::kInitOTARequestorDelaySec),
+        ChipLogProgress(AppServer, "DNS-SD initialized, scheduling OTA Requestor initialization");
+        chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(OTAConfig::kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);
 #endif // SILABS_OTA_ENABLED
-     }
-     break;
+    }
+    break;
 
     case DeviceEventType::kCommissioningComplete: {
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER


### PR DESCRIPTION
### Problem
https://jira.silabs.com/browse/MATTER-4885 
With some Thread apps (most often seen in ICDs) the BaseApplication::OnPlatformEvent() does not get registered in time to receive the DeviceEventType::kThreadConnectivityChange event when the device joins the Thread network. As a result the OTA Requestor does not get initialized. 

### Solution
Add another OTA Requestor initialization call from DeviceEventType::kDnssdInitialized event handling. The  OTA Requestor initialization is idempotent and is safe to call multiple times (i.e. in cases when we catch both the Thread and DNS-SD handling). 

#### Testing
Verified that OTA Requestor init is invoked even if  DeviceEventType::kThreadConnectivityChange event is missed. Verified that NotifyUpdateApplied command is sent out in the OTA Update scenario.
