### PR TITLE
[CSA-CP][ACL][WriteClient] Encoding non-empty ReplaceAll when writing to AccessControl Cluster

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -232,7 +232,7 @@ CHIP_ERROR AccessControl::CreateEntry(const SubjectDescriptor * subjectDescripto
 
     VerifyOrReturnError((count + 1) <= maxCount, CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    ReturnErrorCodeIf(!IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
 
     size_t i = 0;
     ReturnErrorOnFailure(mDelegate->CreateEntry(&i, entry, &fabric));
@@ -250,7 +250,7 @@ CHIP_ERROR AccessControl::UpdateEntry(const SubjectDescriptor * subjectDescripto
                                       const Entry & entry)
 {
     VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
-    ReturnErrorCodeIf(!IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(mDelegate->UpdateEntry(index, entry, &fabric));
     NotifyEntryChanged(subjectDescriptor, fabric, index, &entry, EntryListener::ChangeType::kUpdated);
     return CHIP_NO_ERROR;
@@ -624,7 +624,7 @@ exit:
 }
 #endif
 
-bool AccessControl::IsValid(const Entry & entry)
+bool AccessControl::Entry::IsValid() const
 {
     const char * log = "unexpected error";
     IgnoreUnusedVariable(log); // logging may be disabled
@@ -636,11 +636,11 @@ bool AccessControl::IsValid(const Entry & entry)
     size_t targetCount      = 0;
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    SuccessOrExit(err = entry.GetAuthMode(authMode));
-    SuccessOrExit(err = entry.GetFabricIndex(fabricIndex));
-    SuccessOrExit(err = entry.GetPrivilege(privilege));
-    SuccessOrExit(err = entry.GetSubjectCount(subjectCount));
-    SuccessOrExit(err = entry.GetTargetCount(targetCount));
+    SuccessOrExit(err = GetAuthMode(authMode));
+    SuccessOrExit(err = GetFabricIndex(fabricIndex));
+    SuccessOrExit(err = GetPrivilege(privilege));
+    SuccessOrExit(err = GetSubjectCount(subjectCount));
+    SuccessOrExit(err = GetTargetCount(targetCount));
 
 #if CHIP_CONFIG_ACCESS_CONTROL_POLICY_LOGGING_VERBOSITY > 1
     ChipLogProgress(DataManagement, "AccessControl: validating f=%u p=%c a=%c s=%d t=%d", fabricIndex,
@@ -663,7 +663,7 @@ bool AccessControl::IsValid(const Entry & entry)
     for (size_t i = 0; i < subjectCount; ++i)
     {
         NodeId subject;
-        SuccessOrExit(err = entry.GetSubject(i, subject));
+        SuccessOrExit(err = GetSubject(i, subject));
         const bool kIsCase  = authMode == AuthMode::kCase;
         const bool kIsGroup = authMode == AuthMode::kGroup;
 #if CHIP_CONFIG_ACCESS_CONTROL_POLICY_LOGGING_VERBOSITY > 1
@@ -675,7 +675,7 @@ bool AccessControl::IsValid(const Entry & entry)
     for (size_t i = 0; i < targetCount; ++i)
     {
         Entry::Target target;
-        SuccessOrExit(err = entry.GetTarget(i, target));
+        SuccessOrExit(err = GetTarget(i, target));
         const bool kHasCluster    = target.flags & Entry::Target::kCluster;
         const bool kHasEndpoint   = target.flags & Entry::Target::kEndpoint;
         const bool kHasDeviceType = target.flags & Entry::Target::kDeviceType;

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -233,6 +233,13 @@ public:
             mDelegate = &mDefaultDelegate.get();
         }
 
+        /**
+         * Validate whether an ACL Entry is valid and complies with all defined constraints.
+         *
+         * @retval true if all the fields within the Entry are valid and compliant.
+         */
+        bool IsValid() const;
+
     private:
         static Global<Delegate> mDefaultDelegate;
         Delegate * mDelegate = &mDefaultDelegate.get();
@@ -501,7 +508,7 @@ public:
      */
     CHIP_ERROR CreateEntry(size_t * index, const Entry & entry, FabricIndex * fabricIndex = nullptr)
     {
-        ReturnErrorCodeIf(!IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->CreateEntry(index, entry, fabricIndex);
     }
@@ -551,7 +558,7 @@ public:
      */
     CHIP_ERROR UpdateEntry(size_t index, const Entry & entry, const FabricIndex * fabricIndex = nullptr)
     {
-        ReturnErrorCodeIf(!IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->UpdateEntry(index, entry, fabricIndex);
     }
@@ -668,8 +675,6 @@ public:
 
 private:
     bool IsInitialized() const { return (mDelegate != nullptr); }
-
-    bool IsValid(const Entry & entry);
 
     void NotifyEntryChanged(const SubjectDescriptor * subjectDescriptor, FabricIndex fabric, size_t index, const Entry * entry,
                             EntryListener::ChangeType changeType);

--- a/src/app/MessageDef/AttributeDataIB.h
+++ b/src/app/MessageDef/AttributeDataIB.h
@@ -105,6 +105,17 @@ public:
      */
     CHIP_ERROR EndOfAttributeDataIB();
 
+    /**
+     *  @brief Get number of bytes required in the buffer to allow EndOfAttributeDataIB() to succeed.
+     *
+     *  @return Expected number of bytes required in the buffer to successfully execute EndOfAttributeDataIB()
+     */
+    static constexpr uint16_t GetSizeToEndAttributeDataIB()
+    {
+        uint16_t kEndOfAttributeDataIBSize = 1;
+        return kEndOfAttributeDataIBSize;
+    };
+
 private:
     AttributePathIB::Builder mPath;
 };

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -247,6 +247,7 @@ CHIP_ERROR WriteClient::PutSinglePreencodedAttributeWritePayload(const chip::app
     return err;
 }
 
+// TODO #38287 Add Unit Tests for PutPreencodedAttribute and for TryPutPreencodedAttributeWritePayloadIntoList.
 CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath & attributePath, const TLV::TLVReader & data)
 {
     ReturnErrorOnFailure(EnsureMessage());
@@ -256,23 +257,66 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
     {
         TLV::TLVReader dataReader;
         TLV::TLVReader valueReader;
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
+        uint16_t encodedItemCount      = 0;
         ConcreteDataAttributePath path = attributePath;
 
+        // By convention, and as tested against all cluster servers, clients have historically encoded an empty list as a
+        // ReplaceAll, (i.e. the entire attribute contents are cleared before appending the new list’s items). However, this
+        // behavior can be problematic, especially for the ACL attribute; sending an empty ReplaceAll list can cause clients to be
+        // locked out. This is because the empty list first deletes all existing ACL entries, and if the new (malformed) ACL is
+        // rejected, the server is left without valid (or with incomplete) ACLs.
+        // SOLUTION: we treat ACL as an exception and avoid encoding an empty ReplaceAll list. Instead, we pack as many ACL entries
+        // as possible into the ReplaceAll list, and send  any remaining entries in subsequent chunks are part of the AppendItem
+        // list operation.
+        // TODO (#38270): Generalize this behavior; send a non-empty ReplaceAll list for all clusters in a later Matter version and
+        // enforce all clusters to support it in testing and in certification.
+        bool encodeEmptyListAsReplaceAll = !(path.mClusterId == Clusters::AccessControl::Id);
+
+        if (encodeEmptyListAsReplaceAll)
+        {
+            ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, DataModel::List<uint8_t>()));
+        }
+        else
+        {
+
+            dataReader.Init(data);
+            dataReader.OpenContainer(valueReader);
+            bool chunkingNeeded = false;
+
+            // Encode as many list-items as possible into a single AttributeDataIB, which will be included in a single
+            // WriteRequestMessage chunk.
+            ReturnErrorOnFailure(
+                TryPutPreencodedAttributeWritePayloadIntoList(path, valueReader, chunkingNeeded, encodedItemCount));
+
+            // If all list items fit perfectly into a single AttributeDataIB, there is no need for any `append-item` or chunking,
+            // and we can exit early.
+            VerifyOrReturnError(chunkingNeeded, CHIP_NO_ERROR);
+
+            // Start a new WriteRequest chunk, as there are still remaining list items to encode. These remaining items will be
+            // appended one by one, each into its own AttributeDataIB. Unlike the first chunk (which contains only one
+            // AttributeDataIB), subsequent chunks may contain multiple AttributeDataIBs if space allows it.
+            ReturnErrorOnFailure(StartNewMessage());
+        }
+        path.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;
+
+        // We will restart iterating on ValueReader, only appending the items we need to append.
         dataReader.Init(data);
         dataReader.OpenContainer(valueReader);
 
-        // Encode an empty list for the chunking protocol.
-        ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, DataModel::List<uint8_t>()));
+        CHIP_ERROR err            = CHIP_NO_ERROR;
+        uint16_t currentItemCount = 0;
 
-        if (err == CHIP_NO_ERROR)
+        while ((err = valueReader.Next()) == CHIP_NO_ERROR)
         {
-            path.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;
-            while ((err = valueReader.Next()) == CHIP_NO_ERROR)
+            currentItemCount++;
+
+            if (currentItemCount <= encodedItemCount)
             {
-                ReturnErrorOnFailure(PutSinglePreencodedAttributeWritePayload(path, valueReader));
+                // Element already encoded via `TryPutPreencodedAttributeWritePayloadIntoList`
+                continue;
             }
+
+            ReturnErrorOnFailure(PutSinglePreencodedAttributeWritePayload(path, valueReader));
         }
 
         if (err == CHIP_END_OF_TLV)
@@ -281,8 +325,96 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
         }
         return err;
     }
+
     // We are writing a non-list attribute, or we are writing a single element of a list.
     return PutSinglePreencodedAttributeWritePayload(attributePath, data);
+}
+
+CHIP_ERROR WriteClient::EnsureListStarted(const ConcreteDataAttributePath & attributePath)
+{
+    TLV::TLVWriter backupWriter;
+    mWriteRequestBuilder.GetWriteRequests().Checkpoint(backupWriter);
+
+    CHIP_ERROR err = TryToStartList(attributePath);
+    if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
+    {
+        // If it failed with no memory, then we create a new chunk for it.
+        mWriteRequestBuilder.GetWriteRequests().Rollback(backupWriter);
+        ReturnErrorOnFailure(StartNewMessage());
+        ReturnErrorOnFailure(TryToStartList(attributePath));
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WriteClient::TryToStartList(const ConcreteDataAttributePath & attributePath)
+{
+
+    // TODO (#38414) : Move reservation/unreservtion of Buffer for TLV Writing to AttributeDataIB Builder instead of WriteClient
+    ReturnErrorOnFailure(mMessageWriter.ReserveBuffer(kReservedSizeForEndOfListAttributeIB));
+
+    ReturnErrorOnFailure(PrepareAttributeIB(attributePath));
+
+    TLV::TLVWriter * writer = GetAttributeDataIBTLVWriter();
+    VerifyOrReturnError(writer != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    TLV::TLVType outerType;
+    ReturnErrorOnFailure(writer->StartContainer(TLV::ContextTag(AttributeDataIB::Tag::kData), TLV::kTLVType_Array, outerType));
+
+    VerifyOrReturnError(outerType == kAttributeDataIBType, CHIP_ERROR_INCORRECT_STATE);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WriteClient::EnsureListEnded()
+{
+    TLV::TLVWriter * writer = GetAttributeDataIBTLVWriter();
+    VerifyOrReturnError(writer != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    // Undo the reservation made in EnsureListStarted() to free up space for the EndOfContainer TLV Elements
+    // (for both the List and AttributeDataIB).
+    ReturnErrorOnFailure(writer->UnreserveBuffer(kReservedSizeForEndOfListAttributeIB));
+    ReturnErrorOnFailure(writer->EndContainer(kAttributeDataIBType));
+
+    return FinishAttributeIB();
+}
+
+CHIP_ERROR
+WriteClient::TryPutPreencodedAttributeWritePayloadIntoList(const ConcreteDataAttributePath & attributePath,
+                                                           TLV::TLVReader & valueReader, bool & outChunkingNeeded,
+                                                           ListIndex & outEncodedItemCount)
+{
+
+    ReturnErrorOnFailure(EnsureListStarted(attributePath));
+
+    AttributeDataIB::Builder & attributeDataIB = mWriteRequestBuilder.GetWriteRequests().GetAttributeDataIBBuilder();
+    TLV::TLVWriter backupWriter;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    outEncodedItemCount = 0;
+
+    while ((err = valueReader.Next()) == CHIP_NO_ERROR)
+    {
+        // Try to put all the list items into the list we just started, until we either run out of items
+        // or run out of space.
+        // Make sure that if we run out of space we don't leave a partially-encoded list item around.
+        attributeDataIB.Checkpoint(backupWriter);
+        err = attributeDataIB.GetWriter()->CopyElement(TLV::AnonymousTag(), valueReader);
+
+        if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
+        {
+            // Rollback through the attributeDataIB, which also resets the Builder's error state.
+            // This returns the object to the state it was in before attempting to copy the element.
+            attributeDataIB.Rollback(backupWriter);
+            outChunkingNeeded = true;
+            err               = CHIP_NO_ERROR;
+            break;
+        }
+        ReturnErrorOnFailure(err);
+        outEncodedItemCount++;
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV || err == CHIP_NO_ERROR, err);
+
+    return EnsureListEnded();
 }
 
 const char * WriteClient::GetStateStr() const

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributePathParams.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelTimeout.h>
@@ -162,9 +164,15 @@ public:
 
     /**
      *  Encode a possibly-chunked list attribute value.  Will create a new chunk when necessary.
+     *
+     * Note: As an exception, for attributes in the Access Control cluster, this method will attempt to encode as many list items
+     * as possible into a single AttributeDataIB with Change set to REPLACE.
+     * If the list is too large, the WriteRequest will be chunked and remaining items will be encoded as individual AttributeDataIBs
+     * with Change set to ADD, chunking them as needed.
+     *
      */
     template <class T>
-    CHIP_ERROR EncodeAttribute(const AttributePathParams & attributePath, const DataModel::List<T> & value,
+    CHIP_ERROR EncodeAttribute(const AttributePathParams & attributePath, const DataModel::List<T> & listValue,
                                const Optional<DataVersion> & aDataVersion = NullOptional)
     {
         // Here, we are using kInvalidEndpointId for missing endpoint id, which is used when sending group write requests.
@@ -172,15 +180,50 @@ public:
             ConcreteDataAttributePath(attributePath.HasWildcardEndpointId() ? kInvalidEndpointId : attributePath.mEndpointId,
                                       attributePath.mClusterId, attributePath.mAttributeId, aDataVersion);
 
+        ListIndex firstItemToAppendIndex = 0;
+        uint16_t encodedItemCount        = 0;
+        bool chunkingNeeded              = false;
+
+        // By convention, and as tested against all cluster servers, clients have historically encoded an empty list as a
+        // ReplaceAll, (i.e. the entire attribute contents are cleared before appending the new list’s items). However, this
+        // behavior can be problematic, especially for the ACL attribute; sending an empty ReplaceAll list can cause clients to be
+        // locked out. This is because the empty list first deletes all existing ACL entries, and if the new (malformed) ACL is
+        // rejected, the server is left without valid (or with incomplete) ACLs.
+        // SOLUTION: we treat ACL as an exception and avoid encoding an empty ReplaceAll list. Instead, we pack as many ACL entries
+        // as possible into the ReplaceAll list, and send  any remaining entries in subsequent chunks are part of the AppendItem
+        // list operation.
+        // TODO (#38270): Generalize this behavior; send a non-empty ReplaceAll list for all clusters in a later Matter version and
+        // enforce all clusters to support it in testing and in certification.
+        bool encodeEmptyListAsReplaceAll = !(path.mClusterId == Clusters::AccessControl::Id);
+
         ReturnErrorOnFailure(EnsureMessage());
 
-        // Encode an empty list for the chunking protocol.
-        ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, DataModel::List<uint8_t>()));
+        if (encodeEmptyListAsReplaceAll)
+        {
+            ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, DataModel::List<uint8_t>()));
+        }
+        else
+        {
+            // Encode as many list-items as possible into a single AttributeDataIB, which will be included in a single
+            // WriteRequestMessage chunk.
+            ReturnErrorOnFailure(TryEncodeListIntoSingleAttributeDataIB(path, listValue, chunkingNeeded, encodedItemCount));
+
+            // If all list items fit perfectly into a single AttributeDataIB, there is no need for any `append-item` or chunking,
+            // and we can exit early.
+            VerifyOrReturnError(chunkingNeeded, CHIP_NO_ERROR);
+
+            // Start a new WriteRequest chunk, as there are still remaining list items to encode. These remaining items will be
+            // appended one by one, each into its own AttributeDataIB. Unlike the first chunk (which contains only one
+            // AttributeDataIB), subsequent chunks may contain multiple AttributeDataIBs if space allows it.
+            ReturnErrorOnFailure(StartNewMessage());
+            firstItemToAppendIndex = encodedItemCount;
+        }
 
         path.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;
-        for (size_t i = 0; i < value.size(); i++)
+
+        for (ListIndex i = firstItemToAppendIndex; i < listValue.size(); i++)
         {
-            ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, value.data()[i]));
+            ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, listValue[i]));
         }
 
         return CHIP_NO_ERROR;
@@ -228,10 +271,17 @@ public:
      */
     CHIP_ERROR SendWriteRequest(const SessionHandle & session, System::Clock::Timeout timeout = System::Clock::kZero);
 
+    /**
+     *  Returns true if the WriteRequest is Chunked.
+     *  WARNING: This method is only used for UnitTests. It should only be called AFTER a call
+     * EncodeAttribute/PutPreencodedAttribute AND BEFORE a call to SendWriteRequest(); only during this window does
+     * "!mChunks.IsNull()" reliably indicate that the WriteRequest is chunked.
+     */
+    bool IsWriteRequestChunked() const { return !mChunks.IsNull(); };
+
 private:
     friend class TestWriteInteraction;
     friend class InteractionModelEngine;
-
     enum class State
     {
         Initialized = 0,     // The client has been initialized
@@ -250,6 +300,32 @@ private:
     CHIP_ERROR ProcessWriteResponseMessage(System::PacketBufferHandle && payload);
     CHIP_ERROR ProcessAttributeStatusIB(AttributeStatusIB::Parser & aAttributeStatusIB);
     const char * GetStateStr() const;
+
+    // TODO (#38453) Clarify and fix the API contract of EnsureListStarted, TryToStartList and EnsureListEnded; in the case of
+    // encoding failure, should we just undo buffer reservation? rollback to a checkpoint that we create within EnsureListStarted?
+    // or just leave the WriteClient in a bad state.
+    /**
+     *     A wrapper for TryToStartList which will start a new chunk when TryToStartList fails with CHIP_ERROR_NO_MEMORY or
+     * CHIP_ERROR_BUFFER_TOO_SMALL.
+     *
+     * @note Must always be followed by a call to EnsureListEnded(), to undo buffer reservation that took place within
+     * it, and properly close TLV Containers.
+     */
+    CHIP_ERROR EnsureListStarted(const ConcreteDataAttributePath & attributePath);
+
+    /**
+     * Prepare the Encoding of an Attribute with List DataType into an AttributeDataIB.
+     *
+     */
+    CHIP_ERROR TryToStartList(const ConcreteDataAttributePath & attributePath);
+
+    /**
+     * Complete the Encoding of an Attribute with List DataType into an AttributeDataIB.
+     *
+     * @note Must always be called after EnsureListStarted(), even in cases of encoding failures; to undo buffer reservation that
+     * took place in EnsureListStarted.
+     */
+    CHIP_ERROR EnsureListEnded();
 
     /**
      *  Encode an attribute value that can be directly encoded using DataModel::Encode.
@@ -281,9 +357,56 @@ private:
         return CHIP_NO_ERROR;
     }
 
+    template <class T>
+    CHIP_ERROR TryEncodeListIntoSingleAttributeDataIB(const ConcreteDataAttributePath & attributePath,
+                                                      const DataModel::List<T> & list, bool & outChunkingNeeded,
+                                                      uint16_t & outEncodedItemCount)
+    {
+        ReturnErrorOnFailure(EnsureListStarted(attributePath));
+
+        AttributeDataIB::Builder & attributeDataIB = mWriteRequestBuilder.GetWriteRequests().GetAttributeDataIBBuilder();
+        TLV::TLVWriter backupWriter;
+        outEncodedItemCount = 0;
+
+        for (auto & item : list)
+        {
+            // Try to put all the list items into the list we just started, until we either run out of items
+            // or run out of space.
+            // Make sure that if we run out of space we don't leave a partially-encoded list item around.
+            attributeDataIB.Checkpoint(backupWriter);
+            CHIP_ERROR err = CHIP_NO_ERROR;
+
+            if constexpr (DataModel::IsFabricScoped<T>::value)
+            {
+                err = DataModel::EncodeForWrite(*attributeDataIB.GetWriter(), TLV::AnonymousTag(), item);
+            }
+            else
+            {
+                err = DataModel::Encode(*attributeDataIB.GetWriter(), TLV::AnonymousTag(), item);
+            }
+
+            if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
+            {
+                // Rollback through the attributeDataIB, which also resets the Builder's error state.
+                // This returns the object to the state it was in before attempting to encode the list item.
+                attributeDataIB.Rollback(backupWriter);
+                outChunkingNeeded = true;
+                break;
+            }
+            ReturnErrorOnFailure(err);
+            outEncodedItemCount++;
+        }
+
+        return EnsureListEnded();
+    }
+
     /**
      * A wrapper for TryEncodeSingleAttributeDataIB which will start a new chunk when failed with CHIP_ERROR_NO_MEMORY or
      * CHIP_ERROR_BUFFER_TOO_SMALL.
+     *
+     * NOTE: This method must not be used for encoding non-empty lists, even if the template accepts a list type.
+     * For such cases, use TryEncodeListIntoSingleAttributeDataIB as part of a suitable encoding strategy,
+     * since it has a different contract and has different usage expectations.
      */
     template <class T>
     CHIP_ERROR EncodeSingleAttributeDataIB(const ConcreteDataAttributePath & attributePath, const T & value)
@@ -310,7 +433,7 @@ private:
     }
 
     /**
-     * Encode a preencoded attribute data, returns TLV encode error if the ramaining space of current chunk is too small for the
+     * Encode a preencoded attribute data, returns TLV encode error if the remaining space of current chunk is too small for the
      * AttributeDataIB.
      */
     CHIP_ERROR TryPutSinglePreencodedAttributeWritePayload(const ConcreteDataAttributePath & attributePath,
@@ -322,6 +445,13 @@ private:
     CHIP_ERROR PutSinglePreencodedAttributeWritePayload(const ConcreteDataAttributePath & attributePath,
                                                         const TLV::TLVReader & data);
 
+    /**
+     * Encodes preencoded attribute data into a list, that will be decoded by cluster servers as a REPLACE Change.
+     * Returns outChunkingNeeded = true if it was not possible to fit all the data into a single list.
+     */
+    CHIP_ERROR TryPutPreencodedAttributeWritePayloadIntoList(const chip::app::ConcreteDataAttributePath & attributePath,
+                                                             TLV::TLVReader & valueReader, bool & outChunkingNeeded,
+                                                             uint16_t & outEncodedItemCount);
     CHIP_ERROR EnsureMessage();
 
     /**
@@ -423,6 +553,11 @@ private:
     static constexpr uint16_t kReservedSizeForTLVEncodingOverhead = kReservedSizeForIMRevision + kReservedSizeForMoreChunksFlag +
         kReservedSizeForEndOfContainer + kReservedSizeForEndOfContainer;
     bool mHasDataVersion = false;
+
+    static constexpr uint16_t kReservedSizeForEndOfListAttributeIB =
+        kReservedSizeForEndOfContainer + AttributeDataIB::Builder::GetSizeToEndAttributeDataIB();
+
+    static constexpr TLV::TLVType kAttributeDataIBType = TLV::kTLVType_Structure;
 };
 
 } // namespace app

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -532,13 +532,17 @@ TEST_F_FROM_FIXTURE(TestWriteInteraction, TestWriteHandlerReceiveInvalidMessage)
     auto * engine = chip::app::InteractionModelEngine::GetInstance();
     EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()), CHIP_NO_ERROR);
 
-    // Reserve all except the last 128 bytes, so that we make sure to chunk.
+    // Reserve all except the last 60 bytes, so that we make sure to chunk. it was empirically determined that with a list of 10
+    // ByteSpan items, we will be able to fit 5/6 list items into the initial ReplaceAll list; thus triggering chunking.
     app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
-                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 128) /* reserved buffer size */);
+                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 60) /* reserved buffer size */);
 
