### PR TITLE
[SL-UP] Adds fix for multi ota custom TLV and factory data update issue

### DIFF
--- a/src/platform/silabs/multi-ota/OTACustomProcessor.h
+++ b/src/platform/silabs/multi-ota/OTACustomProcessor.h
@@ -33,7 +33,6 @@ private:
     CHIP_ERROR ProcessInternal(ByteSpan & block) override;
     CHIP_ERROR ProcessDescriptor(ByteSpan & block);
 
-    OTADataAccumulator mAccumulator;
     bool mDescriptorProcessed               = false;
     static constexpr size_t kAlignmentBytes = 64;
     static uint32_t mWriteOffset; // End of last written block

--- a/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.h
+++ b/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.h
@@ -72,7 +72,6 @@ private:
     CHIP_ERROR UpdateValue(uint8_t tag, ByteSpan & newValue);
 
     OTAFactoryPayload mPayload;
-    OTADataAccumulator mAccumulator;
     uint8_t * mFactoryData = nullptr;
 
 protected:


### PR DESCRIPTION
#### Changelog
Fixed issue of multi-ota with custom TLV  and factory data update

#### Testing

- Verified multi-ota with custom TLVs enabled on BRD4187C + 917 NCP and it is working fine

`./third_party/matter_sdk/scripts/tools/silabs/ota/ota_multi_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 2 -vs "2.0" -da sha256 --app-input-file lock-app-917-ncp.gbl --json third_party/matter_sdk/scripts/tools/silabs/ota/examples/ota_custom_entries_example.json ncp_custom.ota
`
- Verified multi-ota with factory data update on BRD4187C thread board and it is working as expected.

`./third_party/matter_sdk/scripts/tools/silabs/ota/ota_multi_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 2 -vs "2.0" -da sha256 --factory-data --dac_cert provision/samples/light/3/dac_cert.der --dac_key provision/samples/light/3/dac_key.der --pai_cert provision/samples/light/3/pai_cert.der --cert_declaration provision/samples/light/3/cd.bin matter-silabs-lighting-example_v2.ota`
