### PR TITLE
[CSA-CP] : Stop using old ubuntu version (#37870)

### DIFF
--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -28,7 +28,7 @@ jobs:
     zap_regeneration:
         name: ZAP Regeneration
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         container:
             image: ghcr.io/project-chip/chip-build:81
         defaults:

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -33,7 +33,7 @@ jobs:
     zap_templates:
         name: ZAP templates generation
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         container:
             image: ghcr.io/project-chip/chip-build:81
         defaults:


### PR DESCRIPTION
In release_2.6-1.4, the zap_template_generation GitHub action is using a deprecated Ubuntu version for building. 
Was fixed in CSA to use ubuntu-latest. This PR cherry picks it. 
We are only seeing this issue today, as this is the cut-off date for it , according to https://github.com/actions/runner-images/issues/11101

#### Testing

Picks up CSA PR: https://github.com/project-chip/connectedhomeip/pull/37870 
