### PR TITLE
[SL-UP] Feature/common token manager

### DIFF
--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -41,8 +41,6 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/silabs/tracing/SilabsTracingMacros.h>
 
-#include <platform/silabs/SilabsConfig.h>
-
 #ifdef SL_CATALOG_SIMPLE_LED_LED1_PRESENT
 #define LIGHT_LED 1
 #else

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -41,6 +41,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/silabs/tracing/SilabsTracingMacros.h>
 
+#include <platform/silabs/SilabsConfig.h>
+
 #ifdef SL_CATALOG_SIMPLE_LED_LED1_PRESENT
 #define LIGHT_LED 1
 #else

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -83,6 +83,8 @@ void OnSoftwareFaultEventHandler(const char * faultRecordString)
 } // namespace DeviceLayer
 } // namespace chip
 
+// This method is already implemented in the Zigbee stack and is required by the Zigbee
+#ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 extern "C" void halInternalAssertFailed(const char * filename, int linenumber)
 {
     char faultMessage[kMaxFaultStringLen] = { 0 };
@@ -92,6 +94,7 @@ extern "C" void halInternalAssertFailed(const char * filename, int linenumber)
 #endif
     configASSERT((volatile void *) NULL);
 }
+#endif
 
 #if HARD_FAULT_LOG_ENABLE
 /**

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -83,6 +83,16 @@ void OnSoftwareFaultEventHandler(const char * faultRecordString)
 } // namespace DeviceLayer
 } // namespace chip
 
+extern "C" void halInternalAssertFailed(const char * filename, int linenumber)
+{
+    char faultMessage[kMaxFaultStringLen] = { 0 };
+    snprintf(faultMessage, sizeof faultMessage, "Assert failed: %s:%d", filename, linenumber);
+#if SILABS_LOG_ENABLED
+    ChipLogError(NotSpecified, "%s", faultMessage);
+#endif
+    configASSERT((volatile void *) NULL);
+}
+
 #if HARD_FAULT_LOG_ENABLE
 /**
  * Log register contents to UART when a hard fault occurs.

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -87,9 +87,9 @@ void OnSoftwareFaultEventHandler(const char * faultRecordString)
 #ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 extern "C" void halInternalAssertFailed(const char * filename, int linenumber)
 {
+#if SILABS_LOG_ENABLED
     char faultMessage[kMaxFaultStringLen] = { 0 };
     snprintf(faultMessage, sizeof faultMessage, "Assert failed: %s:%d", filename, linenumber);
-#if SILABS_LOG_ENABLED
     ChipLogError(NotSpecified, "%s", faultMessage);
 #endif
     configASSERT((volatile void *) NULL);

--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -63,16 +63,16 @@ namespace DeviceLayer {
 namespace Internal {
 
 namespace {
-CHIP_ERROR MapNvm3Error(Ecode_t nvm3Res)
+CHIP_ERROR MapNvm3Error(sl_status_t nvm3Res)
 {
     CHIP_ERROR err;
 
     switch (nvm3Res)
     {
-    case ECODE_NVM3_OK:
+    case SL_STATUS_OK:
         err = CHIP_NO_ERROR;
         break;
-    case ECODE_NVM3_ERR_KEY_NOT_FOUND:
+    case SL_STATUS_NOT_FOUND:
         err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
         break;
     default:
@@ -395,7 +395,7 @@ CHIP_ERROR SilabsConfig::ForEachRecord(Key firstNvm3Key, Key lastNvm3Key, bool a
 
     for (Key nvm3Key = firstNvm3Key; nvm3Key <= lastNvm3Key; ++nvm3Key)
     {
-        Ecode_t nvm3Res;
+        sl_status_t nvm3Res;
         uint32_t objectType;
         size_t dataLen;
 
@@ -403,7 +403,7 @@ CHIP_ERROR SilabsConfig::ForEachRecord(Key firstNvm3Key, Key lastNvm3Key, bool a
         nvm3Res = nvm3_getObjectInfo(nvm3_defaultHandle, nvm3Key, &objectType, &dataLen);
         switch (nvm3Res)
         {
-        case ECODE_NVM3_OK:
+        case SL_STATUS_OK:
             if (!addNewRecord)
             {
                 // Invoke the caller's function
@@ -411,7 +411,7 @@ CHIP_ERROR SilabsConfig::ForEachRecord(Key firstNvm3Key, Key lastNvm3Key, bool a
                 err = funct(nvm3Key, dataLen);
             }
             break;
-        case ECODE_NVM3_ERR_KEY_NOT_FOUND:
+        case SL_STATUS_NOT_FOUND:
             if (addNewRecord)
             {
                 // Invoke caller's function

--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -93,7 +93,7 @@ CHIP_ERROR ReadConfigValueHelper(SilabsConfig::Key key, T & val)
     // Verify the key is valid
     VerifyOrReturnError(SilabsConfig::ValidConfigKey(key), CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
-    // Get token size
+    // Get object size
     ReturnErrorOnFailure(MapNvm3Error(nvm3_getObjectInfo(nvm3_defaultHandle, key, &objectType, &dataLen)));
 
     // Ensure the data size matches the expected size

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -27,8 +27,12 @@
 #include <functional>
 #include <platform/CHIPDeviceError.h>
 
+#ifndef SL_TOKEN_MANAGER_CONFIG_H
 #include "nvm3.h"
 #include "nvm3_hal_flash.h"
+#else
+#include <sl_token_manager_defines.h>
+#endif
 
 #ifndef KVS_MAX_ENTRIES
 #define KVS_MAX_ENTRIES 255 // Available key slot count for Kvs Key mapping.
@@ -57,6 +61,7 @@ namespace Internal {
  * the template class (e.g. the ReadConfigValue() method).
  */
 
