### PR TITLE
[SL-ONLY]Add cmp datamodel sync api

### DIFF
--- a/examples/platform/silabs/cmp/sl-matter-attribute-storage.cpp
+++ b/examples/platform/silabs/cmp/sl-matter-attribute-storage.cpp
@@ -1,0 +1,54 @@
+/*****************************************************************************
+ * @file sl-matter-attribute-storage.cpp
+ * @brief Link zigbee datamodel attribute changes to Matter attribute storage.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2024 Silicon Laboratories Inc.
+ *www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon
+ *Laboratories Inc. Your use of this software is
+ *governed by the terms of Silicon Labs Master
+ *Software License Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement.
+ *This software is distributed to you in Source Code
+ *format and is governed by the sections of the MSLA
+ *applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#include <app/util/attribute-metadata.h>
+#include <app/util/attribute-table.h>
+#include <lib/support/TypeTraits.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <protocols/interaction_model/StatusCode.h>
+#include <sl-matter-attribute-storage.h>
+#include <sl_component_catalog.h>
+
+namespace {
+// This is called from simplicity_sdk/protocol/zigbee/app/framework/util/attribute-storage.c on ZB attribute write
+// when GENERATED_MULTI_PROTOCOL_ATTRIBUTE_MAPPING and SL_CATALOG_MULTIPROTOCOL_ZIGBEE_MATTER_COMMON_PRESENT are defined.
+extern "C" sl_status_t sli_matter_af_write_attribute(uint16_t endpointId, uint32_t clusterId, uint32_t attributeId,
+                                                     uint8_t * attributeValue, uint8_t type)
+{
+    // All type shall be directly applicable. We expect compilation error if type changes.
+    chip::EndpointId matterEndpointId   = endpointId;
+    chip::ClusterId matterClusterId     = clusterId;
+    chip::AttributeId matterAttributeId = attributeId;
+    EmberAfAttributeType matterDataType = type;
+
+    chip::Protocols::InteractionModel::Status imStatus =
+        emberAfWriteAttribute(matterEndpointId, matterClusterId, matterAttributeId, attributeValue, matterDataType);
+
+    // For sl internal use so we return a known status type to our stack
+    sl_status_t slStatus = SL_STATUS_OK;
+    if (imStatus != chip::Protocols::InteractionModel::Status::Success)
+    {
+        ChipLogError(Zcl, "Failed to write Matter attribute from multiprotocol update. Err:0x%02x", chip::to_underlying(imStatus));
+        slStatus = SL_STATUS_FAIL;
+    }
+
+    return slStatus;
+}
+} // namespace

--- a/examples/platform/silabs/cmp/sl-matter-attribute-storage.h
+++ b/examples/platform/silabs/cmp/sl-matter-attribute-storage.h
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * @file sl-matter-attribute-storage.h
+ * @brief Link zigbee datamodel attribute changes to Matter attribute storage.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#ifndef SL_MATTER_ATTRIBUTE_STORAGE
+#define SL_MATTER_ATTRIBUTE_STORAGE
+
+#include <sl_status.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Writes an attribute value to the Matter attribute storage.
+ *
+ *  *** This is a Silabs internal api. ***
+ *
+ * It exposes the Matter API that writes to the Matter attribute storage to our zigbee datamodel stack,
+ * implemented in C, for multiprotocol usecases, without exposing matter datamodel elements
+ *
+ * This function expect that either the used Zigbee cluster/attributes maps 1 to 1 to the matter counter part
+ * or that the caller translated the Zigbee attribute parameters to Matter attribute parameters.
+ *
+ * The function ultimaly uses those fields in the Matter API to perform the attribute write operation.
+ *
+ * @param endpointId Linked ZB/Matter endpoint identifier.
+ * @param clusterId Linked ZB/Matter cluster identifier.
+ * @param attributeId Linked ZB/Matter attribute identifier.
+ * @param attributeValue Pointer to the attribute value to be written.
+ * @param type The data type of the attribute. Shall match Matters' EmberAfAttributeType
+ * @return sl_status_t Status of the write operation, SL_STATUS_OK if successful, otherwise SL_STATUS_FAIL.
+ */
+sl_status_t sli_matter_af_write_attribute(uint16_t endpointId, uint32_t clusterId, uint32_t attributeId, uint8_t * attributeValue,
+                                          uint8_t type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SL_MATTER_ATTRIBUTE_STORAGE


### PR DESCRIPTION
This PR adds a silabs internal api to sync Zigbee datamodel to matter's on zb attribute write.
sli_matter_af_write_attribute is called from the zigbee stack when the generated multiprotocol mapping is available.

note: file naming conventions doesn't correspond ours/matter's but was decided with the sisdk convention

#### Testing
Commission the Zigbee Matter CMP Light to matter and zigbee network. Update on-off, level-control, color-control attributes for either network and confirm the update is also done one the counterpart datamodel.
