### PR TITLE
[CSA-CP] Adds fix for integer overflow in TicksToMS function

### DIFF
--- a/src/lwip/freertos/sys_arch.c
+++ b/src/lwip/freertos/sys_arch.c
@@ -58,7 +58,7 @@ static uint8_t gTCPIPMsgQueueStorage[SYS_MESG_QUEUE_LENGTH * sizeof(void *)];
 
 static inline u32_t TicksToMS(TickType_t ticks)
 {
-    return (ticks * 1000) / configTICK_RATE_HZ;
+    return ((uint64_t) ticks * 1000) / configTICK_RATE_HZ;
 }
 
 void sys_init(void)

--- a/src/lwip/freertos/sys_arch.c
+++ b/src/lwip/freertos/sys_arch.c
@@ -58,6 +58,7 @@ static uint8_t gTCPIPMsgQueueStorage[SYS_MESG_QUEUE_LENGTH * sizeof(void *)];
 
 static inline u32_t TicksToMS(TickType_t ticks)
 {
+    // Cast to uint64_t to prevent integer overflow when multiplying ticks by 1000.
     return ((uint64_t) ticks * 1000) / configTICK_RATE_HZ;
 }
 


### PR DESCRIPTION
Cherry Pick of https://github.com/project-chip/connectedhomeip/pull/38757

#### Description
Adds fix for integer overflow in LWIP function which causes timer to not work post 70mins.

#### Testing
Manually tested using logs of LWIP timers with CSA PR

