### PR TITLE
[SL-UP] Use sl_system logic in upgraded projects

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -431,7 +431,7 @@ CHIP_ERROR BaseApplication::BaseInit()
     return err;
 }
 
-void BaseApplication::InitCompleteCallback(CHIP_ERROR err)
+void BaseApplication::InitCompleteCallback([[maybe_unused]] CHIP_ERROR err)
 {
     // A stub for backward compatibility
 }

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -205,12 +205,15 @@ void SilabsMatterConfig::AppInit()
 {
     GetPlatform().Init();
     sMainTaskHandle = osThreadNew(ApplicationStart, nullptr, &kMainTaskAttr);
+
+
     ChipLogProgress(DeviceLayer, "Starting scheduler");
     VerifyOrDie(sMainTaskHandle); // We can't proceed if the Main Task creation failed.
 
 // SL-TEMP: GN cannot use sl_main until it supports sisdk 2025.6
 // sl_system_init is always used for 917 soc
-#if (SL_MATTER_GN_BUILD == 1 || SLI_SI91X_MCU_INTERFACE)
+// Also use sl_system for projects upgraded to 2025.6, identified by the presence of SL_CATALOG_CUSTOM_MAIN_PRESENT
+#if (SL_MATTER_GN_BUILD == 1 || SLI_SI91X_MCU_INTERFACE) || defined (SL_CATALOG_CUSTOM_MAIN_PRESENT)
     GetPlatform().StartScheduler();
 
     // Should never get here.

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -205,15 +205,13 @@ void SilabsMatterConfig::AppInit()
 {
     GetPlatform().Init();
     sMainTaskHandle = osThreadNew(ApplicationStart, nullptr, &kMainTaskAttr);
-
-
     ChipLogProgress(DeviceLayer, "Starting scheduler");
     VerifyOrDie(sMainTaskHandle); // We can't proceed if the Main Task creation failed.
 
 // SL-TEMP: GN cannot use sl_main until it supports sisdk 2025.6
 // sl_system_init is always used for 917 soc
 // Also use sl_system for projects upgraded to 2025.6, identified by the presence of SL_CATALOG_CUSTOM_MAIN_PRESENT
-#if (SL_MATTER_GN_BUILD == 1 || SLI_SI91X_MCU_INTERFACE) || defined (SL_CATALOG_CUSTOM_MAIN_PRESENT)
+#if (SL_MATTER_GN_BUILD == 1 || SLI_SI91X_MCU_INTERFACE) || defined(SL_CATALOG_CUSTOM_MAIN_PRESENT)
     GetPlatform().StartScheduler();
 
     // Should never get here.

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -232,7 +232,7 @@ void SilabsPlatform::StartScheduler()
 {
 // SL-TEMP: GN cannot use sl_main until it supports sisdk 2025.6 Use sl_system
 // Also use sl_system for projects upgraded to 2025.6, identified by the presence of SL_CATALOG_CUSTOM_MAIN_PRESENT
-#if (SL_MATTER_GN_BUILD == 1) || defined (SL_CATALOG_CUSTOM_MAIN_PRESENT)
+#if (SL_MATTER_GN_BUILD == 1) || defined(SL_CATALOG_CUSTOM_MAIN_PRESENT)
     sl_system_kernel_start();
 #endif
 }

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -30,7 +30,7 @@
 
 // SL-TEMP: GN cannot use sl_main until it supports sisdk 2025.6 Use sl_system
 // Also use sl_system for projects upgraded to 2025.6, identified by the presence of SL_CATALOG_CUSTOM_MAIN_PRESENT
-#if (SL_MATTER_GN_BUILD == 1) || defined (SL_CATALOG_CUSTOM_MAIN_PRESENT)
+#if (SL_MATTER_GN_BUILD == 1) || defined(SL_CATALOG_CUSTOM_MAIN_PRESENT)
 #include "sl_system_kernel.h"
 #endif
 

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -29,7 +29,8 @@
 #endif // _SILICON_LABS_32B_SERIES_2
 
 // SL-TEMP: GN cannot use sl_main until it supports sisdk 2025.6 Use sl_system
-#if (SL_MATTER_GN_BUILD == 1)
+// Also use sl_system for projects upgraded to 2025.6, identified by the presence of SL_CATALOG_CUSTOM_MAIN_PRESENT
+#if (SL_MATTER_GN_BUILD == 1) || defined (SL_CATALOG_CUSTOM_MAIN_PRESENT)
 #include "sl_system_kernel.h"
 #endif
 
@@ -230,7 +231,8 @@ CHIP_ERROR SilabsPlatform::ToggleLed(uint8_t led)
 void SilabsPlatform::StartScheduler()
 {
 // SL-TEMP: GN cannot use sl_main until it supports sisdk 2025.6 Use sl_system
-#if (SL_MATTER_GN_BUILD == 1)
+// Also use sl_system for projects upgraded to 2025.6, identified by the presence of SL_CATALOG_CUSTOM_MAIN_PRESENT
+#if (SL_MATTER_GN_BUILD == 1) || defined (SL_CATALOG_CUSTOM_MAIN_PRESENT)
     sl_system_kernel_start();
 #endif
 }


### PR DESCRIPTION
#### Overview 

With SiSDK 2025.6.0 the Matter projects use the sl_main component and the corresponding scheduling initialization logic. The projects upgraded to SiSDK 2025.6.0 (Matter 2.6.0) use the sl_system and the corresponding logic (project upgrades do not modify main.cpp). The current PR selects the sl_system logic to be followed in the upgraded projects. The upgraded projects are detected by the presence of the SL_CATALOG_CUSTOM_MAIN_PRESENT: the sl_main_custom_main component is new in 2025.6.0 and is added to the project by the SiSDK upgrade rule. See https://github.com/SiliconLabsSoftware/matter_sdk/pull/450 for context. 

Unrelated to the above, add [[maybe_unused]] to a stub function to prevent possible compile warnings. 

#### Testing

Verified that Matter/Thread projects upgraded from 2.4.5-1.4 to 2.6.0-1.4 successfully commission. 