-    ByteSpan list[5];
+    constexpr uint8_t kTestListLength = 10;
+    ByteSpan list[kTestListLength];
 
-    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 5)), CHIP_NO_ERROR);
+    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength)), CHIP_NO_ERROR);
+
+    EXPECT_TRUE(writeClient.IsWriteRequestChunked());
 
     GetLoopback().mSentMessageCount                 = 0;
     GetLoopback().mNumMessagesToDrop                = 1;
@@ -597,13 +601,17 @@ TEST_F(TestWriteInteraction, TestWriteHandlerInvalidateFabric)
     auto * engine = chip::app::InteractionModelEngine::GetInstance();
     EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()), CHIP_NO_ERROR);
 
-    // Reserve all except the last 128 bytes, so that we make sure to chunk.
+    // Reserve all except the last 60 bytes, so that we make sure to chunk. it was empirically determined that with a list of 10
+    // ByteSpan items, we will be able to fit 5/6 list items into the initial ReplaceAll list; thus triggering chunking.
     app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
-                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 128) /* reserved buffer size */);
+                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 60) /* reserved buffer size */);
 
-    ByteSpan list[5];
+    constexpr uint8_t kTestListLength = 10;
+    ByteSpan list[kTestListLength];
 
-    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 5)), CHIP_NO_ERROR);
+    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength)), CHIP_NO_ERROR);
+
+    EXPECT_TRUE(writeClient.IsWriteRequestChunked());
 
     GetLoopback().mDroppedMessageCount              = 0;
     GetLoopback().mSentMessageCount                 = 0;

