### PR TITLE
[SL-ONLY] Fix Apple Keychain fabric edge-cases for multi-admin

### DIFF
--- a/examples/platform/silabs/wifi/icd/vendor-handlers/AppleKeychainHandler.h
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/AppleKeychainHandler.h
@@ -35,6 +35,8 @@ namespace Silabs {
  * This method checks if there is any fabric with the Apple Home vendor ID that
  * has at least one active subscription. If such a fabric is found, it allows
  * the device to go to LI based sleep.
+ * If the device has an Apple Keychain fabric but no Apple fabric, the device can go to LI based
+ * sleep.
  */
 class AppleKeychainHandler : public VendorHandler<AppleKeychainHandler>
 {
@@ -44,15 +46,26 @@ public:
     {
         VerifyOrReturnValue(subscriptionsInfoProvider != nullptr && fabricTable != nullptr, false);
 
-        bool hasValidException = false;
+        bool hasValidException = true; // Default to true if no VendorId::Apple fabric is found
 
-        for (auto it = fabricTable->begin(); it != fabricTable->end(); ++it)
+        if (fabricTable->FabricCount() == 0)
         {
-            if ((it->GetVendorId() == chip::VendorId::Apple) &&
-                subscriptionsInfoProvider->FabricHasAtLeastOneActiveSubscription(it->GetFabricIndex()))
+            // This condition should never happen in practice. We shouldn't be calling an excepting handler if there are no fabrics.
+            // But if it does, we can assume that the device is in a state where it cannot go to LI based sleep.
+            hasValidException = false;
+        }
+        else
+        {
+            for (auto it = fabricTable->begin(); it != fabricTable->end(); ++it)
             {
-                hasValidException = true;
-                break;
+                if (it->GetVendorId() == chip::VendorId::Apple)
+                {
+                    if (!subscriptionsInfoProvider->FabricHasAtLeastOneActiveSubscription(it->GetFabricIndex()))
+                    {
+                        hasValidException = false; // Found an Apple fabric, but no active subscription
+                    }
+                    break;
+                }
             }
         }
 

--- a/examples/platform/silabs/wifi/icd/vendor-handlers/tests/TestAppleKeychainHandler.cpp
+++ b/examples/platform/silabs/wifi/icd/vendor-handlers/tests/TestAppleKeychainHandler.cpp
@@ -231,7 +231,7 @@ TEST_F(TestAppleKeychainHandler, ProcessVendorCaseImpl_InvalidExceptionNoAppleFa
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
     EXPECT_EQ(CHIP_NO_ERROR, LoadAppleKeychainFabric(fabricTable));
-    EXPECT_FALSE(AppleKeychainHandler::ProcessVendorCaseImpl(&subscriptionsInfoProvider, &fabricTable));
+    EXPECT_TRUE(AppleKeychainHandler::ProcessVendorCaseImpl(&subscriptionsInfoProvider, &fabricTable));
 }
 
 TEST_F(TestAppleKeychainHandler, ProcessVendorCaseImpl_InvalidExceptionNoFabrics)
@@ -243,6 +243,13 @@ TEST_F(TestAppleKeychainHandler, ProcessVendorCaseImpl_InvalidExceptionNoFabrics
     EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
+    /*
+     * In this case, we have no fabrics in the fabric table. The Apple Keychain
+     * handler should return False since we cannot determine if the device can go to LI based sleep.
+     *
+     * In practice, this use-case should never happen since we shouldn't be calling an excepting handler if there are no fabrics.
+     * But if it does, we can assume that the device is in a state where it cannot go to LI based sleep.
+     */
     EXPECT_FALSE(AppleKeychainHandler::ProcessVendorCaseImpl(&subscriptionsInfoProvider, &fabricTable));
 }
 


### PR DESCRIPTION
#### Description
While doing multi-admin test cases, I noticed while using the Google Home app on my iphone that the Appley Keychain fabric was being added to the device even if the operating fabric was not Apple. This behavior was preventing the device from entering Listen based sleep because the exception handler tried to find an Apple fabric to validate that it had an activate subscription while the fabric was not present on the device.

The PR modifies the exception handler to verify if we find an Apple fabric. If the Apple fabric is absent but we have an Apple Keychain fabric, this means that the operationnal fabric is not Apple's and the exception handler should not prevent the device from going to sleep.

#### Tests
- Updated the unit-tests to reflect the new behavior
- The multi-admin test case that allowed me to see the issue worked (Commission samsung and share to google on an Iphone)