### PR TITLE
[SL-ONLY] Fixing the zigbee app with latest update

### DIFF
--- a/examples/zigbee-matter-light/silabs/src/AppTask.cpp
+++ b/examples/zigbee-matter-light/silabs/src/AppTask.cpp
@@ -26,8 +26,9 @@
 #include <app/clusters/on-off-server/on-off-server.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
-#include <app/util/persistence/DefaultAttributePersistenceProvider.h>
-#include <app/util/persistence/DeferredAttributePersistenceProvider.h>
+#include <app/persistence/AttributePersistenceProviderInstance.h>
+#include <app/persistence/DefaultAttributePersistenceProvider.h>
+#include <app/persistence/DeferredAttributePersistenceProvider.h>
 #include <setup_payload/OnboardingCodesUtil.h>
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT

--- a/examples/zigbee-matter-light/silabs/src/AppTask.cpp
+++ b/examples/zigbee-matter-light/silabs/src/AppTask.cpp
@@ -24,11 +24,11 @@
 #include "LEDWidget.h"
 
 #include <app/clusters/on-off-server/on-off-server.h>
-#include <app/server/Server.h>
-#include <app/util/attribute-storage.h>
 #include <app/persistence/AttributePersistenceProviderInstance.h>
 #include <app/persistence/DefaultAttributePersistenceProvider.h>
 #include <app/persistence/DeferredAttributePersistenceProvider.h>
+#include <app/server/Server.h>
+#include <app/util/attribute-storage.h>
 #include <setup_payload/OnboardingCodesUtil.h>
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT


### PR DESCRIPTION
#### Summary
The zigbee app was broken after the last CSA update. 
Fixing the headers path.
Due to the change https://github.com/project-chip/connectedhomeip/pull/39693

#### Testing
Build locally

