### PR TITLE
[SL-UP] Adds support for PKCS7 padding in OTA flow

### DIFF
--- a/scripts/tools/silabs/ota/crypto_utils.py
+++ b/scripts/tools/silabs/ota/crypto_utils.py
@@ -380,10 +380,11 @@ class rijndael:
 
 def encryptFlashData(nonce, key, data, imageLen):
     encyptedBlock = ''
-    if (imageLen % 16) != 0:
-        for x in range(16 - (imageLen % 16)):
-            data = data + bytes([255])
-        imageLen = len(data)
+    block_size = 16
+    # pad using PKCS#7 padding
+    pad_len = block_size - (imageLen % block_size)
+    data = data + bytes([pad_len] * pad_len)
+    imageLen = len(data)
 
     r = rijndael(key, block_size=16)
 

--- a/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
@@ -72,6 +72,14 @@ CHIP_ERROR OTAFirmwareProcessor::ProcessInternal(ByteSpan & block)
     }
 
     OTATlvProcessor::vOtaProcessInternalEncryption(byteBlock);
+    if (IsLastBlock() == true)
+    {
+        // Unpad the file if it is the last block
+        // This is necessary to remove any padding that might have been added during encryption.
+        // The unpadding logic is specific to the encryption scheme used.
+        VerifyOrReturnError(OTATlvProcessor::UnpadFile(byteBlock) == CHIP_NO_ERROR, CHIP_ERROR_WRONG_ENCRYPTION_TYPE,
+                            ChipLogError(SoftwareUpdate, "UnpadFile failed"));
+    }
     block = byteBlock;
 #endif
 

--- a/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
@@ -76,7 +76,7 @@ CHIP_ERROR OTAFirmwareProcessor::ProcessInternal(ByteSpan & block)
     {
         // Remove padding from the last block since if the file was padded, last block will contain padding bytes.
         VerifyOrReturnError(OTATlvProcessor::RemovePadding(byteBlock) == CHIP_NO_ERROR, CHIP_ERROR_WRONG_ENCRYPTION_TYPE,
-                            ChipLogError(SoftwareUpdate, "RemovePadding failed"));
+                            ChipLogError(SoftwareUpdate, "Failed to remove padding"));
     }
     block = byteBlock;
 #endif

--- a/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
@@ -74,11 +74,9 @@ CHIP_ERROR OTAFirmwareProcessor::ProcessInternal(ByteSpan & block)
     OTATlvProcessor::vOtaProcessInternalEncryption(byteBlock);
     if (IsLastBlock() == true)
     {
-        // Unpad the file if it is the last block
-        // This is necessary to remove any padding that might have been added during encryption.
-        // The unpadding logic is specific to the encryption scheme used.
-        VerifyOrReturnError(OTATlvProcessor::UnpadFile(byteBlock) == CHIP_NO_ERROR, CHIP_ERROR_WRONG_ENCRYPTION_TYPE,
-                            ChipLogError(SoftwareUpdate, "UnpadFile failed"));
+        // Remove padding from the last block since if the file was padded, last block will contain padding bytes.
+        VerifyOrReturnError(OTATlvProcessor::RemovePadding(byteBlock) == CHIP_NO_ERROR, CHIP_ERROR_WRONG_ENCRYPTION_TYPE,
+                            ChipLogError(SoftwareUpdate, "RemovePadding failed"));
     }
     block = byteBlock;
 #endif

--- a/src/platform/silabs/multi-ota/OTAMultiImageProcessorImpl.cpp
+++ b/src/platform/silabs/multi-ota/OTAMultiImageProcessorImpl.cpp
@@ -427,14 +427,13 @@ void OTAMultiImageProcessorImpl::HandleApply(intptr_t context)
     imageProcessor->mAccumulator.Clear();
 
     ChipLogProgress(SoftwareUpdate, "HandleApply: Finished and Soft Reset initiated");
