### PR TITLE
Revert "[SL-TEMP] Fix commissioning with test credentials (#366)"

### DIFF
--- a/examples/platform/silabs/provision/BUILD.gn
+++ b/examples/platform/silabs/provision/BUILD.gn
@@ -22,7 +22,7 @@ if (wifi_soc) {
   import("${silabs_sdk_build_root}/efr32_sdk.gni")
 }
 
-# Seperate import since the matter_support_root is defined in the ef32_sdk.gni / SiWx917_sdk.gni
+# Separate import since the matter_support_root is defined in the ef32_sdk.gni / SiWx917_sdk.gni
 import("${matter_support_root}/provision/args.gni")
 source_set("storage") {
   sources = [ "ProvisionStorageCustom.cpp" ]


### PR DESCRIPTION
This reverts commit 529e9342e2778bb05445bfafc3252b9144808942.

#### Summary
PR #509 merged provisioning development from main to 2.6 and brought the example factory data fallback gating-define the change `CHIP_DEVICE_CONFIG_ENABLE_EXAMPLE_CREDENTIALS` to `SL_MATTER_ENABLE_EXAMPLE_CREDENTIALS`.
Revert the temp fix.

Note `SL_MATTER_ENABLE_EXAMPLE_CREDENTIALS` is defined at build time in `third_party/silabs/matter_support/provision/BUILD.gn`

#### Related issues
https://jira.silabs.com/browse/MATTER-5294

#### Testing
commission an un-provisioning succesfully