### PR TITLE
[SL-ONLY] Fixing the build issue with the refrigerator app

### DIFF
--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -113,7 +113,7 @@ CHIP_ERROR RefrigeratorDoorEventHandler(int argc, char ** argv)
     int value = std::stoi(argv[0]); // Safe to use now, as we validated the input earlier
 
     RefrigeratorAlarmEventData * data = Platform::New<RefrigeratorAlarmEventData>();
-    data->eventId                     = Events::Notify::Id;
+    data->eventId                     = chip::app::Clusters::RefrigeratorAlarm::Events::Notify::Id;
     data->doorState                   = static_cast<AlarmBitmap>(value);
 
     DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -163,7 +163,7 @@ void EventWorkerFunction(intptr_t context)
 
     switch (data->eventId)
     {
-    case Events::Notify::Id: {
+    case chip::app::Clusters::RefrigeratorAlarm::Events::Notify::Id: {
         RefrigeratorAlarmEventData * alarmData = reinterpret_cast<RefrigeratorAlarmEventData *>(context);
         RefrigeratorAlarmServer::Instance().SetStateValue(kRefEndpointId, alarmData->doorState);
         break;


### PR DESCRIPTION
With the zap update all the clusters are having there own EventIds.h file. Hence Event::Notify::Id is available in RefrigeratorAlarm, RefrigeratorAndTemperatureControlledCabinetMode and TemperatureControl which is throwing the error 'Events' is ambiguous. 

Fixing it by specfying the Id which needs to be updated. 

#### Testing
Tested locally on 917 SoC shell command.
