### PR TITLE
[CSA-CP]Fault Logging Fix

### DIFF
--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -147,7 +147,7 @@ extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
  * Log a fault to the debugHardfault function.
  * This function is called by the fault handlers to log the fault details.
  */
-extern "C" void LogFault_Handler(void)
+extern "C" __attribute__((naked)) void LogFault_Handler(void)
 {
     uint32_t * sp;
     __asm volatile("tst lr, #4 \n"

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -25,6 +25,7 @@
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DiagnosticDataProvider.h>
+#include <uart.h>
 
 #if !defined(SLI_SI91X_MCU_INTERFACE) || !defined(SLI_SI91X_ENABLE_BLE)
 #include "rail_types.h"
@@ -91,6 +92,9 @@ extern "C" void halInternalAssertFailed(const char * filename, int linenumber)
     char faultMessage[kMaxFaultStringLen] = { 0 };
     snprintf(faultMessage, sizeof faultMessage, "Assert failed: %s:%d", filename, linenumber);
     ChipLogError(NotSpecified, "%s", faultMessage);
+#if SILABS_LOG_OUT_UART
+    uartFlushTxQueue();
+#endif // SILABS_LOG_OUT_UART
 #endif
     configASSERT((volatile void *) NULL);
 }
@@ -131,24 +135,59 @@ extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
     ChipLogError(NotSpecified, "LR          0x%08lx", lr);
     ChipLogError(NotSpecified, "PC          0x%08lx", pc);
     ChipLogError(NotSpecified, "PSR         0x%08lx", psr);
+#if SILABS_LOG_OUT_UART
+    uartFlushTxQueue();
+#endif // SILABS_LOG_OUT_UART
 #endif // SILABS_LOG_ENABLED
 
     configASSERTNULL(NULL);
 }
 
 /**
- * Override default hard-fault handler
+ * Log a fault to the debugHardfault function.
+ * This function is called by the fault handlers to log the fault details.
  */
+extern "C" void LogFault_Handler(void)
+{
+    uint32_t * sp;
+    __asm volatile("tst lr, #4 \n"
+                   "ite eq \n"
+                   "mrseq %0, msp \n"
+                   "mrsne %0, psp \n"
+                   : "=r"(sp));
+    debugHardfault(sp);
+}
+
 #ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
+extern "C" __attribute__((naked)) void NMI_Handler(void)
+{
+    __asm volatile("b LogFault_Handler");
+}
 extern "C" __attribute__((naked)) void HardFault_Handler(void)
 {
-    __asm volatile("tst lr, #4                                    \n"
-                   "ite eq                                        \n"
-                   "mrseq r0, msp                                 \n"
-                   "mrsne r0, psp                                 \n"
-                   "ldr r1, debugHardfault_address                \n"
-                   "bx r1                                         \n"
-                   "debugHardfault_address: .word debugHardfault  \n");
+    __asm volatile("b LogFault_Handler");
+}
+extern "C" __attribute__((naked)) void mpu_fault_handler(void)
+{
+    __asm volatile("b LogFault_Handler");
+}
+extern "C" __attribute__((naked)) void BusFault_Handler(void)
+{
+    __asm volatile("b LogFault_Handler");
+}
+extern "C" __attribute__((naked)) void UsageFault_Handler(void)
+{
+    __asm volatile("b LogFault_Handler");
+}
+#if (__CORTEX_M >= 23U)
+extern "C" __attribute__((naked)) void SecureFault_Handler(void)
+{
+    __asm volatile("b LogFault_Handler");
+}
+#endif // (__CORTEX_M >= 23U)
+extern "C" __attribute__((naked)) void DebugMon_Handler(void)
+{
+    __asm volatile("b LogFault_Handler");
 }
 #endif // SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 
