### PR TITLE
[SL-ONLY] Add factory reset call for zigbee

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -897,6 +897,9 @@ void BaseApplication::ScheduleFactoryReset()
         PlatformMgr().HandleServerShuttingDown(); // HandleServerShuttingDown calls OnShutdown() which is only implemented for the
                                                   // basic information cluster it seems. And triggers and Event flush, which is not
                                                   // relevant when there are no fabrics left
+#ifdef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
+        Zigbee::TokenFactoryReset();
+#endif
         ConfigurationMgr().InitiateFactoryReset();
     });
 }


### PR DESCRIPTION
Zigbee data model state for nvm attributes are stored in Tokens. We were not actively clearing those on our factory reset sequence.

This PR added the call for it.

#### Testing
Commission CMP app on Rainier. toggle light on. Factory reset the device with pb0. Confirm light is off after reboot and init

