### PR TITLE
[SL-UP] Rename remaining deprecated define to be inline with the new standard

### DIFF
--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -35,7 +35,7 @@
 #endif // NDEBUG
 #if defined(SL_MATTER_ENABLE_OTA_ENCRYPTION) && SL_MATTER_ENABLE_OTA_ENCRYPTION
 #include <platform/silabs/multi-ota/OtaTlvEncryptionKey.h>
-#endif // OTA_ENCRYPTION_ENABLE
+#endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
 #ifndef SLI_SI91X_MCU_INTERFACE
 #include <psa/crypto.h>
 #endif
@@ -726,7 +726,7 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif // SL_MBEDTLS_USE_TINYCRYPT
 }
-#endif // OTA_ENCRYPTION_ENABLE
+#endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
 
 #if defined(SL_MATTER_TEST_EVENT_TRIGGER_ENABLED) && SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
 CHIP_ERROR Storage::SetTestEventTriggerKey(const ByteSpan & value)

--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -726,6 +726,21 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif // SL_MBEDTLS_USE_TINYCRYPT
 }
+#else
+CHIP_ERROR Storage::SetOtaTlvEncryptionKey(const ByteSpan & value)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR Storage::GetOtaTlvEncryptionKeyId(uint32_t & keyId)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uint32_t & ivOffset)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
 #endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
 
 #if defined(SL_MATTER_TEST_EVENT_TRIGGER_ENABLED) && SL_MATTER_TEST_EVENT_TRIGGER_ENABLED

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -27,7 +27,7 @@
 #include <string.h>
 #if defined(SL_MATTER_ENABLE_OTA_ENCRYPTION) && SL_MATTER_ENABLE_OTA_ENCRYPTION
 #include <platform/silabs/multi-ota/OtaTlvEncryptionKey.h>
-#endif // OTA_ENCRYPTION_ENABLE
+#endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
 
 #if !(SL_MATTER_GN_BUILD || defined(SL_PROVISION_GENERATOR))
 #include <sl_matter_provision_config.h>
@@ -789,7 +789,7 @@ CHIP_ERROR Storage::DecryptUsingOtaTlvEncryptionKey(MutableByteSpan & block, uin
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif // SL_MBEDTLS_USE_TINYCRYPT
 }
-#endif // OTA_ENCRYPTION_ENABLE
+#endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
 
 CHIP_ERROR Storage::SetTestEventTriggerKey(const ByteSpan & value)
 {

--- a/src/platform/silabs/efr32/efr32-psa-crypto-config.h
+++ b/src/platform/silabs/efr32/efr32-psa-crypto-config.h
@@ -34,9 +34,9 @@
 #endif // SL_USE_COAP_CONFIG
 
 // Multi-chip OTA encryption processing
-#if OTA_ENCRYPTION_ENABLE
+#if SL_MATTER_ENABLE_OTA_ENCRYPTION
 #define PSA_WANT_ALG_CTR
-#endif // OTA_ENCRYPTION_ENABLE
+#endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
 
 // Include Generated fies
 #include "psa_crypto_config.h"

--- a/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
@@ -28,7 +28,7 @@ CHIP_ERROR OTAFactoryDataProcessor::ProcessInternal(ByteSpan & block)
     CHIP_ERROR error = CHIP_NO_ERROR;
 
     ReturnErrorOnFailure(mAccumulator.Accumulate(block));
-#if OTA_ENCRYPTION_ENABLE
+#if SL_MATTER_ENABLE_OTA_ENCRYPTION
     MutableByteSpan byteBlock = MutableByteSpan(mAccumulator.data(), mAccumulator.GetThreshold());
     OTATlvProcessor::vOtaProcessInternalEncryption(byteBlock);
 #endif

--- a/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
@@ -47,12 +47,12 @@ CHIP_ERROR OTAFirmwareProcessor::ProcessInternal(ByteSpan & block)
     if (!mDescriptorProcessed)
     {
         ReturnErrorOnFailure(ProcessDescriptor(block));
-#if OTA_ENCRYPTION_ENABLE
+#if SL_MATTER_ENABLE_OTA_ENCRYPTION
         /* 16 bytes to used to store undecrypted data because of unalignment */
         mAccumulator.Init(requestedOtaMaxBlockSize + 16);
 #endif
     }
-#if OTA_ENCRYPTION_ENABLE
+#if SL_MATTER_ENABLE_OTA_ENCRYPTION
     MutableByteSpan byteBlock = MutableByteSpan(mAccumulator.data(), mAccumulator.GetThreshold());
     memcpy(&byteBlock[0], &byteBlock[requestedOtaMaxBlockSize], mUnalignmentNum);
     memcpy(&byteBlock[mUnalignmentNum], block.data(), block.size());

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
@@ -24,7 +24,7 @@
 #include <headers/ProvisionStorage.h>
 #include <platform/silabs/multi-ota/OTAMultiImageProcessorImpl.h>
 #include <platform/silabs/multi-ota/OTATlvProcessor.h>
-#if OTA_ENCRYPTION_ENABLE
+#if SL_MATTER_ENABLE_OTA_ENCRYPTION
 #include <platform/silabs/multi-ota/OtaTlvEncryptionKey.h>
 #endif
 
@@ -37,7 +37,7 @@ CHIP_ERROR OTATlvProcessor::Init()
 {
     VerifyOrReturnError(mCallbackProcessDescriptor != nullptr, CHIP_OTA_PROCESSOR_CB_NOT_REGISTERED);
     mAccumulator.Init(GetAccumulatorLength());
-#ifdef OTA_ENCRYPTION_ENABLE
+#ifdef SL_MATTER_ENABLE_OTA_ENCRYPTION
     mUnalignmentNum = 0;
 #endif
     return CHIP_NO_ERROR;
@@ -48,7 +48,7 @@ CHIP_ERROR OTATlvProcessor::Clear()
     OTATlvProcessor::ClearInternal();
     mAccumulator.Clear();
     mDescriptorProcessed = false;
-#ifdef OTA_ENCRYPTION_ENABLE
+#ifdef SL_MATTER_ENABLE_OTA_ENCRYPTION
     mUnalignmentNum = 0;
 #endif
     return CHIP_NO_ERROR;
@@ -90,7 +90,7 @@ void OTATlvProcessor::ClearInternal()
     mProcessedLength = 0;
     mWasSelected     = false;
     mLastBlock       = false;
-#if OTA_ENCRYPTION_ENABLE
+#if SL_MATTER_ENABLE_OTA_ENCRYPTION
     mIVOffset = 0;
 #endif
 }
@@ -137,7 +137,7 @@ CHIP_ERROR OTADataAccumulator::Accumulate(ByteSpan & block)
     return CHIP_NO_ERROR;
 }
 
