### PR TITLE
[SL-UP] Fix NVM3 Key leak on reboot

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -944,10 +944,16 @@ void BaseApplication::ScheduleFactoryReset()
 void BaseApplication::DoProvisioningReset()
 {
     PlatformMgr().ScheduleWork([](intptr_t) {
+        // Force the KeyMap update to make sure nvm3 is updated before anything happens.
+        // If the device reboots before the timer update happens, "shadow" keys are left in nvm3 causing a reduction of the
+        // overall available nvm3 - similar to a memory leak.
+        // FactoryResetThreadStack forces a reboot which was causing a memory loss.
+        chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().ForceKeyMapSave();
+
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
         ConfigurationManagerImpl::GetDefaultInstance().ClearThreadStack();
         ThreadStackMgrImpl().FactoryResetThreadStack();
-        ThreadStackMgr().InitThreadStack();
+        // Triggers a reboot - nothing gets executed after this
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION

--- a/src/platform/silabs/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "MigrationManager.h"
+#include <cmsis_os2.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/KeyValueStoreManager.h>
@@ -40,29 +41,38 @@ namespace chip {
 namespace DeviceLayer {
 namespace PersistedStorage {
 
-KeyValueStoreManagerImpl KeyValueStoreManagerImpl::sInstance;
+namespace {
+
 uint16_t mKvsKeyMap[KeyValueStoreManagerImpl::kMaxEntries] = { 0 };
+
+} // namespace
+
+KeyValueStoreManagerImpl KeyValueStoreManagerImpl::sInstance;
 
 CHIP_ERROR KeyValueStoreManagerImpl::Init(void)
 {
-    CHIP_ERROR err;
-    err = SilabsConfig::Init();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(SilabsConfig::Init());
 
     Silabs::MigrationManager::GetMigrationInstance().applyMigrations();
 
     memset(mKvsKeyMap, 0, sizeof(mKvsKeyMap));
-    size_t outLen;
-    err = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_KvsStringKeyMap, reinterpret_cast<uint8_t *>(mKvsKeyMap),
-                                           sizeof(mKvsKeyMap), outLen);
-
-    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND) // Initial boot
+    size_t outLen    = 0;
+    CHIP_ERROR error = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_KvsStringKeyMap,
+                                                        reinterpret_cast<uint8_t *>(mKvsKeyMap), sizeof(mKvsKeyMap), outLen);
+    if (error == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND) // Initial boot
     {
-        err = CHIP_NO_ERROR;
+        error = CHIP_NO_ERROR;
+    }
+    ReturnErrorOnFailure(error);
+
+    constexpr osThreadAttr_t attr = { .name = "KvsKeyMapCleanupTask", .stack_size = 512 /* bytes */, .priority = osPriorityLow7 };
+    if (osThreadNew(KvsKeyMapCleanup, nullptr, &attr) == nullptr)
+    {
+        // We don't need to crash and force a reboot. we will retry at the next reboot
+        ChipLogError(DeviceLayer, "Failed to create KvsCleanupTask");
     }
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 bool KeyValueStoreManagerImpl::IsValidKvsNvm3Key(uint32_t nvm3Key) const
@@ -109,7 +119,15 @@ CHIP_ERROR KeyValueStoreManagerImpl::MapKvsKeyToNvm3(const char * key, uint16_t 
             // Collision prevention
             // Read the data from NVM3 it should be prefixed by the kvsString
             // else we will look for another matching hash in the map
-            SilabsConfig::ReadConfigValueBin(tempNvm3key, reinterpret_cast<uint8_t *>(strPrefix), length, readCount, 0);
+
+            CHIP_ERROR err =
+                SilabsConfig::ReadConfigValueBin(tempNvm3key, reinterpret_cast<uint8_t *>(strPrefix), length, readCount, 0);
+            if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+            {
+                // No steps to be taken, clean up will be done at init
+                ChipLogError(DeviceLayer, "Key Hash with no associated NVM3 entry - potential Shadow key detected");
+            }
+
             if (strcmp(key, strPrefix) == 0)
             {
                 // String matches we have confirmed the hash pointed us the right key data
@@ -297,6 +315,36 @@ void KeyValueStoreManagerImpl::KvsMapMigration(void)
         // start with a fresh kvs section.
         KeyValueStoreMgrImpl().ErasePartition();
     }
+}
+
+void KeyValueStoreManagerImpl::KvsKeyMapCleanup(void * argument)
+{
+    bool requireKvsKeyMapSave = false;
+
+    for (uint16_t key = 0; key < KeyValueStoreManagerImpl::kMaxEntries; key++)
+    {
+        // Only check the keys that should have a NVM entry
+        if (mKvsKeyMap[key] != 0)
+        {
+            // We don't need to take a mutex - protection is done by the underlying nvm3 APIs
+            if (!SilabsConfig::ConfigValueExists(CONVERT_KEYMAP_INDEX_TO_NVM3KEY(key)))
+            {
+                // We have found a shadow key (key with no NVM entry)
+                // Delete unused key to free up space
+                mKvsKeyMap[key]      = 0;
+                requireKvsKeyMapSave = true;
+            }
+        }
+    }
+
+    if (requireKvsKeyMapSave)
+    {
+        PlatformMgr().LockChipStack();
+        KeyValueStoreMgrImpl().ForceKeyMapSave();
+        PlatformMgr().UnlockChipStack();
+    }
+
+    osThreadExit();
 }
 
 } // namespace PersistedStorage

--- a/src/platform/silabs/KeyValueStoreManagerImpl.h
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.h
@@ -46,7 +46,10 @@ public:
     static void KvsMapMigration();
 
 private:
+    static KeyValueStoreManagerImpl sInstance;
+
     static void OnScheduledKeyMapSave(System::Layer * systemLayer, void * appState);
+    static void KvsKeyMapCleanup(void * argument);
 
     void ScheduleKeyMapSave(void);
     bool IsValidKvsNvm3Key(const uint32_t nvm3Key) const;
@@ -56,8 +59,6 @@ private:
     //  ===== Members for internal use by the following friends.
     friend KeyValueStoreManager & KeyValueStoreMgr();
     friend KeyValueStoreManagerImpl & KeyValueStoreMgrImpl();
-
-    static KeyValueStoreManagerImpl sInstance;
 };
 
 /**
@@ -75,7 +76,7 @@ inline KeyValueStoreManager & KeyValueStoreMgr(void)
  * Returns the platform-specific implementation of the KeyValueStoreManager singleton object.
  *
  * Chip applications can use this to gain access to features of the KeyValueStoreManager
- * that are specific to the ESP32 platform.
+ * that are specific to the Silabs platform.
  */
 inline KeyValueStoreManagerImpl & KeyValueStoreMgrImpl(void)
 {


### PR DESCRIPTION
## Description
This PR fixes an NVM3 KeyMap leak that occurred when the device rebooted before the KeyMap was persisted in NVM3. When we modify the `KvsKeyMap` during operation, there is a two-second delay between modification of the RAM copy and its persistence in NVM3.

This delay is necessary to avoid flash wear and cannot be removed.

**Key Deletion Flow**
1. Delete NVM3 data.
2. Delete the RAM `KeyMap` entry.
3. Wait two seconds.
4. Persist the updated table to NVM3.

If the device reboots during step 3, it creates a "shadow key"—a `KvsKeyMap` entry that does not point to a valid NVM3 value. This reduces the number of available keys, as the key will never be freed.

This issue occurs systematically when removing the last fabric, because `FactoryResetThreadStack` causes a reboot immediately after updating the `KvsKeyMap`. In other words, rebooting is guaranteed at step 3. After 25 commissioning and unpairing sequences, we were unable to commission anymore because all key entries were consumed by "shadow keys."

## Fixes
This PR implements two solutions:
- When `DoProvisioningReset` is called, we force an update to `KvsKeyMap` to ensure the latest KeyMap is persisted.
- A background task is added, triggered at boot, that cleans up any existing shadow keys. Since shadow keys can be created as part of standard operation, this cleanup runs at every boot, ensuring they will never lead to a failure scenario.

Fixes [MATTER-4951](https://jira.silabs.com/browse/MATTER-4951).

## Tests
**Background Task Validation**
- Commissioned and unpaired until NVM3 failure (25 times) using a binary without the background task.
- Flashed a binary with the background task, and commissioning worked.
- Read and parsed NVM3 to confirm the KeyMap was emptied.

**`DoProvisioningReset` Validation**
- Ran a stress test without the background task for multiple hours without any failures.

I haven't figured out how to right a unit tests that would validate this due to the reboot requirement and i am running out of time with my PTO comming up. When i upstream the PR to CSA, i'll investigate this further.