### PR TITLE
[SL-TEMP] Init the OTA Requestor based on the DNS-SD event (#399)

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -976,6 +976,15 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
     }
     break;
 
+    case DeviceEventType::kDnssdInitialized: {
+#if SILABS_OTA_ENABLED
+        ChipLogProgress(AppServer, "DNS-SD initialized, scheduling OTA Requestor initialization");
+        chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(OTAConfig::kInitOTARequestorDelaySec),
+                                                    InitOTARequestorHandler, nullptr);
+#endif // SILABS_OTA_ENABLED
+    }
+    break;
+
     case DeviceEventType::kCommissioningComplete: {
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
         // DUT is commissioned, removing the High Performance request


### PR DESCRIPTION
Merge 2.5 into 2.6. It can be directly fast-forwarded. It brings only 1 pr

#### Testing
just ci 
