### PR TITLE
[SL-UP] BLE Side channel indicate/notify support

### DIFF
--- a/examples/platform/silabs/shell/ble/BLEShellCommands.cpp
+++ b/examples/platform/silabs/shell/ble/BLEShellCommands.cpp
@@ -56,7 +56,6 @@ CHIP_ERROR BLECommandHandler(int argc, char ** argv)
 
 CHIP_ERROR StartBLESideChannelAdvertising(int argc, char ** argv)
 {
-    // TODO : Configure first
     CHIP_ERROR err = DeviceLayer::Internal::BLEMgrImpl().SideChannelConfigureAdvertisingDefaultData();
     VerifyOrReturnError(
         err == CHIP_NO_ERROR, err,
@@ -73,6 +72,24 @@ CHIP_ERROR StopBLESideChannelAvertising(int argc, char ** argv)
     return DeviceLayer::Internal::BLEMgrImpl().SideChannelStopAdvertising();
 }
 
+CHIP_ERROR NotifyBLESideChannel(int argc, char ** argv)
+{
+    CHIP_ERROR err = DeviceLayer::Internal::BLEMgrImpl().SideChannelNotify();
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err,
+                        streamer_printf(streamer_get(), "Failed to notify BLE side channel: %s\n", ErrorStr(err)););
+    streamer_printf(streamer_get(), "Notified BLE side channel\n");
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR IndicateBLESideChannel(int argc, char ** argv)
+{
+    CHIP_ERROR err = DeviceLayer::Internal::BLEMgrImpl().SideChannelIndicate();
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err,
+                        streamer_printf(streamer_get(), "Failed to indicate BLE side channel: %s\n", ErrorStr(err)););
+    streamer_printf(streamer_get(), "Indicated BLE side channel\n");
+    return CHIP_NO_ERROR;
+}
+
 } // namespace
 
 namespace BLEShellCommands {
@@ -83,6 +100,10 @@ void RegisterCommands()
         { &BLEHelpHandler, "help", "Output the BLE Commands help menu" },
         { &StartBLESideChannelAdvertising, "AdvStart", "Start BLE Side Channel advertising with default parameters" },
         { &StopBLESideChannelAvertising, "AdvStop", "Stop BLE Side Channel advertising" },
+        { &NotifyBLESideChannel, "Notify",
+          "Make the side channel send a notify event for its tx characteristic (if the CCCD is set)" },
+        { &IndicateBLESideChannel, "Indicate",
+          "Make the side channel send an indicate event for its tx characteristic (if the CCCD is set)" },
     };
     static const Shell::Command sBleCmds = { &BLECommandHandler, "ble-side", "Dispatch Silicon Labs BLE Side Channel commands" };
 

--- a/examples/platform/silabs/shell/ble/BLEShellCommands.cpp
+++ b/examples/platform/silabs/shell/ble/BLEShellCommands.cpp
@@ -54,6 +54,10 @@ CHIP_ERROR BLECommandHandler(int argc, char ** argv)
     return sShellBLESubCommands.ExecCommand(argc, argv);
 }
 