--- a/src/app/tests/suites/TestAccessControlCluster.yaml
+++ b/src/app/tests/suites/TestAccessControlCluster.yaml
@@ -215,6 +215,14 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  # Since the writeAttribute failed, the entire list was rejected, and the previous ACL values remained unchanged
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Write entry invalid auth mode"
@@ -248,6 +256,13 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,
@@ -289,6 +304,13 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Write entry invalid target"
@@ -323,6 +345,13 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,
@@ -386,6 +415,13 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Write entry too many targets"
@@ -441,6 +477,13 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,
@@ -520,54 +563,21 @@ tests:
       command: "readAttribute"
       attribute: "ACL"
       response:
-          value: [
+          value: # Since the writeAttribute failed, the entire list was rejected, and the previous ACL values remained unchanged
+              [
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
                       Subjects: null,
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 0, DeviceType: null },
-                              { Cluster: 1, Endpoint: null, DeviceType: null },
-                              { Cluster: 2, Endpoint: 3, DeviceType: null },
-                          ],
+                      Targets: null,
                   },
                   {
                       FabricIndex: 1,
                       Privilege: 1, # view
                       AuthMode: 2, # case
-                      Subjects: [4, 5, 6, 7],
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 8, DeviceType: null },
-                              { Cluster: 9, Endpoint: null, DeviceType: null },
-                              { Cluster: 10, Endpoint: 11, DeviceType: null },
-                          ],
-                  },
-                  {
-                      FabricIndex: 1,
-                      Privilege: 3, # operate
-                      AuthMode: 3, # group
-                      Subjects: [12, 13, 14, 15],
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 16, DeviceType: null },
-                              { Cluster: 17, Endpoint: null, DeviceType: null },
-                              { Cluster: 18, Endpoint: 19, DeviceType: null },
-                          ],
-                  },
-                  {
-                      FabricIndex: 1,
-                      Privilege: 1, # view
-                      AuthMode: 2, # case
-                      Subjects: [20, 21, 22, 23],
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 24, DeviceType: null },
-                              { Cluster: 25, Endpoint: null, DeviceType: null },
-                              { Cluster: 26, Endpoint: 27, DeviceType: null },
-                          ],
+                      Subjects: null,
+                      Targets: null,
                   },
               ]
 