+#ifndef SL_TOKEN_MANAGER_CONFIG_H
 // Silabs NVM3 objects use a 20-bit number,
 // NVM3 Key 19:16 Stack region
 // NVM3 Key 15:0 Available NVM3 keys 0x0000 -> 0xFFFF.
@@ -67,13 +72,30 @@ namespace Internal {
 // '01' = the id offset inside the group.
 inline constexpr uint32_t kUserNvm3KeyDomainLoLimit = 0x000000U; // User Domain NVM3 Key Range lower limit
 inline constexpr uint32_t kUserNvm3KeyDomainHiLimit = 0x00FFFFU; // User Domain NVM3 Key Range Maximum limit
-inline constexpr uint32_t kMatterNvm3KeyDomain      = 0x080000U;
-inline constexpr uint32_t kMatterNvm3KeyLoLimit     = 0x087200U; // Do not modify without Silabs GSDK team approval
-inline constexpr uint32_t kMatterNvm3KeyHiLimit     = 0x087FFFU; // Do not modify without Silabs GSDK team approval
+inline constexpr uint32_t kMatterNvm3KeyDomain      = 0x087000U; // Matter specific NVM3 range
 constexpr inline uint32_t SilabsConfigKey(uint8_t keyBaseOffset, uint8_t id)
 {
     return kMatterNvm3KeyDomain | static_cast<uint32_t>(keyBaseOffset) << 8 | id;
 }
+#else
+
+inline constexpr uint32_t kUserNvm3KeyDomainLoLimit = SL_TOKEN_NVM3_REGION_USER;
+inline constexpr uint32_t kUserNvm3KeyDomainHiLimit = SL_TOKEN_NVM3_REGION_ZIGBEE - 1;
+inline constexpr uint32_t kMatterNvm3KeyDomain      = SL_TOKEN_NVM3_REGION_COMMON | 0x007000U; // Matter specific NVM3 range
+
+constexpr inline uint32_t SilabsConfigKey(uint8_t keyBaseOffset, uint8_t id)
+{
+    return SL_TOKEN_TYPE_NVM3 | kMatterNvm3KeyDomain | static_cast<uint32_t>(keyBaseOffset) << 8 | id;
+}
+
+constexpr inline uint32_t SilabsSecureTokenKey(uint8_t keyBaseOffset, uint8_t id)
+{
+    return SL_TOKEN_TYPE_STATIC_SECURE | static_cast<uint32_t>(keyBaseOffset) << 8 | id;
+}
+#endif
+
+inline constexpr uint32_t kMatterNvm3KeyLoLimit = 0x087200U; // Do not modify without Silabs GSDK team approval
+inline constexpr uint32_t kMatterNvm3KeyHiLimit = 0x087FFFU; // Do not modify without Silabs GSDK team approval
 
 class SilabsConfig
 {
@@ -85,14 +107,14 @@ public:
     // NVM3 key base offsets used by the CHIP Device Layer.
     // ** Key base can range from 0x72 to 0x7F **
     // Persistent config values set at manufacturing time. Retained during factory reset.
-    static constexpr uint8_t kMatterFactory_KeyBase = 0x72;
+    static constexpr uint8_t kMatterFactory_KeyBase = 0x2;
     // Persistent config values set at runtime. Cleared during factory reset.
-    static constexpr uint8_t kMatterConfig_KeyBase = 0x73;
+    static constexpr uint8_t kMatterConfig_KeyBase = 0x3;
     // Persistent counter values set at runtime. Retained during factory reset.
-    static constexpr uint8_t kMatterCounter_KeyBase = 0x74;
+    static constexpr uint8_t kMatterCounter_KeyBase = 0x4;
     // Persistent config values set at runtime. Cleared during factory reset.
-    static constexpr uint8_t kMatterKvs_KeyBase       = 0x75;
-    static constexpr uint8_t kMatterKvs_ExtendedRange = 0x76;
+    static constexpr uint8_t kMatterKvs_KeyBase       = 0x5;
+    static constexpr uint8_t kMatterKvs_ExtendedRange = 0x6;
 
     // Key definitions for well-known configuration values.
     // Factory config keys
@@ -201,15 +223,13 @@ public:
     static CHIP_ERROR ReadConfigValue(Key key, uint32_t & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint64_t & val);
     static CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen);
-    static CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen);
-    static CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen, size_t offset);
+    static CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen, size_t offset = 0);
     static CHIP_ERROR ReadConfigValueCounter(uint8_t counterIdx, uint32_t & val);
     static CHIP_ERROR WriteConfigValue(Key key, bool val);
     static CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint32_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint64_t val);
