### PR TITLE
[SL-UP] Removing the unused variable when multi ota is enabled

### DIFF
--- a/src/platform/silabs/multi-ota/OtaTlvEncryptionKeyMbed.cpp
+++ b/src/platform/silabs/multi-ota/OtaTlvEncryptionKeyMbed.cpp
@@ -13,7 +13,6 @@ CHIP_ERROR OtaTlvEncryptionKey::Decrypt(const ByteSpan & key, MutableByteSpan & 
     uint8_t iv[16]           = { AU8IV_INIT_VALUE };
     uint8_t stream_block[16] = { 0 };
     size_t nc_off            = 0;
-    size_t remaining         = block.size();
 
     // Set IV based on mIVOffset
     uint32_t counter = ((uint32_t) iv[12] << 24) | ((uint32_t) iv[13] << 16) | ((uint32_t) iv[14] << 8) | (uint32_t) iv[15];


### PR DESCRIPTION
#### Summary

The build for 917 SoC is failing when multi ota is enabled.

#### Related issues
https://jira.silabs.com/browse/MATTER-5096

#### Testing
Local build with mult-ota enabled.

