### PR TITLE
[SL-ONLY] Matter-4543 update tracing time source

### DIFF
--- a/src/platform/silabs/tracing/SilabsTracing.cpp
+++ b/src/platform/silabs/tracing/SilabsTracing.cpp
@@ -21,6 +21,23 @@
 #include <lib/support/PersistentData.h>
 #include <string> // Include the necessary header for std::string
 
+#if defined(SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT) && SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT
+#include <rail.h>
+// RAIL_GetTime() returns time in usec
+#define SILABS_GET_TIME() System::Clock::Milliseconds32(RAIL_GetTime() / 1000)
+#define SILABS_GET_DURATION(tracker)                                                                                               \
+    (tracker.mEndTime < tracker.mStartTime)                                                                                        \
+        ? (tracker.mEndTime + System::Clock::Milliseconds32((UINT32_MAX / 1000)) - tracker.mStartTime)                             \
+        : tracker.mEndTime - tracker.mStartTime
+#else
+#define SILABS_GET_TIME() System::SystemClock().GetMonotonicTimestamp()
+#define SILABS_GET_DURATION(tracker) tracker.mEndTime - tracker.mStartTime
+#endif
+
+#if defined(SILABS_LOG_OUT_UART) && SILABS_LOG_OUT_UART
+#include "uart.h"
+#endif
+
 #if !CONFIG_BUILD_FOR_HOST_UNIT_TEST
 #include <platform/silabs/Logging.h> // for isLogInitialized
 #endif