-    static CHIP_ERROR WriteConfigValueStr(Key key, const char * str);
-    static CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen);
+    static CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen = 0);
     static CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen);
     static CHIP_ERROR WriteConfigValueCounter(uint8_t counterIdx, uint32_t val);
     static CHIP_ERROR ClearConfigValue(Key key);
@@ -224,9 +244,6 @@ public:
 protected:
     using ForEachRecordFunct = std::function<CHIP_ERROR(const Key & nvm3Key, const size_t & length)>;
     static CHIP_ERROR ForEachRecord(Key firstKey, Key lastKey, bool addNewRecord, ForEachRecordFunct funct);
-
-private:
-    static CHIP_ERROR MapNvm3Error(Ecode_t nvm3Res);
 };
 
 } // namespace Internal

--- a/src/platform/silabs/SilabsConfigCTM.cpp
+++ b/src/platform/silabs/SilabsConfigCTM.cpp
@@ -63,16 +63,16 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 namespace {
-CHIP_ERROR MapNvm3Error(uint32_t nvm3Res)
+CHIP_ERROR MapNvm3Error(sl_status_t nvm3Res)
 {
     CHIP_ERROR err;
 
     switch (nvm3Res)
     {
-    case ECODE_NVM3_OK:
+    case SL_STATUS_OK:
         err = CHIP_NO_ERROR;
         break;
-    case ECODE_NVM3_ERR_KEY_NOT_FOUND:
+    case SL_STATUS_NOT_FOUND:
         err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
         break;
     default:
@@ -356,14 +356,14 @@ CHIP_ERROR SilabsConfig::ForEachRecord(Key firstNvm3Key, Key lastNvm3Key, bool a
 
     for (Key nvm3Key = firstNvm3Key; nvm3Key <= lastNvm3Key; ++nvm3Key)
     {
-        Ecode_t nvm3Res;
+        sl_status_t nvm3Res;
         uint32_t dataLen;
 
         // Find nvm3 object with current nvm3 iteration key.
         nvm3Res = sl_token_manager_get_size(nvm3Key, &dataLen);
         switch (nvm3Res)
         {
-        case ECODE_NVM3_OK:
+        case SL_STATUS_OK:
             if (!addNewRecord)
             {
                 // Invoke the caller's function
@@ -371,7 +371,7 @@ CHIP_ERROR SilabsConfig::ForEachRecord(Key firstNvm3Key, Key lastNvm3Key, bool a
                 ReturnErrorOnFailure(funct(nvm3Key, dataLen));
             }
             break;
-        case ECODE_NVM3_ERR_KEY_NOT_FOUND:
+        case SL_STATUS_NOT_FOUND:
             if (addNewRecord)
             {
                 // Invoke caller's function

--- a/src/platform/silabs/SilabsConfigCTM.cpp
+++ b/src/platform/silabs/SilabsConfigCTM.cpp
@@ -28,13 +28,14 @@
 #include <platform/internal/testing/ConfigUnitTest.h>
 #include <platform/silabs/CHIPDevicePlatformConfig.h>
 
+#include "uart.h"
+#include <FreeRTOS.h>
 #include <nvm3.h>
 #include <nvm3_default.h>
 #include <nvm3_hal_flash.h>
 #include <nvm3_lock.h>
-
-#include <FreeRTOS.h>
 #include <semphr.h>
+#include <sl_token_manager_interface.h>
 // Substitute the GSDK weak nvm3_lockBegin and nvm3_lockEnd
 // for an application controlled re-entrance protection
 static SemaphoreHandle_t nvm3_Sem;
@@ -61,9 +62,8 @@ void nvm3_lockEnd(void)
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
-
 namespace {
-CHIP_ERROR MapNvm3Error(Ecode_t nvm3Res)
+CHIP_ERROR MapNvm3Error(uint32_t nvm3Res)
 {
     CHIP_ERROR err;
 
@@ -86,19 +86,21 @@ CHIP_ERROR MapNvm3Error(Ecode_t nvm3Res)
 template <typename T>
 CHIP_ERROR ReadConfigValueHelper(SilabsConfig::Key key, T & val)
 {
-    uint32_t objectType;
-    size_t dataLen;
-    T tmpVal = {};
+    uint32_t dataLen = 0;
+    T tmpVal         = {};
 
     // Verify the key is valid
     VerifyOrReturnError(SilabsConfig::ValidConfigKey(key), CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     // Get token size
-    ReturnErrorOnFailure(MapNvm3Error(nvm3_getObjectInfo(nvm3_defaultHandle, key, &objectType, &dataLen)));
+    ReturnErrorOnFailure(MapNvm3Error(sl_token_manager_get_size(key, &dataLen)));
 
     // Ensure the data size matches the expected size
     VerifyOrReturnError(dataLen == sizeof(T), CHIP_ERROR_INVALID_ARGUMENT);
-    ReturnErrorOnFailure(MapNvm3Error(nvm3_readData(nvm3_defaultHandle, key, &tmpVal, dataLen)));
+
+    // TODO: size_out from sl_token_manager_get_data is not used nor useful, remove once the API gets updated
+    uint32_t unusedSizeOut;
+    ReturnErrorOnFailure(MapNvm3Error(sl_token_manager_get_data(key, &tmpVal, dataLen, &unusedSizeOut)));
 
     val = tmpVal;
     return CHIP_NO_ERROR;
@@ -111,25 +113,26 @@ CHIP_ERROR WriteConfigValueHelper(SilabsConfig::Key key, const T & val)
     VerifyOrReturnError(SilabsConfig::ValidConfigKey(key), CHIP_ERROR_INVALID_ARGUMENT);
 
     // Write the data
-    return MapNvm3Error(nvm3_writeData(nvm3_defaultHandle, key, &val, sizeof(val)));
+    return MapNvm3Error(sl_token_manager_set_data(key, const_cast<void *>(static_cast<const void *>(&val)), sizeof(T)));
 }
-} // namespace
+
+} // anonymous namespace
 
 // Matter NVM3 space is placed in the silabs default nvm3 section shared with other stack.
 // 'kMatterNvm3KeyDomain' identify the matter nvm3 domain.
-// The NVM3 default section is placed at end of Flash minus 1 page byt the linker file
+// The NVM3 default section is placed at end of Flash minus 1 page (2 pages in series 3) byt the linker file
 // See examples/platform/efr32/ldscripts/efr32mgXX.ld
 
 CHIP_ERROR SilabsConfig::Init()
 {
     // nvm3_Sem is created in nvm3_lockBegin()
-
-    return MapNvm3Error(nvm3_open(nvm3_defaultHandle, nvm3_defaultInit));
+    return MapNvm3Error(sl_token_manager_init());
 }
 
 void SilabsConfig::DeInit()
 {
     vSemaphoreDelete(nvm3_Sem);
+    // TODO: We do not have an API for deinit with CTM, confirm needed and open ticket.
     nvm3_close(nvm3_defaultHandle);
 }
 
@@ -156,15 +159,14 @@ CHIP_ERROR SilabsConfig::ReadConfigValue(Key key, uint64_t & val)
 CHIP_ERROR SilabsConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     CHIP_ERROR err;
-    uint32_t objectType;
-    size_t dataLen;
+    uint32_t dataLen;
 
     outLen = 0;
 
     VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
 
     // Get nvm3 object info.
-    err = MapNvm3Error(nvm3_getObjectInfo(nvm3_defaultHandle, key, &objectType, &dataLen));
+    err = MapNvm3Error(sl_token_manager_get_size(key, &dataLen));
     SuccessOrExit(err);
     VerifyOrExit(dataLen > 0, err = CHIP_ERROR_INVALID_STRING_LENGTH);
 
@@ -175,7 +177,9 @@ CHIP_ERROR SilabsConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize,
         // terminator char).
         VerifyOrExit((bufSize > dataLen), err = CHIP_ERROR_BUFFER_TOO_SMALL);
 
-        err = MapNvm3Error(nvm3_readData(nvm3_defaultHandle, key, buf, dataLen));
+        // TODO: size_out from sl_token_manager_get_data is not used nor useful, remove once the API gets updated
+        uint32_t unusedSizeOut;
+        err = MapNvm3Error(sl_token_manager_get_data(key, buf, dataLen, &unusedSizeOut));
         SuccessOrExit(err);
 
         outLen      = ((dataLen == 1) && (buf[0] == 0)) ? 0 : dataLen;
@@ -191,7 +195,9 @@ CHIP_ERROR SilabsConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize,
         {
             // Read the first byte of the nvm3 string into a tmp var.
             char firstByte;
-            err = MapNvm3Error(nvm3_readData(nvm3_defaultHandle, key, &firstByte, 1));
+            // TODO: size_out from sl_token_manager_get_data is not used nor useful, remove once the API gets updated
+            uint32_t unusedSizeOut;
+            err = MapNvm3Error(sl_token_manager_get_data(key, &firstByte, 1, &unusedSizeOut));
             SuccessOrExit(err);
 
             outLen = (firstByte == 0) ? 0 : dataLen;
@@ -204,16 +210,13 @@ exit:
 
 CHIP_ERROR SilabsConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen, size_t offset)
 {
-    CHIP_ERROR err;
-    uint32_t objectType;
-    size_t dataLen;
+    uint32_t dataLen;
 
     outLen = 0;
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
+    VerifyOrReturnError(ValidConfigKey(key), CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
 
     // Get nvm3 object info.
-    err = MapNvm3Error(nvm3_getObjectInfo(nvm3_defaultHandle, key, &objectType, &dataLen));
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(MapNvm3Error(sl_token_manager_get_size(key, &dataLen)));
 
     if (buf != NULL)
     {
@@ -222,38 +225,34 @@ CHIP_ERROR SilabsConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSi
         size_t maxReadLength = dataLen - offset;
         if (bufSize >= maxReadLength)
         {
-            err = MapNvm3Error(nvm3_readPartialData(nvm3_defaultHandle, key, buf, offset, maxReadLength));
-            SuccessOrExit(err);
+            // TODO: No API currently exist for partial reads in sl_token_manager_interface, replace this when available
+            ReturnErrorOnFailure(MapNvm3Error(nvm3_readPartialData(nvm3_defaultHandle, key, buf, offset, maxReadLength)));
             outLen = maxReadLength;
         }
         else
         {
-            err = MapNvm3Error(nvm3_readPartialData(nvm3_defaultHandle, key, buf, offset, bufSize));
-            SuccessOrExit(err);
+            // TODO: No API currently exist for partial reads in sl_token_manager_interface, replace this when available
+            ReturnErrorOnFailure(MapNvm3Error(nvm3_readPartialData(nvm3_defaultHandle, key, buf, offset, bufSize)));
             // read was successful, but we did not read all the data from the object.
-            err    = CHIP_ERROR_BUFFER_TOO_SMALL;
             outLen = bufSize;
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
         }
     }
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SilabsConfig::ReadConfigValueCounter(uint8_t counterIdx, uint32_t & val)
 {
-    CHIP_ERROR err;
     uint32_t tmpVal = 0;
     Key key         = kMinConfigKey_MatterCounter + counterIdx;
 
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
+    VerifyOrReturnError(ValidConfigKey(key), CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
 
-    // Read bytes into tmp.
-    err = MapNvm3Error(nvm3_readCounter(nvm3_defaultHandle, key, &tmpVal));
-    SuccessOrExit(err);
+    // TODO: size_out from sl_token_manager_get_data is not used nor useful, remove once the API gets updated
+    uint32_t unusedSizeOut;
+    ReturnErrorOnFailure(MapNvm3Error(sl_token_manager_get_data(key, &tmpVal, sizeof(tmpVal), &unusedSizeOut)));
     val = tmpVal;
-
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SilabsConfig::WriteConfigValue(Key key, bool val)
@@ -278,90 +277,63 @@ CHIP_ERROR SilabsConfig::WriteConfigValue(Key key, uint64_t val)
 
 CHIP_ERROR SilabsConfig::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
-    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+    VerifyOrReturnError(ValidConfigKey(key), CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
 
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
+    VerifyOrReturnError(str != NULL, CHIP_ERROR_INVALID_ARGUMENT);
 
-    if (str != NULL)
-    {
-        // Write the string to nvm3 without the terminator char (apart from
-        // empty strings where only the terminator char is stored in nvm3).
-        err = MapNvm3Error(nvm3_writeData(nvm3_defaultHandle, key, str, (strLen > 0) ? strLen : 1));
-        SuccessOrExit(err);
-    }
+    // Write the string to nvm3 without the terminator char (apart from
+    // empty strings where only the terminator char is stored in nvm3).
 
-exit:
-    return err;
+    ReturnErrorOnFailure(MapNvm3Error(
+        sl_token_manager_set_data(key, const_cast<void *>(static_cast<const void *>(str)), (strLen > 0) ? strLen : 1)));
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SilabsConfig::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
-    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
-
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
+    VerifyOrReturnError(ValidConfigKey(key), CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
 
     // Only write NULL pointer if the given size is 0, since in that case, nothing is read at the pointer
-    if ((data != NULL) || (dataLen == 0))
-    {
-        // Write the binary data to nvm3.
-        err = MapNvm3Error(nvm3_writeData(nvm3_defaultHandle, key, data, dataLen));
-        SuccessOrExit(err);
-    }
+    VerifyOrReturnError(((data != NULL) || (dataLen == 0)), CHIP_ERROR_INVALID_ARGUMENT);
 
-exit:
-    return err;
+    ReturnErrorOnFailure(
+        MapNvm3Error(sl_token_manager_set_data(key, const_cast<void *>(static_cast<const void *>(data)), dataLen)));
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SilabsConfig::WriteConfigValueCounter(uint8_t counterIdx, uint32_t val)
 {
-    CHIP_ERROR err;
     Key key = kMinConfigKey_MatterCounter + counterIdx;
 
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
-
-    err = MapNvm3Error(nvm3_writeCounter(nvm3_defaultHandle, key, val));
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    VerifyOrReturnError(ValidConfigKey(key), CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
+    ReturnErrorOnFailure(MapNvm3Error(sl_token_manager_set_data(key, &val, sizeof(val))));
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SilabsConfig::ClearConfigValue(Key key)
 {
-    CHIP_ERROR err;
-
     // Delete the nvm3 object with the given key id.
-    err = MapNvm3Error(nvm3_deleteObject(nvm3_defaultHandle, key));
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    ReturnErrorOnFailure(MapNvm3Error(sl_token_manager_delete_dynamic_token(key)));
+    return CHIP_NO_ERROR;
 }
 
 bool SilabsConfig::ConfigValueExists(Key key)
 {
-    uint32_t objectType;
-    size_t dataLen;
-
-    // Find object with key id.
-    CHIP_ERROR err = MapNvm3Error(nvm3_getObjectInfo(nvm3_defaultHandle, key, &objectType, &dataLen));
-    return (err == CHIP_NO_ERROR);
+    uint32_t dataLen;
+    return (CHIP_NO_ERROR == MapNvm3Error(sl_token_manager_get_size(key, &dataLen)));
 }
 
 bool SilabsConfig::ConfigValueExists(Key key, size_t & dataLen)
 {
-    uint32_t objectType;
-    size_t dLen;
+    uint32_t dLen;
 
     // Find object with key id.
-    CHIP_ERROR err = MapNvm3Error(nvm3_getObjectInfo(nvm3_defaultHandle, key, &objectType, &dLen));
+    VerifyOrReturnValue(CHIP_NO_ERROR == MapNvm3Error(sl_token_manager_get_size(key, &dLen)), false);
 
-    if (err == CHIP_NO_ERROR)
-    {
-        dataLen = dLen;
-    }
-
-    return (err == CHIP_NO_ERROR);
+    dataLen = dLen;
+    return true;
 }
 
 CHIP_ERROR SilabsConfig::FactoryResetConfig(void)
@@ -369,21 +341,12 @@ CHIP_ERROR SilabsConfig::FactoryResetConfig(void)
     // Deletes all nvm3 'Config' type objects.
     // Note- 'Factory' and 'Counter' type nvm3 objects are NOT deleted.
 
-    CHIP_ERROR err;
-
     // Iterate over all the CHIP Config nvm3 records and delete each one...
-    err = ForEachRecord(kMinConfigKey_MatterConfig, kMaxConfigKey_MatterConfig, false,
-                        [](const Key & nvm3Key, const size_t & length) -> CHIP_ERROR {
-                            CHIP_ERROR err2;
-                            // Delete the nvm3 object with the given key id.
-                            err2 = ClearConfigValue(nvm3Key);
-                            SuccessOrExit(err2);
-
-                        exit:
-                            return err2;
-                        });
-
-    return err;
+    return ForEachRecord(kMinConfigKey_MatterConfig, kMaxConfigKey_MatterConfig, false,
+                         [](const Key & nvm3Key, const size_t & length) -> CHIP_ERROR {
+                             // Delete the nvm3 object with the given key id.
+                             return ClearConfigValue(nvm3Key);
+                         });
 }
 
 CHIP_ERROR SilabsConfig::ForEachRecord(Key firstNvm3Key, Key lastNvm3Key, bool addNewRecord, ForEachRecordFunct funct)
@@ -391,16 +354,13 @@ CHIP_ERROR SilabsConfig::ForEachRecord(Key firstNvm3Key, Key lastNvm3Key, bool a
     // Iterates through the specified range of nvm3 object key ids.
     // Invokes the callers CB function when appropriate.
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     for (Key nvm3Key = firstNvm3Key; nvm3Key <= lastNvm3Key; ++nvm3Key)
     {
         Ecode_t nvm3Res;
-        uint32_t objectType;
-        size_t dataLen;
+        uint32_t dataLen;
 
         // Find nvm3 object with current nvm3 iteration key.
-        nvm3Res = nvm3_getObjectInfo(nvm3_defaultHandle, nvm3Key, &objectType, &dataLen);
+        nvm3Res = sl_token_manager_get_size(nvm3Key, &dataLen);
         switch (nvm3Res)
         {
         case ECODE_NVM3_OK:
@@ -408,7 +368,7 @@ CHIP_ERROR SilabsConfig::ForEachRecord(Key firstNvm3Key, Key lastNvm3Key, bool a
             {
                 // Invoke the caller's function
                 // (for retrieve,store,delete,enumerate GroupKey operations).
-                err = funct(nvm3Key, dataLen);
+                ReturnErrorOnFailure(funct(nvm3Key, dataLen));
             }
             break;
         case ECODE_NVM3_ERR_KEY_NOT_FOUND:
@@ -416,19 +376,16 @@ CHIP_ERROR SilabsConfig::ForEachRecord(Key firstNvm3Key, Key lastNvm3Key, bool a
             {
                 // Invoke caller's function
                 // (for add GroupKey operation).
-                err = funct(nvm3Key, dataLen);
+                ReturnErrorOnFailure(funct(nvm3Key, dataLen));
             }
             break;
         default:
-            err = MapNvm3Error(nvm3Res);
+            ReturnErrorOnFailure(MapNvm3Error(nvm3Res));
             break;
         }
-
-        SuccessOrExit(err);
     }
 
-exit:;
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 bool SilabsConfig::ValidConfigKey(Key key)
@@ -459,9 +416,9 @@ void SilabsConfig::RepackNvm3Flash(void)
     // Repack nvm3 flash if nvm3 space < headroom threshold.
     // Note- checking periodically during idle periods should prevent
     // forced repack events on any write operation.
+    // TODO: We do not have an API for repack with CTM, we should use it once available
     nvm3_repack(nvm3_defaultHandle);
 }
-
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip


### PR DESCRIPTION
Cleanup of SilabsConfig and implementation of common token manager API, had to keep some nvm3 calls due to lack of API for those.

#### Testing

Compile -> Provision -> Flash -> Commission -> Toggle

Compared tokens fetched with old and new API, compatibility seems to work.