### PR TITLE
[SL-UP]Removed configUSE_NEWLIB_REENTRANT 

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -231,7 +231,7 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #define configUSE_TRACE_FACILITY 1
 #define configQUEUE_REGISTRY_SIZE (10)
 #define configUSE_QUEUE_SETS (0)
-#define configUSE_NEWLIB_REENTRANT (1)
+#define configUSE_NEWLIB_REENTRANT (0)
 #define configENABLE_BACKWARD_COMPATIBILITY (1)
 #define configSUPPORT_STATIC_ALLOCATION (1)
 #define configSUPPORT_DYNAMIC_ALLOCATION (1)

--- a/src/test_driver/efr32/include/FreeRTOSConfig.h
+++ b/src/test_driver/efr32/include/FreeRTOSConfig.h
@@ -233,7 +233,7 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #define configUSE_TRACE_FACILITY 1
 #define configQUEUE_REGISTRY_SIZE (10)
 #define configUSE_QUEUE_SETS (0)
-#define configUSE_NEWLIB_REENTRANT (1)
+#define configUSE_NEWLIB_REENTRANT (0)
 #define configENABLE_BACKWARD_COMPATIBILITY (1)
 #define configSUPPORT_STATIC_ALLOCATION (1)
 #define configSUPPORT_DYNAMIC_ALLOCATION (1)


### PR DESCRIPTION
The new FreeRTOS kernel relies on a file that is not supported in Sisdk.
Disabling configUSE_NEWLIB_REENTRANT avoids including that file.
No impact was measured on device performance after removing this config.
#### Testing

Compile, flash, commission, toggle
