### PR TITLE
[SL-UP] Fixing multi-ota factorydata update for 917 SoC

### DIFF
--- a/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
@@ -66,9 +66,10 @@ exit:
     }
     else
     {
-        ChipLogProgress(SoftwareUpdate, "Factory data update finished.");
+        error = Provision::Manager::GetInstance().GetStorage().Commit();
+        VerifyOrReturnError(error == CHIP_NO_ERROR, error, ChipLogError(SoftwareUpdate, "Failed to commit factory data. Error: %s",ErrorStr(error)));
     }
-
+    ChipLogProgress(SoftwareUpdate, "Factory data update finished.");
     return error;
 }
 

--- a/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
@@ -67,7 +67,8 @@ exit:
     else
     {
         error = Provision::Manager::GetInstance().GetStorage().Commit();
-        VerifyOrReturnError(error == CHIP_NO_ERROR, error, ChipLogError(SoftwareUpdate, "Failed to commit factory data. Error: %s",ErrorStr(error)));
+        VerifyOrReturnError(error == CHIP_NO_ERROR, error,
+                            ChipLogError(SoftwareUpdate, "Failed to commit factory data. Error: %s", ErrorStr(error)));
     }
     ChipLogProgress(SoftwareUpdate, "Factory data update finished.");
     return error;


### PR DESCRIPTION
#### Summary

This PR fixing the multi-ota factory  data update on 917 SoC.

#### Related Issues

https://jira.silabs.com/browse/MATTER-5068

#### Testing
Tested on 917 SoC with the following steps:

- Provision the 917 SoC board.
- Build the ota file using sample certification files. 

```
 ./ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 2 -vs "2.0" -da sha256  --factory-data --dac_cert provision/samples/light/3/dac_cert.der --dac_key provision/samples/light/3/dac_key.der --pai_cert provision/samples/light/3/pai_cert.der --cert_declaration provision/samples/light/3/cd.bin matter-silabs-lighting-example.ota
 ./chip-ota-provider-app -f  matter-silabs-lighting-example.ota
 ./chip-tool pairing onnetwork 1 20202021
 ./chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233], "targets": null}, {"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": null, "targets": null}]' 1 0
 Commission the device with certs provided by which device is provisioned.
./chip-tool otasoftwareupdaterequestor announce-ota-provider 1 0 0 0 2 0
```
- Once software update done, recommission the device with default certs.