@@ -584,6 +594,13 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  {
+                      FabricIndex: 0,
+                      Privilege: 3, # operate
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Verify"
@@ -594,6 +611,107 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 3, # operate
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+              ]
+
+    - label:
+          "Write invalid field in first ACL Entry, with 2nd ACL Entry completely
+          valid"
+      command: "writeAttribute"
+      attribute: "ACL"
+      arguments:
+          value: [
+                  {
+                      FabricIndex: 0,
+                      Privilege: 0, # invalid privilege
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 0,
+                      Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: [12, 13, 14, 15],
+                      Targets: null,
+                  },
+              ]
+      response:
+          error: CONSTRAINT_ERROR
+
+    # Even though a malformed entry was sent, nothing has changed and we still retain the Valid ACLs from previous step
+    - label: "Verify"
+      command: "readAttribute"
+      attribute: "ACL"
+      response:
+          value: [
+                  {
+                      FabricIndex: 1,
+                      Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 3, # operate
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+              ]
+
+    - label:
+          "Write invalid field in second ACL Entry, with 1st ACL Entry being
+          Valid"
+      command: "writeAttribute"
+      attribute: "ACL"
+      arguments:
+          value: [
+                  {
+                      FabricIndex: 0,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 0,
+                      Privilege: 0, # invalid privilege
+                      AuthMode: 2, # case
+                      Subjects: [12, 13, 14, 15],
+                      Targets: null,
+                  },
+              ]
+      response:
+          error: CONSTRAINT_ERROR
+
+    # Test: If second ACL Entry had invalid field, even 1st ACL Entry should be rejected. While retaining the previous Valid ACLs
+    - label: "Verify"
+      command: "readAttribute"
+      attribute: "ACL"
+      response:
+          value: [
+                  {
+                      FabricIndex: 1,
+                      Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 3, # operate
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_3.yaml
@@ -257,7 +257,7 @@ tests:
       command: "readAttribute"
       attribute: "Extension"
       response:
-          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndexValue }]
+          value: [{ Data: D_OK_FULL, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 19: TH1 writes DUT Endpoint 0 AccessControl cluster Extension

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
@@ -23,17 +23,17 @@ config:
     cluster: "Access Control"
     endpoint: 0
     CAT1:
-        type: int64u
-        defaultValue: 65520
+        type: node_id
+        defaultValue: 0xFFFFFFFDABCD0001
     CAT2:
-        type: int64u
-        defaultValue: 65521
+        type: node_id
+        defaultValue: 0xFFFFFFFDFFFF0001
     CAT3:
-        type: int64u
-        defaultValue: 65522
+        type: node_id
+        defaultValue: 0xFFFFFFFD071C1074
     CAT4:
-        type: int64u
-        defaultValue: 65523
+        type: node_id
+        defaultValue: 0xFFFFFFFDAB120003
 
 tests:
     - label: "Step 1:Wait for the commissioned device to be retrieved"
@@ -1101,12 +1101,19 @@ tests:
       command: "readAttribute"
       attribute: "ACL"
       response:
-          value:
-              [
+          value: [
                   {
                       Privilege: 5,
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
+                      Targets: null,
+                      FabricIndex: CurrentFabricIndexValue,
+                  },
+                  # We are retaining the ACLs from Step 21 and Step 22
+                  {
+                      Privilege: 3,
+                      AuthMode: 2,
+                      Subjects: [CAT1, CAT2, CAT3, CAT4],
                       Targets: null,
                       FabricIndex: CurrentFabricIndexValue,
                   },

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
@@ -140,20 +140,7 @@ tests:
                       {
                           AdminNodeID: CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Data: D_OK_EMPTY,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Data: D_OK_SINGLE,
@@ -174,26 +161,19 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
+      # Since a CONSTRAINT_ERROR was triggered in Step 8, no change will happen to the already-existing "Extension", and thus no AccessControlExtensionChanged event will be generated
+      # SKIP for Now, as there is currently no way to check that AccessControlExtensionChanged value is an empty list
     - label:
           "Step 9: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlExtensionChanged event"
-      PICS: ACL.S.E01
+      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E01
+      disabled: true
+
       command: "readEvent"
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
-          value:
-              {
-                  AdminNodeID: CommissionerNodeId,
-                  AdminPasscodeID: null,
-                  ChangeType: 2,
-                  LatestValue:
-                      {
-                          Data: D_OK_SINGLE,
-                          FabricIndex: CurrentFabricIndexValue,
-                      },
-                  FabricIndex: CurrentFabricIndexValue,
-              }
+          value: {}
 
     - label:
           "Step 10: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -211,26 +191,19 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
+      # Since a CONSTRAINT_ERROR was triggered in Step 10, no change will happen to the already-existing "Extension", and thus no AccessControlExtensionChanged event will be generated
+      # SKIP for Now, as there is currently no way to check that AccessControlExtensionChanged value is an empty list
     - label:
           "Step 11: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlExtensionChanged event"
-      PICS: ACL.S.E01
+      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E01
+      disabled: true
+
       command: "readEvent"
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
-          value:
-              {
-                  AdminNodeID: CommissionerNodeId,
-                  AdminPasscodeID: null,
-                  ChangeType: 1,
-                  LatestValue:
-                      {
-                          Data: D_OK_EMPTY,
-                          FabricIndex: CurrentFabricIndexValue,
-                      },
-                  FabricIndex: CurrentFabricIndexValue,
-              }
+          value: {}
 
     - label:
           "Step 12: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -254,9 +227,9 @@ tests:
                   AdminNodeID: CommissionerNodeId,
                   AdminPasscodeID: null,
                   ChangeType: 2,
-                  LatestValue:
-                      {
-                          Data: D_OK_EMPTY,
+                  LatestValue: {
+                          # The Extension data D_OK_SINGLE that was "Changed" in Step in 7 will be removed
+                          Data: D_OK_SINGLE,
                           FabricIndex: CurrentFabricIndexValue,
                       },
                   FabricIndex: CurrentFabricIndexValue,

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
@@ -114,23 +114,7 @@ tests:
                       {
                           AdminNodeID: CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Privilege: 5,
@@ -190,59 +174,22 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
+      # Since in Step 6 one of the ACL List Entries had an invalid item, then the whole ACL Entries List was rejected, As such no change will happen to the already-existing AccessControl Entries, and thus no AccessControlEntryChanged event will be generated
+      # SKIP for Now, as YAML does not provide a way to check that the received ReportDataMessage does NOT contain an EventReportIB
+      # Example of Output of this Step
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] ReportDataMessage =
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] {
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] 	SuppressResponse = true,
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] 	InteractionModelRevision = 12
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] }
     - label:
           "Step 7: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlEntryChanged event"
-      PICS: ACL.S.E00
+      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E00
+      disabled: true
       command: "readEvent"
       event: "AccessControlEntryChanged"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
           - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 3,
-                                  AuthMode: 3,
-                                  Subjects: null,
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
+                - value: {}

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_8.yaml
@@ -378,23 +378,7 @@ tests:
                       {
                           AdminNodeID: TH1CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [TH1CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: TH1FabricIndex,
-                              },
-                          FabricIndex: TH1FabricIndex,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: TH1CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Privilege: 5,
@@ -435,23 +419,7 @@ tests:
                       {
                           AdminNodeID: TH2CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [TH2CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: TH2FabricIndex,
-                              },
-                          FabricIndex: TH2FabricIndex,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: TH2CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Privilege: 5,

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -53,7 +53,7 @@ uint32_t gIterationCount = 0;
 // already used in the fixed endpoint set of size 1. Consequently, let's use the next
 // number higher than that for our dynamic test endpoint.
 //
-constexpr EndpointId kTestEndpointId      = 2;
+constexpr EndpointId kTestEndpointId      = 0;
 constexpr AttributeId kTestListAttribute  = 6;
 constexpr AttributeId kTestListAttribute2 = 7;
 constexpr uint32_t kTestListLength        = 5;
@@ -93,9 +93,11 @@ protected:
     };
 
     void RunTest(Instructions instructions);
+    void RunTest_NonEmptyReplaceAll(Instructions instructions);
 };
 
 //clang-format off
+
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(testClusterAttrsOnEndpoint)
 DECLARE_DYNAMIC_ATTRIBUTE(kTestListAttribute, ARRAY, 1, MATTER_ATTRIBUTE_FLAG_WRITABLE),
     DECLARE_DYNAMIC_ATTRIBUTE(kTestListAttribute2, ARRAY, 1, MATTER_ATTRIBUTE_FLAG_WRITABLE), DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
@@ -106,7 +108,22 @@ DECLARE_DYNAMIC_CLUSTER(Clusters::UnitTesting::Id, testClusterAttrsOnEndpoint, Z
 
 DECLARE_DYNAMIC_ENDPOINT(testEndpoint, testEndpointClusters);
 
-DataVersion dataVersionStorage[ArraySize(testEndpointClusters)];
+// Second Endpoint to Test Chunking when we send non-empty initial ReplaceAll List, which is used for ACL, see
+// WriteClient::EncodeAttribute()
+
+DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(testClusterAttrsOnEndpoint2)
+DECLARE_DYNAMIC_ATTRIBUTE(Clusters::AccessControl::Attributes::Acl::Id, ARRAY, 8, MATTER_ATTRIBUTE_FLAG_WRITABLE),
+    DECLARE_DYNAMIC_ATTRIBUTE(Clusters::AccessControl::Attributes::Extension::Id, ARRAY, 1, MATTER_ATTRIBUTE_FLAG_WRITABLE),
+    DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
+
+DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(testEndpointClusters2)
+DECLARE_DYNAMIC_CLUSTER(Clusters::AccessControl::Id, testClusterAttrsOnEndpoint2, ZAP_CLUSTER_MASK(SERVER), nullptr, nullptr),
+    DECLARE_DYNAMIC_CLUSTER_LIST_END;
+
+DECLARE_DYNAMIC_ENDPOINT(testEndpointAcl, testEndpointClusters2);
+
+DataVersion dataVersionStorage[MATTER_ARRAY_SIZE(testEndpointClusters)];
+DataVersion dataVersionStorageAcl[MATTER_ARRAY_SIZE(testEndpointClusters2)];
 
 //clang-format on
 
@@ -182,14 +199,69 @@ CHIP_ERROR TestAttrAccess::Write(const app::ConcreteDataAttributePath & aPath, a
     {
         app::DataModel::Nullable<app::DataModel::DecodableList<ByteSpan>> list;
         CHIP_ERROR err = aDecoder.Decode(list);
-        ChipLogError(Zcl, "Decode result: %s", err.AsString());
+        ChipLogError(Zcl, "NotList/ReplaceAll: Decode result: %s", err.AsString());
         return err;
     }
     if (aPath.mListOp == app::ConcreteDataAttributePath::ListOperation::AppendItem)
     {
         ByteSpan listItem;
         CHIP_ERROR err = aDecoder.Decode(listItem);
-        ChipLogError(Zcl, "Decode result: %s", err.AsString());
+        ChipLogError(Zcl, "AppendItem: Decode result: %s", err.AsString());
+        return err;
+    }
+
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+class TestAttrAccessAcl : public app::AttributeAccessInterface
+{
+public:
+    // Register for the Test Cluster cluster on all endpoints.
+    TestAttrAccessAcl() : AttributeAccessInterface(Optional<EndpointId>::Missing(), AccessControl::Id) {}
+
+    CHIP_ERROR Read(const app::ConcreteReadAttributePath & aPath, app::AttributeValueEncoder & aEncoder) override;
+    CHIP_ERROR Write(const app::ConcreteDataAttributePath & aPath, app::AttributeValueDecoder & aDecoder) override;
+
+    void OnListWriteBegin(const app::ConcreteAttributePath & aPath) override
+    {
+        if (mOnListWriteBegin)
+        {
+            mOnListWriteBegin(aPath);
+        }
+    }
+
+    void OnListWriteEnd(const app::ConcreteAttributePath & aPath, bool aWriteWasSuccessful) override
+    {
+        if (mOnListWriteEnd)
+        {
+            mOnListWriteEnd(aPath, aWriteWasSuccessful);
+        }
+    }
+
+    std::function<void(const app::ConcreteAttributePath & path)> mOnListWriteBegin;
+    std::function<void(const app::ConcreteAttributePath & path, bool wasSuccessful)> mOnListWriteEnd;
+} testServerAcl;
+
+CHIP_ERROR TestAttrAccessAcl::Read(const app::ConcreteReadAttributePath & aPath, app::AttributeValueEncoder & aEncoder)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR TestAttrAccessAcl::Write(const app::ConcreteDataAttributePath & aPath, app::AttributeValueDecoder & aDecoder)
+{
+    // We only care about the number of attribute data.
+    if (!aPath.IsListItemOperation())
+    {
+        app::DataModel::Nullable<app::DataModel::DecodableList<ByteSpan>> list;
+        CHIP_ERROR err = aDecoder.Decode(list);
+        ChipLogError(Zcl, "NotList/ReplaceAll: Decode result: %s", err.AsString());
+        return err;
+    }
+    if (aPath.mListOp == app::ConcreteDataAttributePath::ListOperation::AppendItem)
+    {
+        ByteSpan listItem;
+        CHIP_ERROR err = aDecoder.Decode(listItem);
+        ChipLogError(Zcl, "AppendItem: Decode result: %s", err.AsString());
         return err;
     }
 
@@ -257,6 +329,92 @@ TEST_F(TestWriteChunking, TestListChunking)
         }
 
         EXPECT_EQ(writeCallback.mSuccessCount, kTestListLength + 1 /* an extra item for the empty list at the beginning */);
+        EXPECT_EQ(writeCallback.mErrorCount, 0u);
+        EXPECT_EQ(writeCallback.mOnDoneCount, 1u);
+
+        EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+
+        //
+        // Stop the test if we detected an error. Otherwise, it'll be difficult to read the logs.
+        //
+        if (HasFailure())
+        {
+            break;
+        }
+    }
+    emberAfClearDynamicEndpoint(0);
+}
+
+/*
+ * A Variant of TestListChunking above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
+ * happens with the ACL Cluster (this would be generalised to all relevant Attributes after issue #38270 is resolved)
+ */
+TEST_F(TestWriteChunking, TestListChunking_NonEmptyReplaceAllList)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    // Initialize the ember side server logic
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    InitDataModelHandler();
+
+    // Register our fake dynamic endpoint.
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpointAcl, Span<DataVersion>(dataVersionStorageAcl));
+
+    // Register our fake attribute access interface.
+    AttributeAccessInterfaceRegistry::Instance().Register(&testServerAcl);
+
+    app::AttributePathParams attributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id);
+
+    // We've empirically determined that by reserving all but 65 bytes in the packet buffer, we can fit a Single AttributeDataIB
+    // into the packet with a List of 8/9 ByteSpans with empty items. So if we have a ByteSpan List of 20 items, our initial
+    // ReplaceAll list will contain 8/9 items, and the remaining items are chunked as appropriate.
+    constexpr size_t maxReservationSize = kMaxSecureSduLengthBytes - 65;
+
+    constexpr uint8_t kTestListLength2 = 20;
+
+    // Start with a high reservation (maxReservationSize) to force chunking, then decrease the reservation in 1-byte steps.
+    // This increases the buffer space available for encoding, gradually reducing the need for chunking, until chunking would not
+    // occur anymore. This helps validate various edge cases.
+    for (uint32_t reservationReduction = 0; reservationReduction < 40; reservationReduction++)
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        TestWriteCallback writeCallback;
+
+        ChipLogDetail(DataManagement, "Running iteration %d\n", static_cast<int>(reservationReduction));
+
+        app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, NullOptional,
+                                     static_cast<uint16_t>(maxReservationSize - reservationReduction) /* reserved buffer size */);
+
+        ByteSpan list[kTestListLength2];
+
+        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength2));
+
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+
+        // Ensure that chunking actually occurred in the first iteration. We will iteratively chunk less and less, until chunking
+        // would not occur anymore. Thus, this check is only needed at start.
+        if (reservationReduction == 0)
+        {
+            ASSERT_TRUE(writeClient.IsWriteRequestChunked());
+        }
+
+        err = writeClient.SendWriteRequest(sessionHandle);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+
+        //
+        // Service the IO + Engine till we get a ReportEnd callback on the client.
+        // Since bugs can happen, we don't want this test to never stop, so create a ceiling for how many
+        // times this can run without seeing expected results.
+        //
+        for (int j = 0; j < 10 && writeCallback.mOnDoneCount == 0; j++)
+        {
+            DrainAndServiceIO();
+        }
+
+        // Due to Write Chunking being done dynamically (fitting as many items as possible into an initial ReplaceAll List, before
+        // starting to chunk), it is fragile to try to predict mSuccessCount. It all depends on how much was packed into the initial
+        // ReplaceAll List.
+        // However, we know for sure that writeCallback should NEVER fail.
         EXPECT_EQ(writeCallback.mErrorCount, 0u);
         EXPECT_EQ(writeCallback.mOnDoneCount, 1u);
 