+} // namespace
+
+namespace BLEShellCommands {
+
 CHIP_ERROR StartBLESideChannelAdvertising(int argc, char ** argv)
 {
     CHIP_ERROR err = DeviceLayer::Internal::BLEMgrImpl().SideChannelConfigureAdvertisingDefaultData();
@@ -89,10 +93,6 @@ CHIP_ERROR IndicateBLESideChannel(int argc, char ** argv)
     streamer_printf(streamer_get(), "Indicated BLE side channel\n");
     return CHIP_NO_ERROR;
 }
-
-} // namespace
-
-namespace BLEShellCommands {
 
 void RegisterCommands()
 {

--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -87,7 +87,16 @@ public:
                                                uint16_t duration, uint8_t maxEvents);
     CHIP_ERROR SideChannelStartAdvertising(void);
     CHIP_ERROR SideChannelStopAdvertising(void);
-
+    CHIP_ERROR SideChannelIndicate(void)
+    {
+        VerifyOrReturnError(mBleSideChannel != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        return mBleSideChannel->IndicateCharacteristic(mBleSideChannel->GetTXCharHandle());
+    }
+    CHIP_ERROR SideChannelNotify(void)
+    {
+        VerifyOrReturnError(mBleSideChannel != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        return mBleSideChannel->NotifyCharacteristic(mBleSideChannel->GetTXCharHandle());
+    }
     // GAP
     CHIP_ERROR SideChannelGeneratAdvertisingData(uint8_t discoverMove, uint8_t connectMode, const Optional<uint16_t> & maxEvents)
     {
@@ -119,21 +128,21 @@ public:
     CHIP_ERROR SideChannelCloseConnection(void) { return mBleSideChannel->CloseConnection(); }
 
     // GATT (All these methods need some event handling to be done in sl_bt_on_event)
-    CHIP_ERROR SideChannelDiscoverServices(void) { return mBleSideChannel->DiscoverServices(); }
+    CHIP_ERROR SideChannelDiscoverServices(void) { return mBleSideChannel->DiscoverRemoteServices(); }
     CHIP_ERROR SideChannelDiscoverCharacteristics(uint32_t serviceHandle)
     {
         VerifyOrReturnError(mBleSideChannel != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        return mBleSideChannel->DiscoverCharacteristics(serviceHandle);
+        return mBleSideChannel->DiscoverRemoteCharacteristics(serviceHandle);
     }
-    CHIP_ERROR SideChannelSetCharacteristicNotification(uint8_t characteristicHandle, uint8_t flags)
+    CHIP_ERROR SideChannelSetCharacteristicNotification(uint16_t characteristicHandle, uint8_t flags)
     {
         VerifyOrReturnError(mBleSideChannel != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        return mBleSideChannel->SetCharacteristicNotification(characteristicHandle, flags);
+        return mBleSideChannel->SetRemoteCharacteristicNotification(characteristicHandle, flags);
     }
-    CHIP_ERROR SideChannelSetCharacteristicValue(uint8_t characteristicHandle, const ByteSpan & value)
+    CHIP_ERROR SideChannelSetCharacteristicValue(uint16_t characteristicHandle, const ByteSpan & value)
     {
         VerifyOrReturnError(mBleSideChannel != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        return mBleSideChannel->SetCharacteristicValue(characteristicHandle, value);
+        return mBleSideChannel->SetRemoteCharacteristicValue(characteristicHandle, value);
     }
     bd_addr SideChannelGetAddr(void) { return mBleSideChannel->GetRandomizedAddr(); }
     BLEConState SideChannelGetConnectionState(void) { return mBleSideChannel->GetConnectionState(); }

--- a/src/platform/silabs/efr32/BLEChannel.h
+++ b/src/platform/silabs/efr32/BLEChannel.h
@@ -85,21 +85,44 @@ public:
     virtual CHIP_ERROR StartAdvertising(void) = 0;
     virtual CHIP_ERROR StopAdvertising(void)  = 0;
 
-    virtual void AddConnection(uint8_t connectionHandle, uint8_t bondingHandle)       = 0;
-    virtual bool RemoveConnection(uint8_t connectionHandle)                           = 0;
-    virtual void HandleReadRequest(volatile sl_bt_msg_t * evt, ByteSpan data)         = 0;
-    virtual void HandleWriteRequest(volatile sl_bt_msg_t * evt, MutableByteSpan data) = 0;
+    /** @brief NotifyCharacteristic
+     * Notify a characteristic identified by its handle. This function is used to send a notification to the client
+     * subscribed to the characteristic.
+     * @param characteristicHandle The handle of the characteristic to notify.
+     * @return CHIP_NO_ERROR on success, or an error code if the notification could not be sent.
+     */
+    virtual CHIP_ERROR NotifyCharacteristic(uint16_t characteristicHandle) = 0;
+    /** @brief IndicateCharacteristic
+     * Indicate a characteristic identified by its handle. This function is used to send an indication to the client
+     * subscribed to the characteristic.
+     * @param characteristicHandle The handle of the characteristic to indicate.
+     * @return CHIP_NO_ERROR on success, or an error code if the indication could not be sent.
+     */
+    virtual CHIP_ERROR IndicateCharacteristic(uint16_t characteristicHandle) = 0;
+    virtual void HandleIndicationTimeout(volatile sl_bt_msg_t * evt)         = 0;
+    virtual void HandleIndicationConfirmation(volatile sl_bt_msg_t * evt)    = 0;
+
+    virtual void AddConnection(uint8_t connectionHandle, uint8_t bondingHandle) = 0;
+    virtual bool RemoveConnection(uint8_t connectionHandle)                     = 0;
+    virtual void HandleReadRequest(volatile sl_bt_msg_t * evt)                  = 0;
+    virtual void HandleWriteRequest(volatile sl_bt_msg_t * evt)                 = 0;
 
     /** @brief CanHandleEvent
-     *  Determine if the side channel can handle a BLE event. This only gets called if the
-     *  targetted event is not supported by MATTERoBLE as the side channel supports every
-     *  event that MATTERoBLE does.
+     *  Determine if the side channel can handle a BLE event.
      *
      * @param event uint32_t Header of sl_bt_msg_t event type
      * @return true if the event can be handled, false otherwise.
      */
     virtual bool CanHandleEvent(uint32_t event) { return false; }
 
+    /** @brief ParseEvent
+     *  Take the appropriate action based on the event received from the BLE stack.
+     *  Note: this method is currently not implemented as the parsing is currently handled
+     *  by the BLEManagerImpl class.
+     *  TODO: Convert ChipoBLE to BLEChannel and implement this method in the derived class.
+     *
+     * @param evt The event to parse.
+     */
     virtual void ParseEvent(volatile sl_bt_msg_t * evt) {}
 
     /** @brief CCCD Write Handler
@@ -109,13 +132,12 @@ public:
      *  whether the request requires a new subscription.
      *
      * @param evt The event containing the CCCD write request.
-     * @param isNewSubscription A boolean indicating whether the request requires a new subscription.
      *
      *
      * @return CHIP_ERROR_INCORRECT_STATE if a request is received when the connection is not allocated or a request is received
      *        for a different connection handle. CHIP_NO_ERROR if the request is handled successfully.
      */
-    virtual CHIP_ERROR HandleCCCDWriteRequest(volatile sl_bt_msg_t * evt, bool & isNewSubscription) = 0;
+    virtual CHIP_ERROR HandleCCCDWriteRequest(volatile sl_bt_msg_t * evt) = 0;
 
     virtual void UpdateMtu(volatile sl_bt_msg_t * evt) = 0;
 
@@ -161,23 +183,30 @@ public:
     virtual CHIP_ERROR SetAdvHandle(uint8_t handle) = 0;
 
     // GATT (All these methods need some event handling to be done in sl_bt_on_event)
-    virtual CHIP_ERROR DiscoverServices()                                                           = 0;
-    virtual CHIP_ERROR DiscoverCharacteristics(uint32_t serviceHandle)                              = 0;
-    virtual CHIP_ERROR SetCharacteristicNotification(uint8_t characteristicHandle, uint8_t flags)   = 0;
-    virtual CHIP_ERROR SetCharacteristicValue(uint8_t characteristicHandle, const ByteSpan & value) = 0;
+    virtual CHIP_ERROR DiscoverRemoteServices()                                                            = 0;
+    virtual CHIP_ERROR DiscoverRemoteCharacteristics(uint32_t serviceHandle)                               = 0;
+    virtual CHIP_ERROR SetRemoteCharacteristicNotification(uint16_t characteristicHandle, uint8_t flags)   = 0;
+    virtual CHIP_ERROR SetRemoteCharacteristicValue(uint16_t characteristicHandle, const ByteSpan & value) = 0;
     // CLI methods END
 
     // Getters
     uint8_t GetAdvHandle(void) const { return mAdvHandle; }
     uint8_t GetConnectionHandle(void) const { return mConnectionState.connectionHandle; }
     uint8_t GetBondingHandle(void) const { return mConnectionState.bondingHandle; }
+    uint16_t GetTXCharHandle(void) const { return mSideTxChar.handle; }
+    uint16_t GetRXCharHandle(void) const { return mSideRxChar.handle; }
     bd_addr GetRandomizedAddr(void) const { return mConnectionState.address; }
     BLEConState GetConnectionState() const { return mConnectionState; }
 
 protected:
     enum class Flags : uint16_t
     {
-        kAdvertising = 0x0001, // Todo : See about flags for connection, subscription, etc.
+        kAdvertising = 0x0001, // Todo : Mode BLEManager flags here when converting ChipOBLE to BLEChannel
+    };
+    struct Characteristic
+    {
+        uint16_t handle;
+        MutableByteSpan buffer;
     };
 
     BLEConState mConnectionState;
@@ -185,7 +214,7 @@ protected:
 
     // Advertising parameters
     // TODO: Default values should be set in a configuration file for the side channel
-    uint8_t mAdvHandle           = 0xff;
+    uint8_t mAdvHandle           = kInvalidAdvertisingHandle;
     uint32_t mAdvIntervalMin     = 0;
     uint32_t mAdvIntervalMax     = 0;
     uint16_t mAdvDuration        = 0;
@@ -194,8 +223,8 @@ protected:
     uint8_t mAdvDiscoverableMode = 0;
 
     uint16_t mSideServiceHandle = 0;
-    uint16_t mSideRxCharHandle  = 0;
-    uint16_t mSideTxCharHandle  = 0;
+    Characteristic mSideRxChar;
+    Characteristic mSideTxChar;
 };
 
 } // namespace Internal

--- a/src/platform/silabs/efr32/BLEChannel.h
+++ b/src/platform/silabs/efr32/BLEChannel.h
@@ -203,6 +203,7 @@ protected:
     {
         kAdvertising = 0x0001, // Todo : Mode BLEManager flags here when converting ChipOBLE to BLEChannel
     };
+    
     struct Characteristic
     {
         uint16_t handle;

--- a/src/platform/silabs/efr32/BLEChannel.h
+++ b/src/platform/silabs/efr32/BLEChannel.h
@@ -203,7 +203,7 @@ protected:
     {
         kAdvertising = 0x0001, // Todo : Mode BLEManager flags here when converting ChipOBLE to BLEChannel
     };
-    
+
     struct Characteristic
     {
         uint16_t handle;

--- a/src/platform/silabs/efr32/BLEChannelImpl.cpp
+++ b/src/platform/silabs/efr32/BLEChannelImpl.cpp
@@ -245,7 +245,7 @@ void BLEChannelImpl::HandleIndicationTimeout(volatile sl_bt_msg_t * evt)
 void BLEChannelImpl::HandleIndicationConfirmation(volatile sl_bt_msg_t * evt)
 {
     sl_bt_evt_gatt_server_characteristic_status_t * indicationConfirmation =
-        (sl_bt_evt_gatt_server_characteristic_status_t *) &(evt->data.evt_gatt_server_indication_timeout);
+        (sl_bt_evt_gatt_server_characteristic_status_t *) &(evt->data.evt_gatt_server_characteristic_status);
 
     VerifyOrReturn(indicationConfirmation->connection == mConnectionState.connectionHandle);
     ChipLogProgress(DeviceLayer, "Indication confirmation for connection: %d characteristic: %d",

--- a/src/platform/silabs/efr32/BLEChannelImpl.cpp
+++ b/src/platform/silabs/efr32/BLEChannelImpl.cpp
@@ -27,16 +27,25 @@ namespace Internal {
 
 namespace {
 
-// Side Channel UUIDS
-const uint8_t kSideServiceUUID[16] = { 0x01, 0x00, 0x00, 0xEE, 0xFF, 0xC0, 0x00, 0x80,
-                                       0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-const uuid_128 kRxUUID = { .data = { 0x01, 0x00, 0x00, 0xEE, 0xFF, 0xC0, 0xAD, 0xDE, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0xEE, 0xFF,
-                                     0xC0 } };
-const uuid_128 kTxUUID = { .data = { 0x02, 0x00, 0x00, 0xEE, 0xFF, 0xC0, 0xAD, 0xDE, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0xEE, 0xFF,
-                                     0xC0 } };
+inline constexpr uint8_t kAdvertisingFlagStaticRandomAddress = 1;
+inline constexpr uint8_t kAttErrorCodeNoError                = 0;
+inline constexpr uint8_t kAttErrorCodeInvalidHandle          = 0x01;
+inline constexpr uint8_t kAttErrorApplicationError           = 0x80;
+// For ble transmit, the size be smaller than  SL_BGAPI_MAX_PAYLOAD_SIZE - SL_BGAPI_MSG_HEADER_LEN : 256 - 5 = (251)
+// For sl_bt_gattdb_add_uuid128_characteristic, the size must be smaller than 255 - 30, so we pick a value below those thresholds.
+inline constexpr uint8_t kCharacteristicBufferSize = 220;
+inline constexpr uint8_t kIndicateTimeout          = 30;
 
-uint8_t InitialValueRX[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
-uint8_t InitialValueTX[16] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+// Side Channel UUIDS
+constexpr uint8_t kSideServiceUUID[16] = { 0x01, 0x00, 0x00, 0xEE, 0xFF, 0xC0, 0x00, 0x80,
+                                           0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+constexpr uuid_128 kRxUUID = { .data = { 0x01, 0x00, 0x00, 0xEE, 0xFF, 0xC0, 0xAD, 0xDE, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0xEE, 0xFF,
+                                         0xC0 } };
+constexpr uuid_128 kTxUUID = { .data = { 0x02, 0x00, 0x00, 0xEE, 0xFF, 0xC0, 0xAD, 0xDE, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0xEE, 0xFF,
+                                         0xC0 } };
+
+uint8_t sRxValueBuffer[kCharacteristicBufferSize] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+uint8_t sTxValueBuffer[kCharacteristicBufferSize] = { 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 };
 
 CHIP_ERROR MapBLEError(int bleErr)
 {
@@ -57,6 +66,19 @@ CHIP_ERROR MapBLEError(int bleErr)
     }
 }
 
+uint8_t MapCHIPError(CHIP_ERROR err)
+{
+    switch (err.AsInteger())
+    {
+    case CHIP_NO_ERROR.AsInteger():
+        return kAttErrorCodeNoError;
+    case CHIP_ERROR_INVALID_ARGUMENT.AsInteger():
+        return kAttErrorCodeInvalidHandle;
+    default:
+        return kAttErrorApplicationError;
+    }
+}
+
 } // namespace
 
 CHIP_ERROR BLEChannelImpl::Init()
@@ -72,33 +94,36 @@ CHIP_ERROR BLEChannelImpl::Init()
     VerifyOrReturnError(ret == SL_STATUS_OK, MapBLEError(ret));
 
     // Add RX characteristic
-    ret = sl_bt_gattdb_add_uuid128_characteristic(session, mSideServiceHandle,
-                                                  SL_BT_GATTDB_CHARACTERISTIC_READ | SL_BT_GATTDB_CHARACTERISTIC_WRITE,
-                                                  0, // No security
-                                                  0, // No flags
-                                                  kRxUUID, sl_bt_gattdb_variable_length_value,
-                                                  255, // Max length
-                                                  sizeof(InitialValueRX), InitialValueRX, &mSideRxCharHandle);
+    mSideRxChar.buffer = MutableByteSpan(sRxValueBuffer, sizeof(sRxValueBuffer));
+    ret                = sl_bt_gattdb_add_uuid128_characteristic(session, mSideServiceHandle,
+                                                                 SL_BT_GATTDB_CHARACTERISTIC_READ | SL_BT_GATTDB_CHARACTERISTIC_WRITE,
+                                                                 0, // No security
+                                                                 0, // No flags
+                                                                 kRxUUID, sl_bt_gattdb_variable_length_value,
+                                                                 kCharacteristicBufferSize, // Max length
+                                                                 kCharacteristicBufferSize, mSideRxChar.buffer.data(), &mSideRxChar.handle);
     VerifyOrReturnError(ret == SL_STATUS_OK, MapBLEError(ret));
 
-    ret = sl_bt_gattdb_add_uuid128_characteristic(session, mSideServiceHandle,
-                                                  SL_BT_GATTDB_CHARACTERISTIC_READ | SL_BT_GATTDB_CHARACTERISTIC_WRITE |
-                                                      SL_BT_GATTDB_CHARACTERISTIC_WRITE_NO_RESPONSE |
-                                                      SL_BT_GATTDB_CHARACTERISTIC_INDICATE,
-                                                  0, // No security
-                                                  0, // No flags
-                                                  kTxUUID, sl_bt_gattdb_variable_length_value,
-                                                  255, // Max length
-                                                  sizeof(InitialValueTX), InitialValueTX, &mSideTxCharHandle);
+    // Add TX characteristic
+    mSideTxChar.buffer = MutableByteSpan(sTxValueBuffer, sizeof(sTxValueBuffer));
+    ret                = sl_bt_gattdb_add_uuid128_characteristic(session, mSideServiceHandle,
+                                                                 SL_BT_GATTDB_CHARACTERISTIC_READ | SL_BT_GATTDB_CHARACTERISTIC_WRITE |
+                                                                     SL_BT_GATTDB_CHARACTERISTIC_WRITE_NO_RESPONSE |
+                                                                     SL_BT_GATTDB_CHARACTERISTIC_NOTIFY | SL_BT_GATTDB_CHARACTERISTIC_INDICATE,
+                                                                 0, // No security
+                                                                 0, // No flags
+                                                                 kTxUUID, sl_bt_gattdb_variable_length_value,
+                                                                 kCharacteristicBufferSize, // Max length
+                                                                 kCharacteristicBufferSize, mSideTxChar.buffer.data(), &mSideTxChar.handle);
     VerifyOrReturnError(ret == SL_STATUS_OK, MapBLEError(ret));
 
     ret = sl_bt_gattdb_start_service(session, mSideServiceHandle);
     VerifyOrReturnError(ret == SL_STATUS_OK, MapBLEError(ret));
 
-    ret = sl_bt_gattdb_start_characteristic(session, mSideRxCharHandle);
+    ret = sl_bt_gattdb_start_characteristic(session, mSideRxChar.handle);
     VerifyOrReturnError(ret == SL_STATUS_OK, MapBLEError(ret));
 
-    ret = sl_bt_gattdb_start_characteristic(session, mSideTxCharHandle);
+    ret = sl_bt_gattdb_start_characteristic(session, mSideTxChar.handle);
     VerifyOrReturnError(ret == SL_STATUS_OK, MapBLEError(ret));
 
     ret = sl_bt_gattdb_commit(session);
@@ -116,7 +141,6 @@ CHIP_ERROR BLEChannelImpl::ConfigureAdvertising(const AdvConfigStruct & config)
         ret = sl_bt_advertiser_create_set(&mAdvHandle);
         VerifyOrReturnLogError(ret == SL_STATUS_OK, MapBLEError(ret));
 
-        // TODO: Check if we need to randomize the address
         uint64_t random = Crypto::GetRandU64();
         memcpy(&mConnectionState.address, &random, sizeof(mConnectionState.address));
 
@@ -151,8 +175,6 @@ CHIP_ERROR BLEChannelImpl::ConfigureAdvertising(const AdvConfigStruct & config)
 
 CHIP_ERROR BLEChannelImpl::StartAdvertising(void)
 {
-    // TODO: Check for handling max connection per handle vs globally
-
     // If already advertising, stop it, before changing values
     if (mFlags.Has(Flags::kAdvertising))
     {
@@ -164,7 +186,7 @@ CHIP_ERROR BLEChannelImpl::StartAdvertising(void)
     ret = sl_bt_advertiser_set_timing(mAdvHandle, mAdvIntervalMin, mAdvIntervalMax, mAdvDuration, mAdvMaxEvents);
     VerifyOrReturnLogError(ret == SL_STATUS_OK, MapBLEError(ret));
 
-    ret = sl_bt_advertiser_configure(mAdvHandle, 1); // TODO : Figure out this magic 1 in the sl_bt_advertiser_flags
+    ret = sl_bt_advertiser_configure(mAdvHandle, kAdvertisingFlagStaticRandomAddress);
     VerifyOrReturnLogError(ret == SL_STATUS_OK, MapBLEError(ret));
 
     // Start advertising
@@ -184,8 +206,6 @@ CHIP_ERROR BLEChannelImpl::StopAdvertising(void)
         sl_status_t ret = SL_STATUS_OK;
 
         mFlags.Clear(Flags::kAdvertising);
-        // TODO: Confirm the fast vs slow advertising concept from a channel perspective vs from CHIPoBLE perspective
-        // mFlags.Set(Flags::kFastAdvertisingEnabled, true);
 
         ret = sl_bt_advertiser_stop(mAdvHandle);
         sl_bt_advertiser_clear_random_address(mAdvHandle);
@@ -197,9 +217,43 @@ CHIP_ERROR BLEChannelImpl::StopAdvertising(void)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR BLEChannelImpl::NotifyCharacteristic(uint16_t characteristicHandle)
+{
+    MutableByteSpan dataSpan;
+    ReturnErrorOnFailure(GetCharacteristicValue(characteristicHandle, dataSpan));
+    sl_status_t ret = sl_bt_gatt_server_send_notification(mConnectionState.connectionHandle, characteristicHandle, dataSpan.size(),
+                                                          dataSpan.data());
+    return MapBLEError(ret);
+}
+
+CHIP_ERROR BLEChannelImpl::IndicateCharacteristic(uint16_t characteristicHandle)
+{
+    MutableByteSpan dataSpan;
+    ReturnErrorOnFailure(GetCharacteristicValue(characteristicHandle, dataSpan));
+    sl_status_t ret = sl_bt_gatt_server_send_indication(mConnectionState.connectionHandle, characteristicHandle, dataSpan.size(),
+                                                        dataSpan.data());
+    return MapBLEError(ret);
+}
+void BLEChannelImpl::HandleIndicationTimeout(volatile sl_bt_msg_t * evt)
+{
+    sl_bt_evt_gatt_server_indication_timeout_t * indicationTimeout =
+        (sl_bt_evt_gatt_server_indication_timeout_t *) &(evt->data.evt_gatt_server_indication_timeout);
+
+    VerifyOrReturn(indicationTimeout->connection == mConnectionState.connectionHandle);
+    ChipLogProgress(DeviceLayer, "Indication timeout for connection: %d", indicationTimeout->connection);
+}
+void BLEChannelImpl::HandleIndicationConfirmation(volatile sl_bt_msg_t * evt)
+{
+    sl_bt_evt_gatt_server_characteristic_status_t * indicationConfirmation =
+        (sl_bt_evt_gatt_server_characteristic_status_t *) &(evt->data.evt_gatt_server_indication_timeout);
+
+    VerifyOrReturn(indicationConfirmation->connection == mConnectionState.connectionHandle);
+    ChipLogProgress(DeviceLayer, "Indication confirmation for connection: %d characteristic: %d",
+                    indicationConfirmation->connection, indicationConfirmation->characteristic);
+}
+
 void BLEChannelImpl::AddConnection(uint8_t connectionHandle, uint8_t bondingHandle)
 {
-    // TODO: Verify if we want to allow multiple connections at once, this is tied to the Endpoint usage as well
     // We currently only support one connection at a time on our side channel
     VerifyOrReturn(!mConnectionState.allocated, ChipLogError(DeviceLayer, "Connection already exists"));
 
@@ -217,20 +271,27 @@ bool BLEChannelImpl::RemoveConnection(uint8_t connectionHandle)
     return true;
 }
 
-void BLEChannelImpl::HandleReadRequest(volatile sl_bt_msg_t * evt, ByteSpan data)
+void BLEChannelImpl::HandleReadRequest(volatile sl_bt_msg_t * evt)
 {
-    uint16_t sent_length; // TODO: Confirm how to leverage this or use a nullptr instead
+    uint16_t sent_length;
 
-    // Add logic to handle received data
     sl_bt_evt_gatt_server_user_read_request_t * readReq =
         (sl_bt_evt_gatt_server_user_read_request_t *) &(evt->data.evt_gatt_server_user_read_request);
 
-    // TODO: define uint8_t error logic for app error for BLE response
-    ChipLogProgress(DeviceLayer, "Handling Read Request for characteristic: %d", readReq->characteristic);
-    sl_status_t ret = sl_bt_gatt_server_send_user_read_response(readReq->connection, readReq->characteristic, 0, data.size(),
-                                                                data.data(), &sent_length);
+    MutableByteSpan dataSpan;
+    CHIP_ERROR err = GetCharacteristicValue(readReq->characteristic, dataSpan);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to get characteristic value, err: %s", ErrorStr(err));
+        sl_bt_gatt_server_send_user_read_response(readReq->connection, readReq->characteristic, MapCHIPError(err), 0, nullptr,
+                                                  &sent_length);
+        return;
+    }
 
-    ChipLogProgress(DeviceLayer, "Sent %d of the %d bytes requested", sent_length, data.size());
+    ChipLogProgress(DeviceLayer, "Handling Read Request for characteristic: %d", readReq->characteristic);
+    sl_status_t ret = sl_bt_gatt_server_send_user_read_response(readReq->connection, readReq->characteristic, kAttErrorCodeNoError,
+                                                                dataSpan.size(), dataSpan.data(), &sent_length);
+    ChipLogProgress(DeviceLayer, "Sent %d of the %d bytes requested", sent_length, dataSpan.size());
 
     if (ret != SL_STATUS_OK)
     {
@@ -238,66 +299,81 @@ void BLEChannelImpl::HandleReadRequest(volatile sl_bt_msg_t * evt, ByteSpan data
     }
 }
 
-void BLEChannelImpl::HandleWriteRequest(volatile sl_bt_msg_t * evt, MutableByteSpan data)
+void BLEChannelImpl::HandleWriteRequest(volatile sl_bt_msg_t * evt)
 {
     sl_bt_evt_gatt_server_user_write_request_t * writeReq =
         (sl_bt_evt_gatt_server_user_write_request_t *) &(evt->data.evt_gatt_server_user_write_request);
     ChipLogProgress(DeviceLayer, "Handling Write Request for characteristic: %d", writeReq->characteristic);
-    // TODO: Review what characteristic we want to offer as default, for now we just copy the data to a buffer
 
-    VerifyOrReturn(data.size() >= writeReq->value.len, ChipLogError(DeviceLayer, "Buffer too small for write request"));
-    memcpy(data.data(), writeReq->value.data, writeReq->value.len);
+    MutableByteSpan dataSpan;
+    CHIP_ERROR err = SetCharacteristicValue(writeReq->characteristic, ByteSpan(writeReq->value.data, writeReq->value.len));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to set characteristic value, err: %s", ErrorStr(err));
+        sl_bt_gatt_server_send_user_write_response(writeReq->connection, writeReq->characteristic, MapCHIPError(err));
+        return;
+    }
 
     ChipLogProgress(DeviceLayer, "Received Write Request for characteristic: %d, data size: %d", writeReq->characteristic,
                     writeReq->value.len);
     // Log the data received
-    ChipLogByteSpan(DeviceLayer, data);
+    ChipLogByteSpan(DeviceLayer, dataSpan);
 
-    // TODO: define uint8_t error logic for app error for BLE response
-    sl_status_t ret = sl_bt_gatt_server_send_user_write_response(writeReq->connection, writeReq->characteristic, 0);
+    sl_status_t ret =
+        sl_bt_gatt_server_send_user_write_response(writeReq->connection, writeReq->characteristic, kAttErrorCodeNoError);
     if (ret != SL_STATUS_OK)
     {
         ChipLogDetail(DeviceLayer, "Failed to send write response, err:%ld", ret);
     }
 }
 
-CHIP_ERROR BLEChannelImpl::HandleCCCDWriteRequest(volatile sl_bt_msg_t * evt, bool & isNewSubscription)
+bool BLEChannelImpl::CanHandleEvent(uint32_t event)
+{
+    // Check if the event is one that this channel can handle
+    return (event == sl_bt_evt_gatt_server_indication_timeout_id);
+}
+
+CHIP_ERROR BLEChannelImpl::HandleCCCDWriteRequest(volatile sl_bt_msg_t * evt)
 {
     ChipLogProgress(DeviceLayer, "Handling CCCD Write");
 
     sl_bt_evt_gatt_server_characteristic_status_t * CCCDWriteReq =
         (sl_bt_evt_gatt_server_characteristic_status_t *) &(evt->data.evt_gatt_server_characteristic_status);
 
-    bool isIndicationEnabled = false;
-    isNewSubscription        = false;
-
     VerifyOrReturnLogError(mConnectionState.allocated, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(mConnectionState.connectionHandle == CCCDWriteReq->connection, CHIP_ERROR_INCORRECT_STATE);
 
-    isIndicationEnabled = (CCCDWriteReq->client_config_flags == sl_bt_gatt_indication);
-
-    if (isIndicationEnabled)
+    switch (CCCDWriteReq->client_config_flags)
     {
-        if (mConnectionState.subscribed)
-        {
-            isNewSubscription = false; // Already subscribed
-        }
-        else
-        {
-            mConnectionState.subscribed = 1;
-            ChipLogProgress(DeviceLayer, "CHIPoBLE Subscribe received for characteristic: %d", CCCDWriteReq->characteristic);
-            isNewSubscription = true;
-        }
+    case sl_bt_gatt_disable:
+        // Handle indication/notification disable
+        ChipLogProgress(DeviceLayer, "Side Channel Indication/Notification disabled for characteristic: %d",
+                        CCCDWriteReq->characteristic); // Log the TX Char handle value
+        break;
+    case sl_bt_gatt_indication: {
+        // Handle indication enable
+        ChipLogProgress(DeviceLayer, "Side Channel Indication enabled for characteristic: %d", CCCDWriteReq->characteristic);
+        MutableByteSpan dataSpan;
+        ReturnErrorOnFailure(GetCharacteristicValue(CCCDWriteReq->characteristic, dataSpan));
+        sl_status_t ret = sl_bt_gatt_server_send_indication(mConnectionState.connectionHandle, CCCDWriteReq->characteristic,
+                                                            dataSpan.size(), dataSpan.data());
+        return MapBLEError(ret);
     }
-    else
-    {
-        mConnectionState.subscribed = 0;
-        ChipLogProgress(DeviceLayer, "CHIPoBLE Unsubscribe received for characteristic: %d", CCCDWriteReq->characteristic);
-        isNewSubscription = false;
+    case sl_bt_gatt_notification: {
+        // Handle notification enable
+        ChipLogProgress(DeviceLayer, "Side Channel Notification enabled for characteristic: %d", CCCDWriteReq->characteristic);
+        MutableByteSpan dataSpan;
+        ReturnErrorOnFailure(GetCharacteristicValue(CCCDWriteReq->characteristic, dataSpan));
+        sl_status_t ret = sl_bt_gatt_server_send_notification(mConnectionState.connectionHandle, CCCDWriteReq->characteristic,
+                                                              dataSpan.size(), dataSpan.data());
+        return MapBLEError(ret);
     }
-
-    // TODO: Leverage Endpoint to send event or implement a timer + callback here
-    ChipLogProgress(DeviceLayer, "Note: This is not implemented yet");
+    default:
+        // Handle unknown flags
+        ChipLogError(DeviceLayer, "Unknown client config flags: %d for characteristic: %d", CCCDWriteReq->client_config_flags,
+                     CCCDWriteReq->characteristic);
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
     return CHIP_NO_ERROR;
 }
@@ -338,10 +414,9 @@ CHIP_ERROR BLEChannelImpl::OpenConnection(bd_addr address, uint8_t addrType)
     }
 
     sl_status_t ret = sl_bt_connection_open(address, addrType, sl_bt_gap_1m_phy, &mConnectionState.connectionHandle);
-
-    // TODO: Confirm this generates a connection event and the AddConnection gets called so that the connection state is updated
     return MapBLEError(ret);
 }
+
 CHIP_ERROR BLEChannelImpl::SetConnectionParams(const Optional<uint8_t> & connectionHandle, uint32_t intervalMin,
                                                uint32_t intervalMax, uint16_t latency, uint16_t timeout)
 {
@@ -381,7 +456,6 @@ CHIP_ERROR BLEChannelImpl::SetAdvertisingParams(uint32_t intervalMin, uint32_t i
 CHIP_ERROR BLEChannelImpl::CloseConnection()
 {
     sl_status_t ret = sl_bt_connection_close(mConnectionState.connectionHandle);
-    // Todo: Confirm this generates a disconnect event and the RemoveConnection gets called
     return MapBLEError(ret);
 }
 
@@ -408,31 +482,81 @@ CHIP_ERROR BLEChannelImpl::SetAdvHandle(uint8_t handle)
     return MapBLEError(ret);
 }
 
-CHIP_ERROR BLEChannelImpl::DiscoverServices()
+CHIP_ERROR BLEChannelImpl::DiscoverRemoteServices()
 {
     sl_status_t ret = sl_bt_gatt_discover_primary_services(mConnectionState.connectionHandle);
     VerifyOrReturnError(ret == SL_STATUS_OK, MapBLEError(ret));
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR BLEChannelImpl::DiscoverCharacteristics(uint32_t serviceHandle)
+
+CHIP_ERROR BLEChannelImpl::DiscoverRemoteCharacteristics(uint32_t serviceHandle)
 {
     sl_status_t ret = sl_bt_gatt_discover_characteristics(mConnectionState.connectionHandle, serviceHandle);
     VerifyOrReturnError(ret == SL_STATUS_OK, MapBLEError(ret));
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BLEChannelImpl::SetCharacteristicNotification(uint8_t characteristicHandle, uint8_t flags)
+CHIP_ERROR BLEChannelImpl::SetRemoteCharacteristicNotification(uint16_t characteristicHandle, uint8_t flags)
 {
     sl_status_t ret = sl_bt_gatt_set_characteristic_notification(mConnectionState.connectionHandle, characteristicHandle, flags);
     VerifyOrReturnError(ret == SL_STATUS_OK, MapBLEError(ret));
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BLEChannelImpl::SetCharacteristicValue(uint8_t characteristicHandle, const ByteSpan & value)
+CHIP_ERROR BLEChannelImpl::SetRemoteCharacteristicValue(uint16_t characteristicHandle, const ByteSpan & value)
 {
     sl_status_t ret =
         sl_bt_gatt_write_characteristic_value(mConnectionState.connectionHandle, characteristicHandle, value.size(), value.data());
     VerifyOrReturnError(ret == SL_STATUS_OK, MapBLEError(ret));
+    return CHIP_NO_ERROR;
+}
+
+// Side Channel methods
+CHIP_ERROR BLEChannelImpl::GetCharacteristicValue(uint16_t charHandle, MutableByteSpan & dataSpan)
+{
+    if (charHandle == mSideRxChar.handle)
+    {
+        dataSpan = mSideRxChar.buffer;
+    }
+    else if (charHandle == mSideTxChar.handle)
+    {
+        dataSpan = mSideTxChar.buffer;
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Unknown characteristic handle: %d", charHandle);
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR BLEChannelImpl::SetCharacteristicValue(uint16_t charHandle, const ByteSpan & value)
+{
+    if (charHandle == mSideRxChar.handle)
+    {
+        if (value.size() > kCharacteristicBufferSize)
+        {
+            ChipLogError(DeviceLayer, "Value size exceeds RX characteristic buffer size");
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+        mSideRxChar.buffer = MutableByteSpan(sRxValueBuffer, sizeof(sRxValueBuffer));
+        CopySpanToMutableSpan(value, mSideRxChar.buffer);
+    }
+    else if (charHandle == mSideTxChar.handle)
+    {
+        if (value.size() > kCharacteristicBufferSize)
+        {
+            ChipLogError(DeviceLayer, "Value size exceeds TX characteristic buffer size");
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+        mSideTxChar.buffer = MutableByteSpan(sTxValueBuffer, sizeof(sTxValueBuffer));
+        CopySpanToMutableSpan(value, mSideTxChar.buffer);
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Unknown characteristic handle: %d", charHandle);
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/silabs/efr32/BLEChannelImpl.h
+++ b/src/platform/silabs/efr32/BLEChannelImpl.h
@@ -25,17 +25,25 @@ namespace Internal {
 class BLEChannelImpl : public BLEChannel
 {
 public:
+    // Parent methods
     CHIP_ERROR Init(void) override;
     CHIP_ERROR ConfigureAdvertising(const AdvConfigStruct & config) override;
     CHIP_ERROR StartAdvertising(void) override;
     CHIP_ERROR StopAdvertising(void) override;
+    CHIP_ERROR NotifyCharacteristic(uint16_t characteristicHandle) override;
+    CHIP_ERROR IndicateCharacteristic(uint16_t characteristicHandle) override;
+
+    void HandleIndicationTimeout(volatile sl_bt_msg_t * evt) override;
+    void HandleIndicationConfirmation(volatile sl_bt_msg_t * evt) override;
 
     void AddConnection(uint8_t connectionHandle, uint8_t bondingHandle) override;
     bool RemoveConnection(uint8_t connectionHandle) override;
-    void HandleReadRequest(volatile sl_bt_msg_t * evt, ByteSpan data) override;
-    void HandleWriteRequest(volatile sl_bt_msg_t * evt, MutableByteSpan data) override;
+    void HandleReadRequest(volatile sl_bt_msg_t * evt) override;
+    void HandleWriteRequest(volatile sl_bt_msg_t * evt) override;
+    bool CanHandleEvent(uint32_t event) override;
 
-    CHIP_ERROR HandleCCCDWriteRequest(volatile sl_bt_msg_t * evt, bool & isNewSubscription) override;
+    CHIP_ERROR HandleCCCDWriteRequest(volatile sl_bt_msg_t * evt) override;
+
     void UpdateMtu(volatile sl_bt_msg_t * evt) override;
 
     CHIP_ERROR GeneratAdvertisingData(uint8_t discoverMove, uint8_t connectMode, const Optional<uint16_t> & maxEvents) override;
@@ -47,10 +55,28 @@ public:
     CHIP_ERROR CloseConnection(void) override;
     CHIP_ERROR SetAdvHandle(uint8_t handle) override;
 
-    CHIP_ERROR DiscoverServices() override;
-    CHIP_ERROR DiscoverCharacteristics(uint32_t serviceHandle) override;
-    CHIP_ERROR SetCharacteristicNotification(uint8_t characteristicHandle, uint8_t flags) override;
-    CHIP_ERROR SetCharacteristicValue(uint8_t characteristicHandle, const ByteSpan & value) override;
+    CHIP_ERROR DiscoverRemoteServices() override;
+    CHIP_ERROR DiscoverRemoteCharacteristics(uint32_t serviceHandle) override;
+    CHIP_ERROR SetRemoteCharacteristicNotification(uint16_t characteristicHandle, uint8_t flags) override;
+    CHIP_ERROR SetRemoteCharacteristicValue(uint16_t characteristicHandle, const ByteSpan & value) override;
+
+    // Side Channel methods
+
+    /** GetCharacteristicValue
+     * Gets the value of a characteristic identified by its handle.
+     * @param charHandle The handle of the characteristic to get.
+     * @param dataSpan A MutableByteSpan to hold the characteristic value.
+     * @return CHIP_NO_ERROR on success, CHIP_ERROR_INVALID_ARGUMENT if the characteristic handle is invalid.
+     */
+    CHIP_ERROR GetCharacteristicValue(uint16_t charHandle, MutableByteSpan & dataSpan);
+    /** SetCharacteristicValue
+     * Sets the value of a characteristic identified by its handle.
+     * @param charHandle The handle of the characteristic to set.
+     * @param value The value to set for the characteristic.
+     * @return CHIP_NO_ERROR on success, CHIP_ERROR_BUFFER_TOO_SMALL if the value is too large for the characteristic's buffer,
+     *        CHIP_ERROR_INVALID_ARGUMENT if the characteristic handle is invalid.
+     */
+    CHIP_ERROR SetCharacteristicValue(uint16_t charHandle, const ByteSpan & value);
 };
 
 } // namespace Internal


### PR DESCRIPTION
#### Summary

**Summary of Commit `4d157d5c115e15fb923531f3086dcc57e12a6f02`:**

  Clean up BLE side channel read/write logic, remove magic numbers, and add support for "indicate" and "notify" operations.


### Key Changes

#### 1. **BLE Shell Commands**
- Added new shell commands for BLE side channel:
  - `Notify`: Triggers a notify event on the TX characteristic.
  - `Indicate`: Triggers an indicate event on the TX characteristic.
- Registered these commands in the shell command table.

#### 2. **BLEManagerImpl**
- Added `SideChannelNotify()` and `SideChannelIndicate()` methods to trigger notifications and indications on the side channel TX characteristic.
- Updated GATT-related methods to use new naming and handle types (`uint16_t` instead of `uint8_t` for characteristic handles).

#### 3. **BLEChannel/BLEChannelImpl**
- Refactored characteristic handling:
  - Introduced a `Characteristic` struct with handle and buffer.
  - Added buffer management for RX and TX characteristics.
- Implemented `NotifyCharacteristic` and `IndicateCharacteristic` methods.
- Improved CCCD write handling to support both notifications and indications.
- Added methods to get/set characteristic values by handle, with error handling.
- Updated event handling for indication timeouts and confirmations.
- Cleaned up and clarified method names for remote GATT operations.

#### 4. **General Improvements**
- Removed magic numbers and replaced them with named constants.
- Improved error mapping between CHIP and BLE error codes.
- Updated event parsing and handling to support new side channel features.
- Improved documentation and comments throughout the code.

---

#### Related issues

<!--
    This section will help the reviewer easily navigate to the GitHub issues related to this PR change.
    Please mention all the related issues in this section.

    Tip: use the syntax of Fixes #.... to mark issues completed on PR merge or use #... to reference issues that are addressed.

    Examples:
        Fixes: #12345
        #12345
        N/A (not preferable)

    Please replace this HTML comment with the actual information about related issues.
-->

#### Testing

Aside from building and running the app, I used a phone BLE app to test the read/write, notify/indicate features.

