### PR TITLE
[SL-UP] Sizeless WriteConfigValueStr fix

### DIFF
--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -284,6 +284,11 @@ CHIP_ERROR SilabsConfig::WriteConfigValueStr(Key key, const char * str, size_t s
 
     if (str != NULL)
     {
+        // Compute the length of the string if not provided.
+        if (strLen == 0)
+        {
+            strLen = strlen(str);
+        }
         // Write the string to nvm3 without the terminator char (apart from
         // empty strings where only the terminator char is stored in nvm3).
         err = MapNvm3Error(nvm3_writeData(nvm3_defaultHandle, key, str, (strLen > 0) ? strLen : 1));

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -229,6 +229,16 @@ public:
     static CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint32_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint64_t val);
+    /** @brief WriteConfigValueStr
+     *  Write a string to the NVM3 storage. This function can be called without providing the length of the string.
+     *  In that case, the length is calculated using strlen() function. Note, this is unsafe as it can lead to buffer
+     *  overflow if the string is not null terminated. We need to support this since the Matter unit test expect
+     *  our API to successfully be able to write a string without providing the length, however we recommend to always
+     *  provide the length of the string.
+     *  @param key The NVM3 key to write the string to.
+     *  @param str The string to write.
+     *  @param strLen The length of the string to write. If 0, the length is calculated using strlen() if the string is not null.
+     */
     static CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen = 0);
     static CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen);
     static CHIP_ERROR WriteConfigValueCounter(uint8_t counterIdx, uint32_t val);

--- a/src/platform/silabs/SilabsConfigCTM.cpp
+++ b/src/platform/silabs/SilabsConfigCTM.cpp
@@ -280,6 +280,11 @@ CHIP_ERROR SilabsConfig::WriteConfigValueStr(Key key, const char * str, size_t s
     VerifyOrReturnError(ValidConfigKey(key), CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
 
     VerifyOrReturnError(str != NULL, CHIP_ERROR_INVALID_ARGUMENT);
+    // Compute the length of the string if not provided.
+    if (strLen == 0)
+    {
+        strLen = strlen(str);
+    }
 
     // Write the string to nvm3 without the terminator char (apart from
     // empty strings where only the terminator char is stored in nvm3).


### PR DESCRIPTION
Added the logic to get the size from the string when not provided in WriteConfigValueStr


#### Testing

Build, flash, commission, toggle
