### PR TITLE
[SL-ONLY] Add a stub for backward compatibility: cherry-pick (#39231)

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -431,6 +431,11 @@ CHIP_ERROR BaseApplication::BaseInit()
     return err;
 }
 
+void BaseApplication::InitCompleteCallback(CHIP_ERROR err)
+{
+    // A stub for backward compatibility
+}
+
 void BaseApplication::FunctionTimerEventHandler(void * timerCbArg)
 {
     AppEvent event;

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -199,6 +199,9 @@ protected:
      */
     virtual CHIP_ERROR AppInit() = 0;
 
+    /* A stub for backward compatibility */
+    void InitCompleteCallback(CHIP_ERROR err);
+
     /**
      * @brief Function called to start the function timer
      *


### PR DESCRIPTION
Cherry-pick https://github.com/project-chip/connectedhomeip/pull/39231

Original PR Description:

Overview
The InitCompleteCallback() method was removed in a recent code refactoring change. Re-add it as a stub for backward compatibility. This change is required to support the Silicon Labs Simplicity Studio development environment, enabling projects created with an older version of Matter to be migrated to a newer version. Since existing projects may call deprecated methods, this stub implementation is added to ensure successful compilation.

Testing
Verified that this change gets rid of the compilation error after a Lighting App project is upgraded from an earlier version. Ran full build on the matter_extension