### PR TITLE
[SL-UP] Fixing the IPv4 builds for NCP and SoC

### DIFF
--- a/src/platform/silabs/wifi/lwip-support/dhcp_client.cpp
+++ b/src/platform/silabs/wifi/lwip-support/dhcp_client.cpp
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#include "lwip/opt.h"
+
 #if LWIP_IPV4 && LWIP_DHCP
 
 #include <stdio.h>
@@ -29,20 +31,6 @@
 
 #define MAX_DHCP_TRIES (4)
 #define NETIF_IPV4_ADDRESS(X, Y) (((X) >> (8 * Y)) & 0xFF)
-
-/* Station IP address */
-uint8_t sta_ip_addr0      = STA_IP_ADDR0_DEFAULT;
-uint8_t sta_ip_addr1      = STA_IP_ADDR1_DEFAULT;
-uint8_t sta_ip_addr2      = STA_IP_ADDR2_DEFAULT;
-uint8_t sta_ip_addr3      = STA_IP_ADDR3_DEFAULT;
-uint8_t sta_netmask_addr0 = STA_NETMASK_ADDR0_DEFAULT;
-uint8_t sta_netmask_addr1 = STA_NETMASK_ADDR1_DEFAULT;
-uint8_t sta_netmask_addr2 = STA_NETMASK_ADDR2_DEFAULT;
-uint8_t sta_netmask_addr3 = STA_NETMASK_ADDR3_DEFAULT;
-uint8_t sta_gw_addr0      = STA_GW_ADDR0_DEFAULT;
-uint8_t sta_gw_addr1      = STA_GW_ADDR1_DEFAULT;
-uint8_t sta_gw_addr2      = STA_GW_ADDR2_DEFAULT;
-uint8_t sta_gw_addr3      = STA_GW_ADDR3_DEFAULT;
 
 /// Current DHCP state machine state.
 static volatile uint8_t dhcp_state = DHCP_OFF;
@@ -77,9 +65,6 @@ void dhcpclient_set_link_state(int link_up)
 uint8_t dhcpclient_poll(void * arg)
 {
     struct netif * netif = (struct netif *) arg;
-    ip_addr_t ipaddr;
-    ip_addr_t netmask;
-    ip_addr_t gw;
     struct dhcp * dhcp;
 
     switch (dhcp_state)
@@ -110,13 +95,6 @@ uint8_t dhcpclient_poll(void * arg)
                 ChipLogProgress(DeviceLayer, "*ERR*DHCP: Failed");
                 /* Stop DHCP */
                 dhcp_stop(netif);
-
-                /* TODO - I am not sure that this is best */
-                /* Static address used */
-                IP_ADDR4(&ipaddr, sta_ip_addr0, sta_ip_addr1, sta_ip_addr2, sta_ip_addr3);
-                IP_ADDR4(&netmask, sta_netmask_addr0, sta_netmask_addr1, sta_netmask_addr2, sta_netmask_addr3);
-                IP_ADDR4(&gw, sta_gw_addr0, sta_gw_addr1, sta_gw_addr2, sta_gw_addr3);
-                netif_set_addr(netif, ip_2_ip4(&ipaddr), ip_2_ip4(&netmask), ip_2_ip4(&gw));
             }
         }
         break;

--- a/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
@@ -829,7 +829,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     ChipLogProgress(DeviceLayer, "DHCP OK: IP=%d.%d.%d.%d", wfx_rsi.ip4_addr[0], wfx_rsi.ip4_addr[1], wfx_rsi.ip4_addr[2],
                     wfx_rsi.ip4_addr[3]);
     /* Notify the Connectivity Manager - via the app */
-    wfx_rsi.dev_state.Set(WifiState::kStationDhcpDone, WifiState::kStationReady);
+    wfx_rsi.dev_state.Set(WifiState::kStationDhcpDone).Set(WifiState::kStationReady);
     wfx_ip_changed_notify(IP_STATUS_SUCCESS);
 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */


### PR DESCRIPTION
The IPv4 build was failing after the refactor. Fixing the IPv4 enabled build

CSA PR: https://github.com/project-chip/connectedhomeip/pull/38830

#### Testing
Tested with ncp and soc commissioning with both ipv4 and ipv6 enabled