@@ -254,8 +271,16 @@ CHIP_ERROR SilabsTracer::StartWatermarksStorage(PersistentStorageDelegate * stor
 CHIP_ERROR SilabsTracer::TimeTraceBegin(TimeTraceOperation aOperation)
 {
     // Log the start time of the operation
-    auto & tracker     = mLatestTimeTrackers[to_underlying(aOperation)];
-    tracker.mStartTime = System::SystemClock().GetMonotonicTimestamp();
+    auto & tracker = mLatestTimeTrackers[to_underlying(aOperation)];
+    // Corner case since no hardware clock is available at this point
+    if (aOperation == TimeTraceOperation::kBootup || aOperation == TimeTraceOperation::kSilabsInit)
+    {
+        tracker.mStartTime = System::Clock::Milliseconds32(0);
+    }
+    else
+    {
+        tracker.mStartTime = SILABS_GET_TIME();
+    }
     tracker.mOperation = to_underlying(aOperation);
     tracker.mType      = OperationType::kBegin;
     tracker.mError     = CHIP_NO_ERROR;
@@ -269,14 +294,14 @@ CHIP_ERROR SilabsTracer::TimeTraceBegin(TimeTraceOperation aOperation)
 CHIP_ERROR SilabsTracer::TimeTraceEnd(TimeTraceOperation aOperation, CHIP_ERROR error)
 {
     auto & tracker   = mLatestTimeTrackers[to_underlying(aOperation)];
-    tracker.mEndTime = System::SystemClock().GetMonotonicTimestamp();
+    tracker.mEndTime = SILABS_GET_TIME();
     tracker.mType    = OperationType::kEnd;
     tracker.mError   = error;
 
     if (error == CHIP_NO_ERROR)
     {
         // Calculate the duration and update the time tracker
-        auto duration = tracker.mEndTime - tracker.mStartTime;
+        auto duration = SILABS_GET_DURATION(tracker);
 
         auto & watermark = mWatermarks[to_underlying(aOperation)];
         watermark.mSuccessfullCount++;
@@ -306,7 +331,7 @@ CHIP_ERROR SilabsTracer::TimeTraceEnd(TimeTraceOperation aOperation, CHIP_ERROR 
 CHIP_ERROR SilabsTracer::TimeTraceInstant(TimeTraceOperation aOperation, CHIP_ERROR error)
 {
     TimeTracker tracker;
-    tracker.mStartTime = System::SystemClock().GetMonotonicTimestamp();
+    tracker.mStartTime = SILABS_GET_TIME();
     tracker.mEndTime   = tracker.mStartTime;
     tracker.mOperation = to_underlying(aOperation);
     tracker.mType      = OperationType::kInstant;
@@ -322,7 +347,7 @@ CHIP_ERROR SilabsTracer::TimeTraceInstant(CharSpan & aOperationKey, CHIP_ERROR e
     ReturnErrorOnFailure(FindAppOperationIndex(aOperationKey, index));
 
     TimeTracker tracker;
-    tracker.mStartTime = System::SystemClock().GetMonotonicTimestamp();
+    tracker.mStartTime = SILABS_GET_TIME();
     tracker.mEndTime   = tracker.mStartTime;
     tracker.mOperation = to_underlying(TimeTraceOperation::kNumTraces) + index;
     tracker.mType      = OperationType::kInstant;
@@ -358,7 +383,7 @@ CHIP_ERROR SilabsTracer::OutputTrace(const TimeTracker & tracker)
         // Save a tracker with TimeTraceOperation::kNumTraces and CHIP_ERROR_BUFFER_TOO_SMALL to indicate that the
         // buffer is full
         TimeTracker resourceExhaustedTracker = tracker;
-        resourceExhaustedTracker.mStartTime  = System::SystemClock().GetMonotonicTimestamp();
+        resourceExhaustedTracker.mStartTime  = SILABS_GET_TIME();
         resourceExhaustedTracker.mEndTime    = resourceExhaustedTracker.mStartTime;
         resourceExhaustedTracker.mOperation  = to_underlying(TimeTraceOperation::kBufferFull);
         resourceExhaustedTracker.mType       = OperationType::kInstant;

--- a/src/platform/tests/TestSilabsTracing.cpp
+++ b/src/platform/tests/TestSilabsTracing.cpp
@@ -261,7 +261,7 @@ TEST_F(TestSilabsTracing, TestBootupSequence)
     // Simulate Silabs Init
     SilabsTracer::Instance().TimeTraceBegin(TimeTraceOperation::kSilabsInit);
     gMockClock.AdvanceMonotonic(150_ms64);
-
+    gMockClock.SetMonotonic(0_ms64); // Resetting to 0 since reboot should reset the monotonic clock
     SilabsTracer::Instance().TimeTraceBegin(TimeTraceOperation::kBootup);
     // Simulate Silabs Init
     SilabsTracer::Instance().TimeTraceBegin(TimeTraceOperation::kSilabsInit);
@@ -572,6 +572,7 @@ TEST_F(TestSilabsTracing, TestOTA)
     EXPECT_EQ(watermark.mCountAboveAvg, uint32_t(0));
 
     // Simulate Bootup steps after OTA failure
+    gMockClock.SetMonotonic(0_ms64); // Resetting to 0 since reboot should reset the monotonic clock
     SilabsTracer::Instance().TimeTraceBegin(TimeTraceOperation::kBootup);
     gMockClock.AdvanceMonotonic(200_ms64);
     SilabsTracer::Instance().TimeTraceEnd(TimeTraceOperation::kBootup);
@@ -626,6 +627,7 @@ TEST_F(TestSilabsTracing, TestLogs)
     SilabsTracer::Instance().TimeTraceEnd(TimeTraceOperation::kOTA);
 
     // Simulate Bootup steps
+    gMockClock.SetMonotonic(0_ms64); // Resetting to 0 since reboot should reset the monotonic clock
     SilabsTracer::Instance().TimeTraceBegin(TimeTraceOperation::kBootup);
     gMockClock.AdvanceMonotonic(200_ms64);
     SilabsTracer::Instance().TimeTraceEnd(TimeTraceOperation::kBootup);
@@ -674,7 +676,7 @@ TEST_F(TestSilabsTracing, TestLogs)
     span = MutableCharSpan(logBuffer);
     EXPECT_EQ(SilabsTracer::Instance().GetTraceByOperation(to_underlying(TimeTraceOperation::kBootup), span), CHIP_NO_ERROR);
     const char * expectedBootupLogFormat =
-        "TimeTracker - Type: End, Operation: Bootup, Status: 0x0, Start: 00:00:00.100, End: 00:00:00.300, Duration: 00:00:00.200";
+        "TimeTracker - Type: End, Operation: Bootup, Status: 0x0, Start: 00:00:00.000, End: 00:00:00.200, Duration: 00:00:00.200";
     EXPECT_STREQ(span.data(), expectedBootupLogFormat);
 
     // Test buffer too small behavior


### PR DESCRIPTION
#### Summary
Cherry-pick for 4f50c2206b from release_2.6-1.4
#Fixes Matter-4543 by switching the time reference to the RAIL timer instead of FreeRTOS SysTick

#### Related issues
MATTER-4543

#### Testing
Tested with a MG24, we can now see the Init and bootup time compared to the previous implementation which returned 0.

App used : CMP app on MG24, build with SLC.
