### PR TITLE
[SL-UP]Support sl_main and remove SL_POWER_MANAGER_EM1 workwaround

### DIFF
--- a/examples/platform/silabs/main.cpp
+++ b/examples/platform/silabs/main.cpp
@@ -29,7 +29,7 @@
 
 using TimeTraceOperation = chip::Tracing::Silabs::TimeTraceOperation;
 
-// This is a User definable functionin sl_main context, called by sl_main_init before the kernel is started
+// This is a User definable function in sl_main context, called by sl_main_init before the kernel is started
 void app_init_early(void)
 {
     SILABS_TRACE_BEGIN(chip::Tracing::Silabs::TimeTraceOperation::kBootup);

--- a/examples/platform/silabs/main.cpp
+++ b/examples/platform/silabs/main.cpp
@@ -16,22 +16,44 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "sl_component_catalog.h"
+
+// SL-TEMP: GN cannot use sl_main until it supports sisdk 2025.6
+// sl_system_init is always used for 917 soc
+#if (SL_MATTER_GN_BUILD == 1 || SLI_SI91X_MCU_INTERFACE)
 #include "sl_system_init.h"
-#include "sl_system_kernel.h"
+#else
+#include "sl_main_init.h"
+#endif
 #include <MatterConfig.h>
 #include <platform/silabs/tracing/SilabsTracingMacros.h>
 
 using TimeTraceOperation = chip::Tracing::Silabs::TimeTraceOperation;
 
-int main(void)
+// This is a User definable functionin sl_main context, called by sl_main_init before the kernel is started
+void app_init_early(void)
 {
     SILABS_TRACE_BEGIN(chip::Tracing::Silabs::TimeTraceOperation::kBootup);
     SILABS_TRACE_BEGIN(chip::Tracing::Silabs::TimeTraceOperation::kSilabsInit);
-    sl_system_init();
+}
+
+// This is a User definable function, in sl_main context, called by start_task_handler once the silabs platform is fully
+// initialized.
+void app_init(void)
+{
     SILABS_TRACE_END(chip::Tracing::Silabs::TimeTraceOperation::kSilabsInit);
     SILABS_TRACE_BEGIN(chip::Tracing::Silabs::TimeTraceOperation::kMatterInit);
-    // Initialize the application. For example, create periodic timer(s) or
-    // task(s) if the kernel is present.
+    // Initialize the matter application. For example, create periodic timer(s) or
+    // task(s).
     SilabsMatterConfig::AppInit();
 }
+
+// SL-TEMP: GN cannot use sl_main until it supports sisdk 2025.6
+// sl_system_init is always used for 917 soc
+#if (SL_MATTER_GN_BUILD == 1 || SLI_SI91X_MCU_INTERFACE)
+int main(void)
+{
+    app_init_early();
+    sl_system_init();
+    app_init();
+}
+#endif

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -27,7 +27,11 @@
 #include "sl_se_manager_types.h"
 #include <sl_se_manager_extmem.h>
 #endif // _SILICON_LABS_32B_SERIES_2
+
+// SL-TEMP: GN cannot use sl_main until it supports sisdk 2025.6 Use sl_system
+#if (SL_MATTER_GN_BUILD == 1)
 #include "sl_system_kernel.h"
+#endif
 
 #ifdef ENABLE_WSTK_LEDS
 extern "C" {
@@ -225,7 +229,10 @@ CHIP_ERROR SilabsPlatform::ToggleLed(uint8_t led)
 
 void SilabsPlatform::StartScheduler()
 {
+// SL-TEMP: GN cannot use sl_main until it supports sisdk 2025.6 Use sl_system
+#if (SL_MATTER_GN_BUILD == 1)
     sl_system_kernel_start();
+#endif
 }
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT


### PR DESCRIPTION
Add support for sl_main for EFR32/SIMG301 platform inits in place of the deprecated sl_system.
This change only takes place with slc. 
sl_main does not apply to 917.
GN cannot use it either until it supports sisdk 2025.6
remove SL_POWER_MANAGER_EM1 workaround as it is not needed anymore with 2025.6

#### Testing
Build mg26 and 917 lighting app with gn
Build mg24, simg301 and 917 lighting app with SLC. 
Manually tested commissioning and light control with the MG24