-
+#if (defined(_SILICON_LABS_32B_SERIES_3) || defined(SLI_SI91X_MCU_INTERFACE)) && CHIP_PROGRESS_LOGGING
+    osDelay(500); // sl-temp: delay for uart print before reboot
+#endif
     // This reboots the device
 #ifdef SLI_SI91X_MCU_INTERFACE // 917 SoC reboot
     chip::DeviceLayer::Silabs::GetPlatform().SoftwareReset();
 #else // EFR reboot
-#if defined(_SILICON_LABS_32B_SERIES_3) && CHIP_PROGRESS_LOGGING
-    osDelay(100); // sl-temp: delay for uart print before reboot
-#endif
     CORE_CRITICAL_SECTION(bootloader_rebootAndInstall();)
 #endif
 }

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
@@ -153,7 +153,7 @@ CHIP_ERROR OTATlvProcessor::vOtaProcessInternalEncryption(MutableByteSpan & bloc
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OTATlvProcessor::UnpadFile(MutableByteSpan & block)
+CHIP_ERROR OTATlvProcessor::RemovePadding(MutableByteSpan & block)
 {
     if (block.size() == 0)
     {
@@ -177,7 +177,7 @@ CHIP_ERROR OTATlvProcessor::UnpadFile(MutableByteSpan & block)
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
     }
-    ChipLogProgress(DeviceLayer, "PKCS7 padding verified, removing %d bytes", padLength);
+
     block.reduce_size(block.size() - padLength);
     return CHIP_NO_ERROR;
 }

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
@@ -59,7 +59,10 @@ CHIP_ERROR OTATlvProcessor::Process(ByteSpan & block)
     CHIP_ERROR status     = CHIP_NO_ERROR;
     uint32_t bytes        = chip::min(mLength - mProcessedLength, static_cast<uint32_t>(block.size()));
     ByteSpan relevantData = block.SubSpan(0, bytes);
-
+    if (mProcessedLength + bytes >= mLength)
+    {
+        mLastBlock = true;
+    }
     status = ProcessInternal(relevantData);
     if (!IsError(status))
     {
@@ -86,6 +89,7 @@ void OTATlvProcessor::ClearInternal()
     mLength          = 0;
     mProcessedLength = 0;
     mWasSelected     = false;
+    mLastBlock       = false;
 #if OTA_ENCRYPTION_ENABLE
     mIVOffset = 0;
 #endif

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.h
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.h
@@ -156,6 +156,7 @@ public:
 
 #ifdef OTA_ENCRYPTION_ENABLE
     CHIP_ERROR vOtaProcessInternalEncryption(MutableByteSpan & block);
+    CHIP_ERROR UnpadFile(MutableByteSpan & block);
 #endif
 
 protected:

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.h
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.h
@@ -159,7 +159,7 @@ public:
     /**
      * @brief Remove padding from the given block.
      * This is necessary to remove any padding that might have been added during encryption.
-     * 
+     *
      * @param block The block of data to remove padding from.
      * @return CHIP_NO_ERROR on success, or an error code if padding removal fails.
      * @note The method assumes the block is padded using PKCS7 padding.

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.h
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.h
@@ -152,6 +152,7 @@ public:
     void SetWasSelected(bool selected) { mWasSelected = selected; }
     bool WasSelected() { return mWasSelected; }
     bool IsValidTag(OTAProcessorTag tag);
+    bool IsLastBlock() const { return mLastBlock; }
 
 #ifdef OTA_ENCRYPTION_ENABLE
     CHIP_ERROR vOtaProcessInternalEncryption(MutableByteSpan & block);
@@ -199,8 +200,9 @@ protected:
     uint32_t mProcessedLength                    = 0;
     bool mWasSelected                            = false;
     ProcessDescriptor mCallbackProcessDescriptor = nullptr;
+    bool mDescriptorProcessed                    = false;
+    bool mLastBlock                              = false;
     OTADataAccumulator mAccumulator;
-    bool mDescriptorProcessed = false;
 };
 
 } // namespace chip

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.h
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.h
@@ -156,7 +156,15 @@ public:
 
 #ifdef OTA_ENCRYPTION_ENABLE
     CHIP_ERROR vOtaProcessInternalEncryption(MutableByteSpan & block);
-    CHIP_ERROR UnpadFile(MutableByteSpan & block);
+    /**
+     * @brief Remove padding from the given block.
+     * This is necessary to remove any padding that might have been added during encryption.
+     * 
+     * @param block The block of data to remove padding from.
+     * @return CHIP_NO_ERROR on success, or an error code if padding removal fails.
+     * @note The method assumes the block is padded using PKCS7 padding.
+     */
+    CHIP_ERROR RemovePadding(MutableByteSpan & block);
 #endif
 
 protected:

--- a/src/platform/silabs/multi-ota/SiWx917/OTAWiFiFirmwareProcessor.cpp
+++ b/src/platform/silabs/multi-ota/SiWx917/OTAWiFiFirmwareProcessor.cpp
@@ -63,6 +63,14 @@ CHIP_ERROR OTAWiFiFirmwareProcessor::ProcessInternal(ByteSpan & block)
     }
 
     OTATlvProcessor::vOtaProcessInternalEncryption(byteBlock);
+    if (IsLastBlock() == true)
+    {
+        // Unpad the file if it is the last block
+        // This is necessary to remove any padding that might have been added during encryption.
+        // The unpadding logic is specific to the encryption scheme used.
+        VerifyOrReturnError(OTATlvProcessor::UnpadFile(byteBlock) == CHIP_NO_ERROR, CHIP_ERROR_WRONG_ENCRYPTION_TYPE,
+                            ChipLogError(SoftwareUpdate, "UnpadFile failed"));
+    }
     block = byteBlock;
 #endif // OTA_ENCRYPTION_ENABLE
 

--- a/src/platform/silabs/multi-ota/SiWx917/OTAWiFiFirmwareProcessor.cpp
+++ b/src/platform/silabs/multi-ota/SiWx917/OTAWiFiFirmwareProcessor.cpp
@@ -65,11 +65,9 @@ CHIP_ERROR OTAWiFiFirmwareProcessor::ProcessInternal(ByteSpan & block)
     OTATlvProcessor::vOtaProcessInternalEncryption(byteBlock);
     if (IsLastBlock() == true)
     {
-        // Unpad the file if it is the last block
-        // This is necessary to remove any padding that might have been added during encryption.
-        // The unpadding logic is specific to the encryption scheme used.
-        VerifyOrReturnError(OTATlvProcessor::UnpadFile(byteBlock) == CHIP_NO_ERROR, CHIP_ERROR_WRONG_ENCRYPTION_TYPE,
-                            ChipLogError(SoftwareUpdate, "UnpadFile failed"));
+        // Remove padding from the last block since if the file was padded, last block will contain padding bytes.
+        VerifyOrReturnError(OTATlvProcessor::RemovePadding(byteBlock) == CHIP_NO_ERROR, CHIP_ERROR_WRONG_ENCRYPTION_TYPE,
+                            ChipLogError(SoftwareUpdate, "Failed to remove padding"));
     }
     block = byteBlock;
 #endif // OTA_ENCRYPTION_ENABLE


### PR DESCRIPTION
#### Summary

The payload of the application/firmware image may not be properly aligned, but for AES encryption the payload needs to be `block_size` aligned, in this case that is `16`. Currently, we are using a naive `0xFF` padding, but that assumes that the payload will not end with `0xFF` which is risky. Hence replacing the naive padding logic with PKCS7 standardized logic.

Since the padding is done on the file and not on the block, this means the last block of the file will have the padding data, hence the last block of the file needs to be identified and padding needs to be removed from that to get back the original file. 

### Testing
 - [x] Tested with 917 SoC
 - [x] Tested with 917 NCP, pending as SiSDK cloning is taking a lot of time.