### PR TITLE
[SL-UP] Fix/unused var in ble manager

### DIFF
--- a/.github/silabs-builds-mg24.json
+++ b/.github/silabs-builds-mg24.json
@@ -15,6 +15,10 @@
         {
             "boards": ["BRD4187C"],
             "arguments": ["--docker", "--wifi SiWx917", "--clean"]
+        },
+        {
+            "boards": ["BRD4187C"],
+            "arguments": ["--docker", "--release"]
         }
     ]
 }

--- a/.github/silabs-builds-mg26.json
+++ b/.github/silabs-builds-mg26.json
@@ -5,7 +5,7 @@
             "arguments": ["--docker"]
         },
         {
-            "boards": ["BRD4187C"],
+            "boards": ["BRD4116A"],
             "arguments": ["--docker", "--release"]
         }
     ],

--- a/.github/silabs-builds-mg26.json
+++ b/.github/silabs-builds-mg26.json
@@ -3,6 +3,10 @@
         {
             "boards": ["BRD4116A", "BRD4117A", "BRD4118A", "BRD2608A"],
             "arguments": ["--docker"]
+        },
+        {
+            "boards": ["BRD4187C"],
+            "arguments": ["--docker", "--release"]
         }
     ],
     "lighting-app":[

--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -736,8 +736,7 @@ void BLEManagerImpl::HandleReadEvent(volatile sl_bt_msg_t * evt)
     else if (mBleSideChannel != nullptr)
     {
         // Side channel read request
-        uint16_t attribute = evt->data.evt_gatt_server_user_read_request.characteristic;
-        ChipLogProgress(DeviceLayer, "Char Read Req, char : %d", attribute);
+        ChipLogProgress(DeviceLayer, "Char Read Req, char : %d", evt->data.evt_gatt_server_user_read_request.characteristic);
 
         char dataBuff[] = "You are reading the Si-Channel TX characteristic";
         ByteSpan dataSpan((const uint8_t *) dataBuff, sizeof(dataBuff));


### PR DESCRIPTION
Build fails with unused variable error when apps are built without logs.
Fix: Remove the usage of the local variable

#### Testing
Build app with log disable/release