-#if OTA_ENCRYPTION_ENABLE
+#if SL_MATTER_ENABLE_OTA_ENCRYPTION
 CHIP_ERROR OTATlvProcessor::vOtaProcessInternalEncryption(MutableByteSpan & block)
 {
 #if defined(SL_MBEDTLS_USE_TINYCRYPT)
@@ -181,5 +181,5 @@ CHIP_ERROR OTATlvProcessor::RemovePadding(MutableByteSpan & block)
     block.reduce_size(block.size() - padLength);
     return CHIP_NO_ERROR;
 }
-#endif // OTA_ENCRYPTION_ENABLE
+#endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
 } // namespace chip

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.h
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.h
@@ -154,7 +154,7 @@ public:
     bool IsValidTag(OTAProcessorTag tag);
     bool IsLastBlock() const { return mLastBlock; }
 
-#ifdef OTA_ENCRYPTION_ENABLE
+#ifdef SL_MATTER_ENABLE_OTA_ENCRYPTION
     CHIP_ERROR vOtaProcessInternalEncryption(MutableByteSpan & block);
     /**
      * @brief Remove padding from the given block.
@@ -198,7 +198,7 @@ protected:
     bool IsError(CHIP_ERROR & status);
     virtual uint32_t GetAccumulatorLength() const { return sizeof(Descriptor); }
 
-#ifdef OTA_ENCRYPTION_ENABLE
+#ifdef SL_MATTER_ENABLE_OTA_ENCRYPTION
     /*ota decryption*/
     uint32_t mIVOffset = 0;
     /* Expected byte size of the OTAEncryptionKeyLength */

--- a/src/platform/silabs/multi-ota/SiWx917/OTAWiFiFirmwareProcessor.cpp
+++ b/src/platform/silabs/multi-ota/SiWx917/OTAWiFiFirmwareProcessor.cpp
@@ -37,13 +37,13 @@ CHIP_ERROR OTAWiFiFirmwareProcessor::ProcessInternal(ByteSpan & block)
     if (!mDescriptorProcessed)
     {
         ReturnErrorOnFailure(ProcessDescriptor(block));
-#if OTA_ENCRYPTION_ENABLE
+#if SL_MATTER_ENABLE_OTA_ENCRYPTION
         /* 16 bytes to used to store undecrypted data because of unalignment */
         mAccumulator.Init(requestedOtaMaxBlockSize + 16);
-#endif // OTA_ENCRYPTION_ENABLE
+#endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
     }
 
-#if OTA_ENCRYPTION_ENABLE
+#if SL_MATTER_ENABLE_OTA_ENCRYPTION
     MutableByteSpan byteBlock = MutableByteSpan(mAccumulator.data(), mAccumulator.GetThreshold());
     memcpy(&byteBlock[0], &byteBlock[requestedOtaMaxBlockSize], mUnalignmentNum);
     memcpy(&byteBlock[mUnalignmentNum], block.data(), block.size());
@@ -70,7 +70,7 @@ CHIP_ERROR OTAWiFiFirmwareProcessor::ProcessInternal(ByteSpan & block)
                             ChipLogError(SoftwareUpdate, "Failed to remove padding"));
     }
     block = byteBlock;
-#endif // OTA_ENCRYPTION_ENABLE
+#endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
 
     if (mFWchunkType == SL_FWUP_RPS_HEADER)
     {

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -361,7 +361,7 @@ template("siwx917_sdk") {
 
     if (chip_enable_multi_ota_requestor) {
       if (chip_enable_multi_ota_encryption) {
-        defines += [ "OTA_ENCRYPTION_ENABLE=1" ]
+        defines += [ "SL_MATTER_ENABLE_OTA_ENCRYPTION=1" ]
       }
     }
 

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -563,7 +563,7 @@ template("efr32_sdk") {
 
     if (chip_enable_multi_ota_requestor) {
       if (chip_enable_multi_ota_encryption) {
-        defines += [ "OTA_ENCRYPTION_ENABLE=1" ]
+        defines += [ "SL_MATTER_ENABLE_OTA_ENCRYPTION=1" ]
       }
 
       if (chip_enable_ota_custom_tlv_testing) {


### PR DESCRIPTION
#### Summary

- PR renames defines to the new standard. This had already been started on the release branch but the multi-ota feature had not yet been updated.
- Updates matter_support submodule to pull in the latest libs. (TBD)

PR does not validate that the multi-ota feature works - this is left up to the feature owner.

#### Related issues
[MATTER-5283](https://jira.silabs.com/browse/MATTER-5283)

#### Testing
Built the app with and without the multi-ota feature.