@@ -181,7 +220,10 @@ extern "C" void vApplicationStackOverflowHook(TaskHandle_t pxTask, char * pcTask
     snprintf(faultMessage, sizeof faultMessage, "%s Task overflowed", pcTaskName);
 #if SILABS_LOG_ENABLED
     ChipLogError(NotSpecified, "%s", faultMessage);
-#endif
+#if SILABS_LOG_OUT_UART
+    uartFlushTxQueue();
+#endif // SILABS_LOG_OUT_UART
+#endif // SILABS_LOG_ENABLED
     Silabs::OnSoftwareFaultEventHandler(faultMessage);
 
     /* Force an assert. */
@@ -263,6 +305,9 @@ extern "C" void RAILCb_AssertFailed(RAIL_Handle_t railHandle, uint32_t errorCode
 #else
     ChipLogError(NotSpecified, "%s", faultMessage);
 #endif // RAIL_ASSERT_DEBUG_STRING
+#if SILABS_LOG_OUT_UART
+    uartFlushTxQueue();
+#endif // SILABS_LOG_OUT_UART
 #endif // SILABS_LOG_ENABLED
     Silabs::OnSoftwareFaultEventHandler(faultMessage);
 

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -162,10 +162,6 @@ extern "C" __attribute__((naked)) void LogFault_Handler(void)
 }
 
 #ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
-extern "C" __attribute__((naked)) void NMI_Handler(void)
-{
-    __asm volatile("b LogFault_Handler");
-}
 extern "C" __attribute__((naked)) void HardFault_Handler(void)
 {
     __asm volatile("b LogFault_Handler");

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -27,6 +27,13 @@
 #include <platform/DiagnosticDataProvider.h>
 #include <uart.h>
 
+// Macro to flush UART TX queue if enabled
+#if SILABS_LOG_OUT_UART
+#define SILABS_UART_FLUSH() uartFlushTxQueue()
+#else
+#define SILABS_UART_FLUSH() ((void) 0)
+#endif
+
 #if !defined(SLI_SI91X_MCU_INTERFACE) || !defined(SLI_SI91X_ENABLE_BLE)
 #include "rail_types.h"
 
@@ -92,10 +99,8 @@ extern "C" void halInternalAssertFailed(const char * filename, int linenumber)
     char faultMessage[kMaxFaultStringLen] = { 0 };
     snprintf(faultMessage, sizeof faultMessage, "Assert failed: %s:%d", filename, linenumber);
     ChipLogError(NotSpecified, "%s", faultMessage);
-#if SILABS_LOG_OUT_UART
-    uartFlushTxQueue();
-#endif // SILABS_LOG_OUT_UART
-#endif
+    SILABS_UART_FLUSH();
+#endif // SILABS_LOG_ENABLED
     configASSERT((volatile void *) NULL);
 }
 #endif
@@ -135,9 +140,7 @@ extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
     ChipLogError(NotSpecified, "LR          0x%08lx", lr);
     ChipLogError(NotSpecified, "PC          0x%08lx", pc);
     ChipLogError(NotSpecified, "PSR         0x%08lx", psr);
-#if SILABS_LOG_OUT_UART
-    uartFlushTxQueue();
-#endif // SILABS_LOG_OUT_UART
+    SILABS_UART_FLUSH();
 #endif // SILABS_LOG_ENABLED
 
     configASSERTNULL(NULL);
@@ -201,7 +204,8 @@ extern "C" void vApplicationMallocFailedHook(void)
     const char * faultMessage = "Failed to allocate memory on HEAP.";
 #if SILABS_LOG_ENABLED
     ChipLogError(NotSpecified, "%s", faultMessage);
-#endif
+    SILABS_UART_FLUSH();
+#endif // SILABS_LOG_ENABLED
     Silabs::OnSoftwareFaultEventHandler(faultMessage);
 
     /* Force an assert. */
@@ -220,9 +224,7 @@ extern "C" void vApplicationStackOverflowHook(TaskHandle_t pxTask, char * pcTask
     snprintf(faultMessage, sizeof faultMessage, "%s Task overflowed", pcTaskName);
 #if SILABS_LOG_ENABLED
     ChipLogError(NotSpecified, "%s", faultMessage);
-#if SILABS_LOG_OUT_UART
-    uartFlushTxQueue();
-#endif // SILABS_LOG_OUT_UART
+    SILABS_UART_FLUSH();
 #endif // SILABS_LOG_ENABLED
     Silabs::OnSoftwareFaultEventHandler(faultMessage);
 
@@ -305,9 +307,7 @@ extern "C" void RAILCb_AssertFailed(RAIL_Handle_t railHandle, uint32_t errorCode
 #else
     ChipLogError(NotSpecified, "%s", faultMessage);
 #endif // RAIL_ASSERT_DEBUG_STRING
-#if SILABS_LOG_OUT_UART
-    uartFlushTxQueue();
-#endif // SILABS_LOG_OUT_UART
+    SILABS_UART_FLUSH();
 #endif // SILABS_LOG_ENABLED
     Silabs::OnSoftwareFaultEventHandler(faultMessage);
 

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -591,7 +591,7 @@ void uartSendBytes(UartTxStruct_t & bufferStruct)
 
 /**
  * @brief Flush the UART TX queue in a blocking manner.
- *   UART logs are non blocking, so we need to flush the queue here other wise the logs will not get logged in case of a hard
+ *   UART logs are non blocking, so we need to flush the queue here otherwise the logs will not get logged in case of a hard
  *   fault as they rely on the UART task to send the logs.
  */
 void uartFlushTxQueue(void)

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -591,6 +591,8 @@ void uartSendBytes(UartTxStruct_t & bufferStruct)
 
 /**
  * @brief Flush the UART TX queue in a blocking manner.
+ *   UART logs are non blocking, so we need to flush the queue here other wise the logs will not get logged in case of a hard
+ *   fault as they rely on the UART task to send the logs.
  */
 void uartFlushTxQueue(void)
 {

--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -114,7 +114,7 @@ static size_t AddTimeStampAndPrefixStr(char * logBuffer, const char * prefix, si
 }
 
 /**
- * Print a log message to RTT
+ * Print a log message
  */
 static void PrintLog(const char * msg)
 {
@@ -145,7 +145,7 @@ static void PrintLog(const char * msg)
 #endif // SILABS_LOG_ENABLED
 
 /**
- * Initialize Segger RTT for logging
+ * Initialize logging
  */
 extern "C" void silabsInitLog(void)
 {


### PR DESCRIPTION

#### Summary

Added a uart flush to force a uart output without relying on the uart task when we hit a fault, added handlers for faults other than hardfault to get logs.


#### Testing

Simulated faults with a wrongly addressed pointer by dereferencing it, observed logs would be generated.

Note: The equivalent PR is also up on CSA.

