### PR TITLE
[SL-TEMP] Removed software diagnostics support for 917 SoC

### DIFF
--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -55,8 +55,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapFree(uint64_t & currentHeap
 #if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #else
-    size_t freeHeapSize = sl_memory_get_free_heap_size();
-    currentHeapFree     = static_cast<uint64_t>(freeHeapSize);
+    size_t freeHeapSize             = sl_memory_get_free_heap_size();
+    currentHeapFree                 = static_cast<uint64_t>(freeHeapSize);
 #endif //(defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     return CHIP_NO_ERROR;
 }
@@ -66,8 +66,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapUsed(uint64_t & currentHeap
 #if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #else
-    size_t heapUsed = sl_memory_get_used_heap_size();
-    currentHeapUsed = static_cast<uint64_t>(heapUsed);
+    size_t heapUsed                 = sl_memory_get_used_heap_size();
+    currentHeapUsed                 = static_cast<uint64_t>(heapUsed);
 #endif //(defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     return CHIP_NO_ERROR;
 }

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -52,31 +52,46 @@ DiagnosticDataProviderImpl & DiagnosticDataProviderImpl::GetDefaultInstance()
  */
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapFree(uint64_t & currentHeapFree)
 {
+#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else
     size_t freeHeapSize = sl_memory_get_free_heap_size();
     currentHeapFree     = static_cast<uint64_t>(freeHeapSize);
+#endif //(defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapUsed(uint64_t & currentHeapUsed)
 {
+#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else
     size_t heapUsed = sl_memory_get_used_heap_size();
     currentHeapUsed = static_cast<uint64_t>(heapUsed);
+#endif //(defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark)
 {
+#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else
     size_t HighestHeapUsageRecorded = sl_memory_get_heap_high_watermark();
     currentHeapHighWatermark        = static_cast<uint64_t>(HighestHeapUsageRecorded);
-
+#endif //(defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
 {
+#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else
     // If implemented, the server SHALL set the value of the CurrentHeapHighWatermark attribute to the
     // value of the CurrentHeapUsed.
     sl_memory_reset_heap_high_watermark();
+#endif //(defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -32,11 +32,9 @@
 
 // TODO add includes ?
 extern "C" {
-#include "em_core.h"
 #if defined(SL_SI91X_BOARD_INIT)
 #include "rsi_board.h"
 #endif // SL_SI91X_BOARD_INIT
-#include "sl_event_handler.h"
 
 #include "sl_si91x_hal_soc_soft_reset.h"
 

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -96,9 +96,6 @@ CHIP_ERROR SilabsPlatform::Init(void)
 {
     mButtonCallback = nullptr;
 
-    // TODO: Setting the highest priority for SVCall_IRQn to avoid the HardFault issue
-    NVIC_SetPriority(SVCall_IRQn, CORE_INTERRUPT_HIGHEST_PRIORITY);
-
 #if (CHIP_CONFIG_ENABLE_ICD_SERVER == 0) && (SL_PROVISION_GENERATOR == 0)
     // Configuration the clock rate
     soc_pll_config();


### PR DESCRIPTION
- As memory_manager support is not there in wifi_sdk, returning `CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE` while reading software diagnostics attributes.
- Removed setting the highest priority for SVCall_IRQn  as sl_device_init_nvic() was used and  causing the hardfault issue.Now `sl_si91x_device_init_nvic()` is used hence it is not required.

Testing
Verified software diagnostics attributes returning '0' after commission with 917SoC board.