@@ -355,8 +513,96 @@ TEST_F(TestWriteChunking, TestBadChunking)
 }
 
 /*
- * When chunked write is enabled, it is dangerious to handle multiple write requests at the same time. In this case, we will reject
- * the latter write requests to the same attribute.
+ * A Variant of TestBadChunking above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
+ * happens with the ACL Cluster.
+ */
+TEST_F(TestWriteChunking, TestBadChunking_NonEmptyReplaceAllList)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    bool atLeastOneRequestSent   = false;
+    bool atLeastOneRequestFailed = false;
+
+    // Initialize the ember side server logic
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    InitDataModelHandler();
+
+    // Register our fake dynamic endpoint.
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpointAcl, Span<DataVersion>(dataVersionStorageAcl));
+
+    // Register our fake attribute access interface.
+    AttributeAccessInterfaceRegistry::Instance().Register(&testServerAcl);
+
+    app::AttributePathParams attributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id);
+
+    constexpr uint8_t kTestListLengthBadChunking = 5;
+
+    for (int bufferSize = 850; bufferSize < static_cast<int>(chip::app::kMaxSecureSduLengthBytes); bufferSize++)
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        TestWriteCallback writeCallback;
+
+        ChipLogDetail(DataManagement, "Running iteration with OCTET_STRING length = %d\n", bufferSize);
+
+        app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, NullOptional);
+
+        ByteSpan list[kTestListLengthBadChunking];
+        for (auto & item : list)
+        {
+            item = ByteSpan(sByteSpanData, static_cast<uint32_t>(bufferSize));
+        }
+
+        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLengthBadChunking));
+        if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
+        {
+            // This kind of error is expected.
+            atLeastOneRequestFailed = true;
+            continue;
+        }
+
+        atLeastOneRequestSent = true;
+
+        // Ensure that chunking actually occurred. Since chunking is dynamic, it's easy to unintentionally avoid it.
+        // This check guarantees that the test is validating chunked behavior as intended.
+        EXPECT_TRUE(writeClient.IsWriteRequestChunked());
+
+        // If we successfully encoded the attribute, then we must be able to send the message.
+        err = writeClient.SendWriteRequest(sessionHandle);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+
+        //
+        // Service the IO + Engine till we get a ReportEnd callback on the client.
+        // Since bugs can happen, we don't want this test to never stop, so create a ceiling for how many
+        // times this can run without seeing expected results.
+        //
+        for (int j = 0; j < 10 && writeCallback.mOnDoneCount == 0; j++)
+        {
+            DrainAndServiceIO();
+        }
+
+        // Due to the way Write Chunking is done, it is difficult to predict mSuccessCount. It all depends on how much was
+        // packed into the initial ReplaceAll List.
+        EXPECT_EQ(writeCallback.mErrorCount, 0u);
+        EXPECT_EQ(writeCallback.mOnDoneCount, 1u);
+
+        EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+
+        //
+        // Stop the test if we detected an error. Otherwise, it'll be difficult to read the logs.
+        //
+        if (HasFailure())
+        {
+            break;
+        }
+    }
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+    EXPECT_TRUE(atLeastOneRequestSent && atLeastOneRequestFailed);
+    emberAfClearDynamicEndpoint(0);
+}
+
+/*
+ * When chunked write is enabled, it is dangerous to handle multiple write requests at the same time. In this case, we will
+ * reject the latter write requests to the same attribute.
  */
 TEST_F(TestWriteChunking, TestConflictWrite)
 {
@@ -429,8 +675,92 @@ TEST_F(TestWriteChunking, TestConflictWrite)
 }
 
 /*
- * When chunked write is enabled, it is dangerious to handle multiple write requests at the same time. However, we will allow such
- * change when writing to different attributes in parallel.
+ * A Variant of TestConflictWrite above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
+ * happens with the ACL Cluster.
+ */
+TEST_F(TestWriteChunking, TestConflictWrite_NonEmptyReplaceAllList)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    // Initialize the ember side server logic
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    InitDataModelHandler();
+
+    // Register our fake dynamic endpoint.
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpointAcl, Span<DataVersion>(dataVersionStorageAcl));
+
+    // Register our fake attribute access interface.
+    AttributeAccessInterfaceRegistry::Instance().Register(&testServerAcl);
+
+    app::AttributePathParams attributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id);
+
+    // To ensure that chunking is triggered: We've empirically determined that by reserving all but 60 bytes in the packet
+    // buffer, we can fit 1 AttributeDataIB into the packet with a List of 5/6 ByteSpans with empty items. So if we have a
+    // ByteSpan List of 10 items, our initial ReplaceAll list will contain 5/6 items, and the remaining items are chunked.
+    constexpr size_t kReserveSize      = kMaxSecureSduLengthBytes - 60;
+    constexpr uint8_t kTestListLength2 = 10;
+
+    ByteSpan list[kTestListLength2];
+
+    TestWriteCallback writeCallback1;
+    app::WriteClient writeClient1(&GetExchangeManager(), &writeCallback1, NullOptional, static_cast<uint16_t>(kReserveSize));
+
+    TestWriteCallback writeCallback2;
+    app::WriteClient writeClient2(&GetExchangeManager(), &writeCallback2, NullOptional, static_cast<uint16_t>(kReserveSize));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = writeClient1.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength2));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    err = writeClient2.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength2));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    // Ensure that chunking actually occurred. Since chunking is dynamic, it's easy to unintentionally avoid it.
+    // This check guarantees that the test is validating chunked behavior as intended.
+    EXPECT_TRUE(writeClient1.IsWriteRequestChunked());
+    EXPECT_TRUE(writeClient2.IsWriteRequestChunked());
+
+    err = writeClient1.SendWriteRequest(sessionHandle);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = writeClient2.SendWriteRequest(sessionHandle);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    DrainAndServiceIO();
+
+    {
+        const TestWriteCallback * writeCallbackRef1 = &writeCallback1;
+        const TestWriteCallback * writeCallbackRef2 = &writeCallback2;
+
+        // Exactly one of WriteClient1 and WriteClient2 should success, not both.
+
+        if (writeCallback1.mSuccessCount == 0)
+        {
+            writeCallbackRef2 = &writeCallback1;
+            writeCallbackRef1 = &writeCallback2;
+        }
+
+        // Due to Write Chunking being done dynamically (fitting as many items as possible into an initial ReplaceAll List,
+        // before starting to chunk), it is fragile to try to predict mSuccessCount. It all depends on how much was packed into
+        // the initial ReplaceAll List. However, we know for sure that writeCallbackRef1 should NEVER fail, and that
+        // writeCallbackRef2 should NEVER Succeed.
+        EXPECT_EQ(writeCallbackRef1->mErrorCount, 0u);
+        EXPECT_EQ(writeCallbackRef2->mSuccessCount, 0u);
+
+        EXPECT_EQ(writeCallbackRef2->mLastErrorReason.mStatus, Protocols::InteractionModel::Status::Busy);
+
+        EXPECT_EQ(writeCallbackRef1->mOnDoneCount, 1u);
+        EXPECT_EQ(writeCallbackRef2->mOnDoneCount, 1u);
+    }
+
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+
+    emberAfClearDynamicEndpoint(0);
+}
+
+/*
+ * When chunked write is enabled, it is dangerous to handle multiple write requests at the same time. However, we will allow
+ * such change when writing to different attributes in parallel.
  */
 TEST_F(TestWriteChunking, TestNonConflictWrite)
 {
@@ -481,6 +811,79 @@ TEST_F(TestWriteChunking, TestNonConflictWrite)
         EXPECT_EQ(writeCallback1.mSuccessCount, kTestListLength + 1);
         EXPECT_EQ(writeCallback2.mErrorCount, 0u);
         EXPECT_EQ(writeCallback2.mSuccessCount, kTestListLength + 1);
+
+        EXPECT_EQ(writeCallback1.mOnDoneCount, 1u);
+        EXPECT_EQ(writeCallback2.mOnDoneCount, 1u);
+    }
+
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+
+    emberAfClearDynamicEndpoint(0);
+}
+
+/*
+ * A Variant of TestNonConflictWrite above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests,
+ * this happens with the ACL Cluster.
+ */
+TEST_F(TestWriteChunking, TestNonConflictWrite_NonEmptyReplaceAllList)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    // Initialize the ember side server logic
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    InitDataModelHandler();
+
+    // Register our fake dynamic endpoint.
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpointAcl, Span<DataVersion>(dataVersionStorageAcl));
+
+    // Register our fake attribute access interface.
+    AttributeAccessInterfaceRegistry::Instance().Register(&testServerAcl);
+
+    app::AttributePathParams attributePath1(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id);
+    app::AttributePathParams attributePath2(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Extension::Id);
+
+    // To ensure that chunking is triggered: We've empirically determined that by reserving all but 60 bytes in the packet
+    // buffer, we can fit 1 AttributeDataIB into the packet with a List of 5/6 ByteSpans with empty items. So if we have a
+    // ByteSpan List of 10 items, our initial ReplaceAll list will contain 5/6 items, and the remaining items are chunked.
+    constexpr size_t kReserveSize      = kMaxSecureSduLengthBytes - 65;
+    constexpr uint8_t kTestListLength2 = 10;
+
+    TestWriteCallback writeCallback1;
+    app::WriteClient writeClient1(&GetExchangeManager(), &writeCallback1, NullOptional, static_cast<uint16_t>(kReserveSize));
+
+    TestWriteCallback writeCallback2;
+    app::WriteClient writeClient2(&GetExchangeManager(), &writeCallback2, NullOptional, static_cast<uint16_t>(kReserveSize));
+
+    ByteSpan list[kTestListLength2];
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = writeClient1.EncodeAttribute(attributePath1, app::DataModel::List<ByteSpan>(list, kTestListLength2));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = writeClient2.EncodeAttribute(attributePath2, app::DataModel::List<ByteSpan>(list, kTestListLength2));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    // Ensure that chunking actually occurred. Since chunking is dynamic, it's easy to unintentionally avoid it.
+    // This check guarantees that the test is validating chunked behavior as intended.
+    EXPECT_TRUE(writeClient1.IsWriteRequestChunked());
+    EXPECT_TRUE(writeClient2.IsWriteRequestChunked());
+
+    err = writeClient1.SendWriteRequest(sessionHandle);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = writeClient2.SendWriteRequest(sessionHandle);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    DrainAndServiceIO();
+
+    {
+
+        // Due to Write Chunking being done dynamically, it is fragile to try to predict mSuccessCount. It all depends on how
+        // much was packed into the initial ReplaceAll List. However, we know for sure that writeCallback1 and writeCallback2
+        // should NEVER fail.
+        EXPECT_EQ(writeCallback1.mErrorCount, 0u);
+        EXPECT_EQ(writeCallback2.mErrorCount, 0u);
 
         EXPECT_EQ(writeCallback1.mOnDoneCount, 1u);
         EXPECT_EQ(writeCallback2.mOnDoneCount, 1u);
@@ -676,6 +1079,228 @@ TEST_F(TestWriteChunking, TestTransactionalList)
         .data           = { ListData::kBadValue },
         .expectedStatus = { false },
     });
