### PR TITLE
[SL-ONLY] Reduce overall permissions and add input checks

### DIFF
--- a/.github/workflows/silabs-open-csa-pr.yaml
+++ b/.github/workflows/silabs-open-csa-pr.yaml
@@ -1,9 +1,5 @@
 name: Open PR from csa to main
 
-permissions:
-    contents: write
-    pull-requests: write
-
 on:
     workflow_run:
         workflows: ["Daily Sync of the csa branch"]

--- a/.github/workflows/silabs-open-csa-pr.yaml
+++ b/.github/workflows/silabs-open-csa-pr.yaml
@@ -19,6 +19,8 @@ jobs:
                   app-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
                   private-key:
                       ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}
+            - name: Mask the generated token
+              run: echo "::add-mask::${{ steps.generate_token.outputs.token }}"
 
             - uses: actions/checkout@v4
               with:

--- a/.github/workflows/silabs-require-admin-action-check.yaml
+++ b/.github/workflows/silabs-require-admin-action-check.yaml
@@ -30,14 +30,16 @@ jobs:
               with:
                   script: |
                       const prNumber = context.payload.pull_request.number;
+
                       const comment = "The check for `sl-require-admin-action` label CI failure for this job is normal. An admin must do the merge.";
                       const { data: comments } = await github.rest.issues.listComments({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: prNumber,
                       });
-                      const existingComment = comments.find(c => c.body.includes(comment));
-                      if (!existingComment) {
+
+                      const commentExists = comments.some(c => c.body.trim() === comment.trim());
+                      if (!commentExists) {
                         await github.rest.issues.createComment({
                           owner: context.repo.owner,
                           repo: context.repo.repo,
@@ -67,14 +69,16 @@ jobs:
               with:
                   script: |
                       const prNumber = context.payload.pull_request.number;
+
                       const comment = "The `sl-require-admin-action` label cannot be removed once it has been added.";
                       const { data: comments } = await github.rest.issues.listComments({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: prNumber,
                       });
-                      const existingComment = comments.find(c => c.body.includes(comment));
-                      if (!existingComment) {
+
+                      const commentExists = comments.some(c => c.body.trim() === comment.trim());
+                      if (!commentExists) {
                         await github.rest.issues.createComment({
                           owner: context.repo.owner,
                           repo: context.repo.repo,
@@ -88,6 +92,7 @@ jobs:
               with:
                   script: |
                       const prNumber = context.payload.pull_request.number;
+
                       await github.rest.issues.addLabels({
                         owner: context.repo.owner,
                         repo: context.repo.repo,

--- a/.github/workflows/silabs-update-csa.yaml
+++ b/.github/workflows/silabs-update-csa.yaml
@@ -18,6 +18,8 @@ jobs:
                   app-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
                   private-key:
                       ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}
+            - name: Mask the generated token
+              run: echo "::add-mask::${{ steps.generate_token.outputs.token }}"
 
             - name: Checkout matter_sdk::csa branch
               uses: actions/checkout@v4

--- a/.github/workflows/silabs-update-csa.yaml
+++ b/.github/workflows/silabs-update-csa.yaml
@@ -1,8 +1,5 @@
 name: Daily Sync of the csa branch
 
-permissions:
-    contents: write
-
 on:
     schedule:
         - cron: "0 0 * * *" # Runs once a day at midnight


### PR DESCRIPTION
### Description
PR aims to clean up silabs specific workflows to remove unnecessary permissions and re-enforce string matching for the admin check action

- Remove unnecessary permissions given to the GitHub token.
- Make the string check much more stringent to avoid any shenanigans if a user were to comment the required string with additional text.
- Mask the generated token to avoid it being printed.

### Tests
CI and automation once merge - should not have any impacts.