### PR TITLE
[SL-ONLY] Replace javascript exit call with bash exit

### DIFF
--- a/.github/workflows/silabs-require-admin-action-check.yaml
+++ b/.github/workflows/silabs-require-admin-action-check.yaml
@@ -47,7 +47,7 @@ jobs:
             - name: Trigger CI failure
               run: |
                   echo "The sl-require-admin-action label is present. Failing the job."
-                  process.exit(1);
+                  exit 1
               env:
                   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
@@ -94,6 +94,6 @@ jobs:
             - name: Trigger CI failure
               run: |
                   echo "The sl-require-admin-action label cannot be removed. Failing the job."
-                  process.exit(1);
+                  exit 1
               env:
                   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### Description 
Exit call being used was javascript code in a bash context. PR replaces with the correct exit function.

### Tests
See CI failure - doesn't crash anymore.

Failure case : https://github.com/SiliconLabsSoftware/matter_sdk/actions/runs/14764010735/job/41451227702
