### PR TITLE
[SL-TEMP] Renaming the ArraySize to MATTER_ARRAY_SIZE

### DIFF
--- a/examples/platform/silabs/shell/ble/BLEShellCommands.cpp
+++ b/examples/platform/silabs/shell/ble/BLEShellCommands.cpp
@@ -86,7 +86,7 @@ void RegisterCommands()
     };
     static const Shell::Command sBleCmds = { &BLECommandHandler, "ble-side", "Dispatch Silicon Labs BLE Side Channel commands" };
 
-    sShellBLESubCommands.RegisterCommands(sBLESubCommands, ArraySize(sBLESubCommands));
+    sShellBLESubCommands.RegisterCommands(sBLESubCommands, MATTER_ARRAY_SIZE(sBLESubCommands));
     Engine::Root().RegisterCommands(&sBleCmds, 1);
 }
 


### PR DESCRIPTION
#### Summary
ArraySize was renamed to MATTER_ARRAY_SIZE on the latest CSA. This was missed in the BLE Side band PR.

#### Testing
CI
