### PR TITLE
[SL-UP] Add wrap config include path to siwx917_sdk template

### DIFF
--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -407,6 +407,7 @@ template("siwx917_sdk") {
           "${sl_si91x_psa_crypto_path}/gcm/inc",
           "${sl_si91x_psa_crypto_path}/sha/inc",
           "${sl_si91x_psa_crypto_path}/trng/inc",
+          "${sl_si91x_psa_crypto_path}/wrap/config",
           "${sl_si91x_psa_crypto_path}/wrap/inc",
           "${sl_si91x_psa_crypto_path}/multithread/inc",
 


### PR DESCRIPTION
### Testing

Manually building application with the change in the `matter_provision` repo on a later commit, meanwhile facing issue on `release_2.6-1.4`, 
```
ERROR: Cannot install protobuf and protobuf~=5.28.2 because these package versions have conflicting dependencies.
```