+
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+
+    emberAfClearDynamicEndpoint(0);
+}
+
+/*
+ * A Variant of RunTest above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
+ * happens with the ACL Cluster.
+ */
+void TestWriteChunking::RunTest_NonEmptyReplaceAll(Instructions instructions)
+{
+    CHIP_ERROR err     = CHIP_NO_ERROR;
+    auto sessionHandle = GetSessionBobToAlice();
+
+    TestWriteCallback writeCallback;
+    std::unique_ptr<WriteClient> writeClient = std::make_unique<WriteClient>(
+        &GetExchangeManager(), &writeCallback, NullOptional,
+        static_cast<uint16_t>(kMaxSecureSduLengthBytes -
+                              66) /* use a smaller chunk so we only need a few attributes in the write request. */);
+
+    ConcreteAttributePath onGoingPath = ConcreteAttributePath();
+    std::vector<PathStatus> status;
+
+    testServerAcl.mOnListWriteBegin = [&](const ConcreteAttributePath & aPath) {
+        EXPECT_EQ(onGoingPath, ConcreteAttributePath());
+        onGoingPath = aPath;
+        ChipLogProgress(Zcl, "OnListWriteBegin endpoint=%u Cluster=" ChipLogFormatMEI " attribute=" ChipLogFormatMEI,
+                        aPath.mEndpointId, ChipLogValueMEI(aPath.mClusterId), ChipLogValueMEI(aPath.mAttributeId));
+        if (instructions.onListWriteBeginActions)
+        {
+            switch (instructions.onListWriteBeginActions(aPath))
+            {
+            case Operations::kNoop:
+                break;
+            case Operations::kShutdownWriteClient:
+                // By setting writeClient to nullptr, we actually shutdown the write interaction to simulate a timeout.
+                writeClient = nullptr;
+            }
+        }
+    };
+    testServerAcl.mOnListWriteEnd = [&](const ConcreteAttributePath & aPath, bool aWasSuccessful) {
+        EXPECT_EQ(onGoingPath, aPath);
+        status.push_back(PathStatus(aPath, aWasSuccessful));
+        onGoingPath = ConcreteAttributePath();
+        ChipLogProgress(Zcl, "OnListWriteEnd endpoint=%u Cluster=" ChipLogFormatMEI " attribute=" ChipLogFormatMEI,
+                        aPath.mEndpointId, ChipLogValueMEI(aPath.mClusterId), ChipLogValueMEI(aPath.mAttributeId));
+    };
+
+    constexpr uint8_t kTestListLength2 = 10;
+
+    ByteSpan list[kTestListLength2];
+    uint8_t badList[kTestListLength2];
+
+    if (instructions.data.size() == 0)
+    {
+        instructions.data = std::vector<ListData>(instructions.paths.size(), ListData::kList);
+    }
+    EXPECT_EQ(instructions.paths.size(), instructions.data.size());
+
+    for (size_t i = 0; i < instructions.paths.size(); i++)
+    {
+        const auto & p = instructions.paths[i];
+        switch (instructions.data[i])
+        {
+        case ListData::kNull: {
+            DataModel::Nullable<uint8_t> null; // The actual type is not important since we will only put a null value.
+            err = writeClient->EncodeAttribute(AttributePathParams(p.mEndpointId, p.mClusterId, p.mAttributeId), null);
+            break;
+        }
+        case ListData::kList: {
+            err = writeClient->EncodeAttribute(AttributePathParams(p.mEndpointId, p.mClusterId, p.mAttributeId),
+                                               DataModel::List<ByteSpan>(list, kTestListLength2));
+            break;
+        }
+        case ListData::kBadValue: {
+            err = writeClient->EncodeAttribute(AttributePathParams(p.mEndpointId, p.mClusterId, p.mAttributeId),
+                                               DataModel::List<uint8_t>(badList, kTestListLength2));
+            break;
+        }
+        }
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+    }
+
+    err = writeClient->SendWriteRequest(sessionHandle);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    GetIOContext().DriveIOUntil(
+        sessionHandle->ComputeRoundTripTimeout(app::kExpectedIMProcessingTime, true /*isFirstMessageOnExchange*/) +
+            System::Clock::Seconds16(1),
+        [&]() { return GetExchangeManager().GetNumActiveExchanges() == 0; });
+
+    EXPECT_EQ(onGoingPath, app::ConcreteAttributePath());
+    EXPECT_EQ(status.size(), instructions.expectedStatus.size());
+
+    for (size_t i = 0; i < status.size(); i++)
+    {
+        EXPECT_EQ(status[i], PathStatus(instructions.paths[i], instructions.expectedStatus[i]));
+    }
+
+    testServerAcl.mOnListWriteBegin = nullptr;
+    testServerAcl.mOnListWriteEnd   = nullptr;
+}
+
+TEST_F(TestWriteChunking, TestTransactionalList_NonEmptyReplaceAllList)
+{
+    // Initialize the ember side server logic.
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    InitDataModelHandler();
+
+    // Register our fake dynamic endpoint.
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpointAcl, Span<DataVersion>(dataVersionStorageAcl));
+
+    // Register our fake attribute access interface.
+    AttributeAccessInterfaceRegistry::Instance().Register(&testServerAcl);
+
+    // Test 1: we should receive transaction notifications
+    ChipLogProgress(Zcl, "Test 1: we should receive transaction notifications");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .expectedStatus = { true },
+    });
+
+    ChipLogProgress(Zcl, "Test 2: we should receive transaction notifications for incomplete list operations");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .onListWriteBeginActions = [&](const app::ConcreteAttributePath & aPath) { return Operations::kShutdownWriteClient; },
+        .expectedStatus          = { false },
+    });
+
+    ChipLogProgress(Zcl, "Test 3: we should receive transaction notifications for every list in the transaction");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                            ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Extension::Id) },
+        .expectedStatus = { true, true },
+    });
+
+    ChipLogProgress(Zcl, "Test 4: we should receive transaction notifications with the status of each list");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                   ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Extension::Id) },
+        .onListWriteBeginActions =
+            [&](const app::ConcreteAttributePath & aPath) {
+                if (aPath.mAttributeId == AccessControl::Attributes::Extension::Id)
+                {
+                    return Operations::kShutdownWriteClient;
+                }
+                return Operations::kNoop;
+            },
+        .expectedStatus = { true, false },
+    });
+
+    ChipLogProgress(Zcl,
+                    "Test 5: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+                    "null value before non null values");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                            ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .data           = { ListData::kNull, ListData::kList },
+        .expectedStatus = { true },
+    });
+
+    ChipLogProgress(Zcl,
+                    "Test 6: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+                    "null value after non null values");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                            ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .data           = { ListData::kList, ListData::kNull },
+        .expectedStatus = { true },
+    });
+
+    ChipLogProgress(Zcl,
+                    "Test 7: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+                    "null value between non null values");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                            ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                            ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .data           = { ListData::kList, ListData::kNull, ListData::kList },
+        .expectedStatus = { true },
+    });
+
+    ChipLogProgress(Zcl, "Test 8: transactional list callbacks will be called for nullable lists");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .data           = { ListData::kNull },
+        .expectedStatus = { true },
+    });
+
+    ChipLogProgress(Zcl,
+                    "Test 9: for nullable lists, we should receive notifications for unsuccessful writes when non-fatal occurred "
+                    "during processing the requests");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .data           = { ListData::kBadValue },
+        .expectedStatus = { false },
+    });
+
+    // This TestCase tests corner cases when we Encode many attributes into the same WriteRequest, up to 10 Attributes will be
+    // Encoded.
+    for (int nullableListCount = 1; nullableListCount <= 10; nullableListCount++)
+    {
+        ChipLogProgress(Zcl, "Test 10.%d: Encoding %d nullable lists following a single non-nullable list", nullableListCount,
+                        nullableListCount);
+
+        Instructions test;
+
+        // Add the single non-nullable list
+        test.paths.push_back(ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id));
+        test.data.push_back(ListData::kList);
+
+        // Add the nullable lists
+        for (int i = 0; i < nullableListCount; i++)
+        {
+            test.paths.push_back(ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id));
+            test.data.push_back(ListData::kNull);
+        }
+
+        test.expectedStatus = { true };
+        RunTest_NonEmptyReplaceAll(test);
+    }
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -31,6 +31,7 @@
 #include <app/CommandHandlerInterface.h>
 #include <app/InteractionModelEngine.h>
 #include <app/WriteClient.h>
