### PR TITLE
fix Use of a broken or weak cryptographic algorithm

### DIFF
--- a/scripts/tools/nxp/factory_data_generator/generate.py
+++ b/scripts/tools/nxp/factory_data_generator/generate.py
@@ -167,8 +167,11 @@ class KlvGenerator:
                 size = len(fullContent)
                 logging.info("(After padding) Size of generated binary is: {} bytes".format(size))
                 from Crypto.Cipher import AES
-                cipher = AES.new(bytes.fromhex(aes_key), AES.MODE_ECB)
+                from Crypto.Random import get_random_bytes
+                iv = get_random_bytes(16)  # Generate a random 16-byte IV
+                cipher = AES.new(bytes.fromhex(aes_key), AES.MODE_CBC, iv)
                 fullContentCipher = cipher.encrypt(fullContent)
+                fullContentCipher = iv + fullContentCipher  # Prepend IV to the ciphertext
 
                 # Add 4 bytes of hashing to generated binary to check for integrity
                 hashing = hashlib.sha256(fullContent).hexdigest()


### PR DESCRIPTION
https://github.com/SiliconLabsSoftware/matter_sdk/blob/1dfb66ac71b66e870fda09812242c88257256dfe/scripts/tools/nxp/factory_data_generator/generate.py#L171-L171

fix the issue, we will replace the use of `AES.MODE_ECB` with a more secure mode, such as `AES.MODE_CBC`. CBC mode requires an initialization vector (IV), which should be randomly generated for each encryption operation. The IV must be stored or transmitted alongside the ciphertext to allow decryption, but it does not need to be kept secret.

Steps to fix:
1. Replace `AES.MODE_ECB` with `AES.MODE_CBC`.
2. Generate a random IV using `Crypto.Random.get_random_bytes`.
3. Prepend the IV to the ciphertext so it can be used during decryption.
4. Update the code to handle the IV appropriately.

Using broken or weak cryptographic algorithms can leave data vulnerable to being decrypted or forged by an attacker. Many cryptographic algorithms provided by cryptography libraries are known to be weak, or flawed. Using such an algorithm means that encrypted or hashed data is less secure than it appears to be. This query alerts on any use of a weak cryptographic algorithm, that is not a hashing algorithm. Use of broken or weak cryptographic hash functions are handled by the `py/weak-sensitive-data-hashing` query.

## POC
The following code uses the `pycryptodome` library to encrypt some secret data. When you create a cipher using pycryptodome you must specify the encryption algorithm to use. The first example uses DES, which is an older algorithm that is now considered weak. The second uses AES, which is a stronger modern algorithm.
```py
from Crypto.Cipher import DES, AES

cipher = DES.new(SECRET_KEY)

def send_encrypted(channel, message):
    channel.send(cipher.encrypt(message)) # BAD: weak encryption


cipher = AES.new(SECRET_KEY)

def send_encrypted(channel, message):
    channel.send(cipher.encrypt(message)) # GOOD: strong encryption
```
## References
[Approved Security Functions](http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf)
[Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf)
[Rule - Use strong approved cryptographic algorithms](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#rule---use-strong-approved-authenticated-encryption)
[CWE-327](https://cwe.mitre.org/data/definitions/327.html)
