### PR TITLE
[SL-UP] Init fix for timer failure

### DIFF
--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -161,10 +161,9 @@ AppTask::Timer::~Timer()
 
 void AppTask::Timer::Stop()
 {
-    osStatus_t status = osTimerStop(mHandler);
-    if (status != osOK)
+    if (osTimerStop(mHandler) == osError)
     {
-        SILABS_LOG("Timer stop() failed with error : %ld", status);
+        SILABS_LOG("Timer stop() failed");
         appError(APP_ERROR_STOP_TIMER_FAILED);
     }
     mIsActive = false;

--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -161,6 +161,7 @@ AppTask::Timer::~Timer()
 
 void AppTask::Timer::Stop()
 {
+    // Abort on osError (-1) as it indicates an unspecified failure with no clear recovery path.
     if (osTimerStop(mHandler) == osError)
     {
         SILABS_LOG("Timer stop() failed");

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -529,10 +529,9 @@ WindowManager::Timer::~Timer()
 void WindowManager::Timer::Stop()
 {
     mIsActive         = false;
-    osStatus_t status = osTimerStop(mHandler);
-    if (status != osOK)
+    if (osTimerStop(mHandler) == osError)
     {
-        SILABS_LOG("Timer stop() failed with error: %ld", status);
+        SILABS_LOG("Timer stop() failed");
         appError(APP_ERROR_STOP_TIMER_FAILED);
     }
 }

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -528,7 +528,7 @@ WindowManager::Timer::~Timer()
 
 void WindowManager::Timer::Stop()
 {
-    mIsActive         = false;
+    mIsActive = false;
     if (osTimerStop(mHandler) == osError)
     {
         SILABS_LOG("Timer stop() failed");

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -528,12 +528,13 @@ WindowManager::Timer::~Timer()
 
 void WindowManager::Timer::Stop()
 {
-    mIsActive = false;
+    // Abort on osError (-1) as it indicates an unspecified failure with no clear recovery path.
     if (osTimerStop(mHandler) == osError)
     {
         SILABS_LOG("Timer stop() failed");
         appError(APP_ERROR_STOP_TIMER_FAILED);
     }
+    mIsActive = false;
 }
 
 void WindowManager::Timer::TimerCallback(void * timerCbArg)


### PR DESCRIPTION
#### Summary

Init failure is seen in window-app and light-switch app due to timer-stop failure after factory-reset.

In this [PR](https://github.com/SiliconLabsSoftware/matter_sdk/pull/486), the error handling has been modified. In timer::Stop() API in window-app and light-switch app, if Timer::Stop() function doesn't return osOk(success code), the error is being logged and the app will be aborted. Earlier, Timer::Stop() function is being aborted only if it returns osError (error code -1).


After factory-reset, btn0 release event is being posted. This event will call Timer::Stop() function, which is failing with error code -3(osErrorResource //Resource not available.).

Below is the flow of timer actions on button press and release : 
When btn0 is pressed - a new timer will be started as follows : 
> osTimerStart(mHandler, pdMS_TO_TICKS(100));

After 100 ticks, the timer will be expired.
When btn0 is released (after a short press), the timer which was created during press will be stopped as below : 

> osStatus_t status = osTimerStop(mHandler);

Now, since the timer created during btn0 press expires in 100ms, if btn0 is released after 100ms, osTimerStop() fails as the timer is not available and returns -3 error code.

In the current PR, the error handling for Timer::Stop() API is being reverted. 

#### Related issues
[MATTER-5098](https://jira.silabs.com/browse/MATTER-5098)

#### Testing
Build and flashed window-app and light-switch app on 917SOC. Triggered factory-reset and confirmed that the app is not getting crashed.
