### PR TITLE
[SL-UP] Adds fix and clean up of multi-ota

### DIFF
--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -663,7 +663,7 @@ CHIP_ERROR Storage::SetOtaTlvEncryptionKey(const ByteSpan & value)
     // Tinycrypt doesn't support the key ID, so we need to store the key as a binary blob
     return SilabsConfig::WriteConfigValueBin(SilabsConfig::kOtaTlvEncryption_KeyId, value.data(), value.size());
 #else  // MBEDTLS_USE_PSA_CRYPTO
-    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey key;
+    Silabs::OtaTlvEncryptionKey key;
     ReturnErrorOnFailure(key.Import(value.data(), value.size()));
     return SilabsConfig::WriteConfigValue(SilabsConfig::kOtaTlvEncryption_KeyId, key.GetId());
 #endif // SL_MBEDTLS_USE_TINYCRYPT
@@ -692,7 +692,7 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
     SilabsConfig::ReadConfigValueBin(SilabsConfig::kOtaTlvEncryption_KeyId, keySpan.data(), keySpan.size());
     VerifyOrReturnError(keySpan.size() == kOTAEncryptionKeyLength, CHIP_ERROR_INVALID_ARGUMENT);
 
-    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::Decrypt((const ByteSpan) keySpan, block, ivOffset);
+    Silabs::OtaTlvEncryptionKey::Decrypt((const ByteSpan) keySpan, block, ivOffset);
     return CHIP_NO_ERROR;
 #else  // MBEDTLS_USE_PSA_CRYPTO
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;

--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -663,7 +663,7 @@ CHIP_ERROR Storage::SetOtaTlvEncryptionKey(const ByteSpan & value)
     // Tinycrypt doesn't support the key ID, so we need to store the key as a binary blob
     return SilabsConfig::WriteConfigValueBin(SilabsConfig::kOtaTlvEncryption_KeyId, value.data(), value.size());
 #else  // MBEDTLS_USE_PSA_CRYPTO
-    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::OtaTlvEncryptionKey key;
+    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey key;
     ReturnErrorOnFailure(key.Import(value.data(), value.size()));
     return SilabsConfig::WriteConfigValue(SilabsConfig::kOtaTlvEncryption_KeyId, key.GetId());
 #endif // SL_MBEDTLS_USE_TINYCRYPT
@@ -692,7 +692,7 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
     SilabsConfig::ReadConfigValueBin(SilabsConfig::kOtaTlvEncryption_KeyId, keySpan.data(), keySpan.size());
     VerifyOrReturnError(keySpan.size() == kOTAEncryptionKeyLength, CHIP_ERROR_INVALID_ARGUMENT);
 
-    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::OtaTlvEncryptionKey.Decrypt((const ByteSpan) keySpan, block, ivOffset);
+    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::Decrypt((const ByteSpan) keySpan, block, ivOffset);
     return CHIP_NO_ERROR;
 #else  // MBEDTLS_USE_PSA_CRYPTO
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -731,7 +731,7 @@ CHIP_ERROR Storage::SetOtaTlvEncryptionKey(const ByteSpan & value)
     // Tinycrypt doesn't support the key ID, so we need to store the key as a binary blob
     return Flash::Set(Parameters::ID::kOtaTlvEncryptionKey, value.data(), value.size());
 #else  // MBEDTLS_USE_PSA_CRYPTO
-    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey key;
+    Silabs::OtaTlvEncryptionKey key;
     ReturnErrorOnFailure(key.Import(value.data(), value.size()));
     return Flash::Set(Parameters::ID::kOtaTlvEncryptionKey, key.GetId());
 #endif // SL_MBEDTLS_USE_TINYCRYPT
