### PR TITLE
[SL-ONLY] Removed define guards in ApplicationSleepManager

### DIFF
--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
@@ -53,17 +53,13 @@ CHIP_ERROR ApplicationSleepManager::Init()
 void ApplicationSleepManager::OnCommissioningWindowOpened()
 {
     mIsCommissionningWindowOpen = true;
-#if (defined(SLI_SI917) && SLI_SI917 == 1)
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
-#endif // (defined(SLI_SI917) && SLI_SI917 == 1)
 }
 
 void ApplicationSleepManager::OnCommissioningWindowClosed()
 {
     mIsCommissionningWindowOpen = false;
-#if (defined(SLI_SI917) && SLI_SI917 == 1)
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
-#endif // (defined(SLI_SI917) && SLI_SI917 == 1)
 }
 
 void ApplicationSleepManager::OnSubscriptionEstablished(chip::app::ReadHandler & aReadHandler)
@@ -170,19 +166,13 @@ bool ApplicationSleepManager::ProcessKeychainEdgeCase()
 void ApplicationSleepManager::OnEnterActiveMode()
 {
     mIsInActiveMode = true;
-// TEMP-fix: Added SLI_SI917 to delay 9116 NCP sleep till wifi-connection
-#if (defined(SLI_SI917) && SLI_SI917 == 1)
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
-#endif // (defined(SLI_SI917) && SLI_SI917 == 1)
 }
 
 void ApplicationSleepManager::OnEnterIdleMode()
 {
     mIsInActiveMode = false;
-// TEMP-fix: Added SLI_SI917 to delay 9116 NCP sleep till wifi-connection
-#if (defined(SLI_SI917) && SLI_SI917 == 1)
     mWifiSleepManager->VerifyAndTransitionToLowPowerMode();
-#endif // (defined(SLI_SI917) && SLI_SI917 == 1)
 }
 
 void ApplicationSleepManager::OnTransitionToIdle()


### PR DESCRIPTION
ApplicationSleepManager is verifying whether 917 TA module is ready to go sleep, before going to power save mode.
As the RS9116 sleep had issues, #ifdef  **SLI_SI917** were added in the ApplicationSleepManager.cpp to so that RS9116 module will not enter into powersave mode . These ifdefs can be removed now as the RS9116 sleep issue got resolved.


#### Testing

Verified commissioning ,commands and factory reset with EFR BRD4187C + RS9116. 
After power cycle device is not able to connect to AP as ssid and passkey values are incorrect while reading from NVM3.
Jira ticket for the issue - https://jira.silabs.com/browse/MATTER-4930 