+#include <app/codegen-data-model-provider/Instance.h>
 #include <app/data-model/Decode.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/DataModelHandler.h>
@@ -347,14 +348,14 @@ TEST_F(TestWriteChunking, TestListChunking)
 
 /*
  * A Variant of TestListChunking above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
- * happens with the ACL Cluster (this would be generalised to all relevant Attributes after issue #38270 is resolved)
+ * happens with the ACL Cluster (this would be generalised to all relevant Attributes after issue #38270 is resolved)ß
  */
 TEST_F(TestWriteChunking, TestListChunking_NonEmptyReplaceAllList)
 {
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance());
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -524,7 +525,7 @@ TEST_F(TestWriteChunking, TestBadChunking_NonEmptyReplaceAllList)
     bool atLeastOneRequestFailed = false;
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance());
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -683,7 +684,7 @@ TEST_F(TestWriteChunking, TestConflictWrite_NonEmptyReplaceAllList)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance());
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -830,7 +831,7 @@ TEST_F(TestWriteChunking, TestNonConflictWrite_NonEmptyReplaceAllList)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance());
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -1186,7 +1187,7 @@ void TestWriteChunking::RunTest_NonEmptyReplaceAll(Instructions instructions)
 TEST_F(TestWriteChunking, TestTransactionalList_NonEmptyReplaceAllList)
 {
     // Initialize the ember side server logic.
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance());
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.


### PR DESCRIPTION
MATTER-4856
Cherry-pick from csa repo


* Modifying how ACL Attribute is written: making it use a non-empty initial ReplaceAll list

* removing Test modifications on ACL Extensions

* adding reference to issue in TODO comment

* integrating comments

* integrating comments

* Revert "removing Test modifications on ACL Extensions"

This reverts commit 055af80d6c71e40ddeef081b6046263bc06ef141.

* Clarifying AttributeDataIB Checkpoint

* adding Valid CAT values

* Integrating comments

* Add comments clarifying AttributeDataIB rollback

* Integrating comments again

* change method order

* integrating new comments

* revert change to IM Error Code return from AccessControl cluster

* changing constants use to reserveBuffer for TLV writing

* Integrating more Boris Comments

* removing state related to IsWriteRequestChunked

* Create TryToStartList that dynamically starts message in case of NO Memory


#### Testing
Certifications test added by the pr Validates the changes. 
The code is active on CSA already