@@ -750,7 +750,7 @@ CHIP_ERROR Storage::GetOtaTlvEncryptionKeyId(uint32_t & keyId)
 CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uint32_t & ivOffset)
 {
 #if defined(SL_MBEDTLS_USE_TINYCRYPT)
-    uint8_t keyBuffer[chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength] = { 0 };
+    uint8_t keyBuffer[Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength] = { 0 };
     size_t keyLen                                                                              = 0;
 
     // Read the key from the provisioning storage
@@ -759,10 +759,10 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
     ReturnErrorOnFailure(Flash::Get(Parameters::ID::kOtaTlvEncryptionKey, keySpan.data(), keySpan.size(), keyLen));
     keySpan.reduce_size(keyLen);
 
-    VerifyOrReturnError(keySpan.size() == chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength,
+    VerifyOrReturnError(keySpan.size() == Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength,
                         CHIP_ERROR_INVALID_ARGUMENT);
 
-    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::Decrypt((const ByteSpan) keySpan, block, ivOffset);
+    Silabs::OtaTlvEncryptionKey::Decrypt((const ByteSpan) keySpan, block, ivOffset);
     return CHIP_NO_ERROR;
 #else  // MBEDTLS_USE_PSA_CRYPTO
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -751,7 +751,7 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
 {
 #if defined(SL_MBEDTLS_USE_TINYCRYPT)
     uint8_t keyBuffer[chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength] = { 0 };
-    size_t keyLen                              = 0;
+    size_t keyLen                                                                              = 0;
 
     // Read the key from the provisioning storage
     MutableByteSpan keySpan = MutableByteSpan(keyBuffer);
@@ -759,7 +759,8 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
     ReturnErrorOnFailure(Flash::Get(Parameters::ID::kOtaTlvEncryptionKey, keySpan.data(), keySpan.size(), keyLen));
     keySpan.reduce_size(keyLen);
 
-    VerifyOrReturnError(keySpan.size() == chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(keySpan.size() == chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength,
+                        CHIP_ERROR_INVALID_ARGUMENT);
 
     chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::Decrypt((const ByteSpan) keySpan, block, ivOffset);
     return CHIP_NO_ERROR;

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -751,7 +751,7 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
 {
 #if defined(SL_MBEDTLS_USE_TINYCRYPT)
     uint8_t keyBuffer[Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength] = { 0 };
-    size_t keyLen                                                                              = 0;
+    size_t keyLen                                                           = 0;
 
     // Read the key from the provisioning storage
     MutableByteSpan keySpan = MutableByteSpan(keyBuffer);
@@ -759,8 +759,7 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
     ReturnErrorOnFailure(Flash::Get(Parameters::ID::kOtaTlvEncryptionKey, keySpan.data(), keySpan.size(), keyLen));
     keySpan.reduce_size(keyLen);
 
-    VerifyOrReturnError(keySpan.size() == Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength,
-                        CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(keySpan.size() == Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength, CHIP_ERROR_INVALID_ARGUMENT);
 
     Silabs::OtaTlvEncryptionKey::Decrypt((const ByteSpan) keySpan, block, ivOffset);
     return CHIP_NO_ERROR;

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -750,7 +750,7 @@ CHIP_ERROR Storage::GetOtaTlvEncryptionKeyId(uint32_t & keyId)
 CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uint32_t & ivOffset)
 {
 #if defined(SL_MBEDTLS_USE_TINYCRYPT)
-    uint8_t keyBuffer[kOTAEncryptionKeyLength] = { 0 };
+    uint8_t keyBuffer[chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength] = { 0 };
     size_t keyLen                              = 0;
 
     // Read the key from the provisioning storage
@@ -759,9 +759,9 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
     ReturnErrorOnFailure(Flash::Get(Parameters::ID::kOtaTlvEncryptionKey, keySpan.data(), keySpan.size(), keyLen));
     keySpan.reduce_size(keyLen);
 
-    VerifyOrReturnError(keySpan.size() == kOTAEncryptionKeyLength, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(keySpan.size() == chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength, CHIP_ERROR_INVALID_ARGUMENT);
 
-    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::OtaTlvEncryptionKey.Decrypt((const ByteSpan) keySpan, block, ivOffset);
+    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::OtaTlvEncryptionKey::Decrypt((const ByteSpan) keySpan, block, ivOffset);
     return CHIP_NO_ERROR;
 #else  // MBEDTLS_USE_PSA_CRYPTO
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -731,7 +731,7 @@ CHIP_ERROR Storage::SetOtaTlvEncryptionKey(const ByteSpan & value)
     // Tinycrypt doesn't support the key ID, so we need to store the key as a binary blob
     return Flash::Set(Parameters::ID::kOtaTlvEncryptionKey, value.data(), value.size());
 #else  // MBEDTLS_USE_PSA_CRYPTO
-    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::OtaTlvEncryptionKey key;
+    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey key;
     ReturnErrorOnFailure(key.Import(value.data(), value.size()));
     return Flash::Set(Parameters::ID::kOtaTlvEncryptionKey, key.GetId());
 #endif // SL_MBEDTLS_USE_TINYCRYPT
@@ -761,7 +761,7 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
 
     VerifyOrReturnError(keySpan.size() == chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::kOTAEncryptionKeyLength, CHIP_ERROR_INVALID_ARGUMENT);
 
-    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::OtaTlvEncryptionKey::Decrypt((const ByteSpan) keySpan, block, ivOffset);
+    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::Decrypt((const ByteSpan) keySpan, block, ivOffset);
     return CHIP_NO_ERROR;
 #else  // MBEDTLS_USE_PSA_CRYPTO
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;

--- a/src/platform/silabs/multi-ota/OTACustomProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTACustomProcessor.cpp
@@ -21,18 +21,6 @@
 
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 
-#if SL_WIFI
-#include <platform/silabs/wifi/wf200/platform/spi_multiplex.h>
-#endif // SL_WIFI
-
-extern "C" {
-#include "btl_interface.h"
-#include "sl_core.h"
-}
-
-/// No error, operation OK
-#define SL_BOOTLOADER_OK 0L
-
 namespace chip {
 
 // Define static memebers

--- a/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
@@ -30,7 +30,7 @@ CHIP_ERROR OTAFactoryDataProcessor::ProcessInternal(ByteSpan & block)
     ReturnErrorOnFailure(mAccumulator.Accumulate(block));
 #if OTA_ENCRYPTION_ENABLE
     MutableByteSpan byteBlock = MutableByteSpan(mAccumulator.data(), mAccumulator.GetThreshold());
-    OTATlvProcessor::vOtaProcessInternalEncryption(byteblock);
+    OTATlvProcessor::vOtaProcessInternalEncryption(byteBlock);
 #endif
     error = DecodeTlv();
 

--- a/src/platform/silabs/multi-ota/OTAFirmwareProcessor.h
+++ b/src/platform/silabs/multi-ota/OTAFirmwareProcessor.h
@@ -33,7 +33,7 @@ private:
     CHIP_ERROR ProcessInternal(ByteSpan & block) override;
     CHIP_ERROR ProcessDescriptor(ByteSpan & block);
 
-    bool mDescriptorProcessed = false;
+    bool mDescriptorProcessed               = false;
     static constexpr size_t kAlignmentBytes = 64;
     static uint32_t mWriteOffset; // End of last written block
     static uint8_t mSlotId;       // Bootloader storage slot

--- a/src/platform/silabs/multi-ota/OTAFirmwareProcessor.h
+++ b/src/platform/silabs/multi-ota/OTAFirmwareProcessor.h
@@ -34,9 +34,6 @@ private:
     CHIP_ERROR ProcessDescriptor(ByteSpan & block);
 
     bool mDescriptorProcessed = false;
-#if OTA_ENCRYPTION_ENABLE
-    uint32_t mUnalignmentNum = 0;
-#endif
     static constexpr size_t kAlignmentBytes = 64;
     static uint32_t mWriteOffset; // End of last written block
     static uint8_t mSlotId;       // Bootloader storage slot

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
@@ -141,7 +141,7 @@ CHIP_ERROR OTATlvProcessor::vOtaProcessInternalEncryption(MutableByteSpan & bloc
 #else  // MBEDTLS_USE_PSA_CRYPTO
     uint32_t keyId;
     Provision::Manager::GetInstance().GetStorage().GetOtaTlvEncryptionKeyId(keyId);
-    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey::OtaTlvEncryptionKey key(keyId);
+    chip::DeviceLayer::Silabs::OtaTlvEncryptionKey key(keyId);
 
     key.Decrypt(block, mIVOffset);
 #endif // SL_MBEDTLS_USE_TINYCRYPT

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.h
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.h
@@ -193,7 +193,7 @@ protected:
     uint32_t mIVOffset = 0;
     /* Expected byte size of the OTAEncryptionKeyLength */
     static constexpr size_t kOTAEncryptionKeyLength = 16;
-    uint32_t mUnalignmentNum = 0;
+    uint32_t mUnalignmentNum                        = 0;
 #endif
     uint32_t mLength                             = 0;
     uint32_t mProcessedLength                    = 0;

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.h
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.h
@@ -193,6 +193,7 @@ protected:
     uint32_t mIVOffset = 0;
     /* Expected byte size of the OTAEncryptionKeyLength */
     static constexpr size_t kOTAEncryptionKeyLength = 16;
+    uint32_t mUnalignmentNum = 0;
 #endif
     uint32_t mLength                             = 0;
     uint32_t mProcessedLength                    = 0;

--- a/src/platform/silabs/multi-ota/OtaTlvEncryptionKey.h
+++ b/src/platform/silabs/multi-ota/OtaTlvEncryptionKey.h
@@ -12,14 +12,12 @@
 namespace chip {
 namespace DeviceLayer {
 namespace Silabs {
-namespace OtaTlvEncryptionKey {
-
-static constexpr uint32_t kAES_KeyId_Default    = (PSA_KEY_ID_USER_MIN + 2);
-static constexpr size_t kOTAEncryptionKeyLength = 128u / 8u; // 128 bits KeyLength expressed in bytes.
-
 class OtaTlvEncryptionKey
 {
 public:
+    static constexpr uint32_t kAES_KeyId_Default    = (PSA_KEY_ID_USER_MIN + 2);
+    static constexpr size_t kOTAEncryptionKeyLength = 128u / 8u; // 128 bits KeyLength expressed in bytes.
+    
     OtaTlvEncryptionKey(uint32_t id = 0) { mId = (id > 0) ? id : kAES_KeyId_Default; }
     ~OtaTlvEncryptionKey() = default;
 
@@ -35,7 +33,6 @@ protected:
     uint32_t mId = 0;
 };
 
-} // namespace OtaTlvEncryptionKey
 } // namespace Silabs
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/silabs/multi-ota/OtaTlvEncryptionKey.h
+++ b/src/platform/silabs/multi-ota/OtaTlvEncryptionKey.h
@@ -17,7 +17,7 @@ class OtaTlvEncryptionKey
 public:
     static constexpr uint32_t kAES_KeyId_Default    = (PSA_KEY_ID_USER_MIN + 2);
     static constexpr size_t kOTAEncryptionKeyLength = 128u / 8u; // 128 bits KeyLength expressed in bytes.
-    
+
     OtaTlvEncryptionKey(uint32_t id = 0) { mId = (id > 0) ? id : kAES_KeyId_Default; }
     ~OtaTlvEncryptionKey() = default;
 

--- a/src/platform/silabs/multi-ota/OtaTlvEncryptionKeyMbed.cpp
+++ b/src/platform/silabs/multi-ota/OtaTlvEncryptionKeyMbed.cpp
@@ -9,7 +9,7 @@ namespace DeviceLayer {
 namespace Silabs {
 namespace OtaTlvEncryptionKey {
 
-static CHIP_ERROR OtaTlvEncryptionKey::Decrypt(const ByteSpan & key, MutableByteSpan & block, uint32_t & mIVOffset)
+CHIP_ERROR OtaTlvEncryptionKey::Decrypt(const ByteSpan & key, MutableByteSpan & block, uint32_t & mIVOffset)
 {
     uint8_t iv[16]           = { AU8IV_INIT_VALUE };
     uint8_t stream_block[16] = { 0 };

--- a/src/platform/silabs/multi-ota/OtaTlvEncryptionKeyMbed.cpp
+++ b/src/platform/silabs/multi-ota/OtaTlvEncryptionKeyMbed.cpp
@@ -7,7 +7,6 @@
 namespace chip {
 namespace DeviceLayer {
 namespace Silabs {
-namespace OtaTlvEncryptionKey {
 
 CHIP_ERROR OtaTlvEncryptionKey::Decrypt(const ByteSpan & key, MutableByteSpan & block, uint32_t & mIVOffset)
 {
@@ -49,7 +48,6 @@ CHIP_ERROR OtaTlvEncryptionKey::Decrypt(const ByteSpan & key, MutableByteSpan & 
     mbedtls_aes_free(&aes_ctx);
     return CHIP_NO_ERROR;
 }
-} // namespace OtaTlvEncryptionKey
 } // namespace Silabs
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/silabs/multi-ota/OtaTlvEncryptionKeyPSA.cpp
+++ b/src/platform/silabs/multi-ota/OtaTlvEncryptionKeyPSA.cpp
@@ -8,7 +8,6 @@
 namespace chip {
 namespace DeviceLayer {
 namespace Silabs {
-namespace OtaTlvEncryptionKey {
 
 using SilabsConfig = chip::DeviceLayer::Internal::SilabsConfig;
 
@@ -121,7 +120,6 @@ CHIP_ERROR OtaTlvEncryptionKey::Decrypt(MutableByteSpan & block, uint32_t & mIVO
     return CHIP_NO_ERROR;
 }
 
-} // namespace OtaTlvEncryptionKey
 } // namespace Silabs
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/silabs/multi-ota/SiWx917/OTAWiFiFirmwareProcessor.h
+++ b/src/platform/silabs/multi-ota/SiWx917/OTAWiFiFirmwareProcessor.h
@@ -44,10 +44,6 @@ private:
     static constexpr size_t kAlignmentBytes = 64;
     static constexpr size_t kBlockSize      = 1024;
 
-#if OTA_ENCRYPTION_ENABLE
-    uint32_t mUnalignmentNum = 0;
-#endif // OTA_ENCRYPTION_ENABLE
-
     CHIP_ERROR ProcessInternal(ByteSpan & block) override;
 
     /**


### PR DESCRIPTION
### Changelog
 - Fixed build of multi-ota when custom TLV is enabled and encryption enabled on 917 SoC
 - Clean up

### Testing
Verified multi-ota with 917 SoC for plain image as well as encryption enabled and working.
OTA file creation commands : `./third_party/matter_sdk/scripts/tools/silabs/ota/ota_multi_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 2 -vs "2.0" -da sha256 --app-input-file soc_combined.rps combined.ota`
` ./third_party/matter_sdk/scripts/tools/silabs/ota/ota_multi_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 2 -vs "2.0" -da sha256 --app-input-file soc_combined_enc.rps combined_enc.ota --enc_enable --input_ota_key 0287421a84c97308a4d47371fe462e25`


