### PR TITLE
[SL-TEMP] BLE Side-Channel  gatt client lib

### DIFF
--- a/.github/silabs-builds-mg24.json
+++ b/.github/silabs-builds-mg24.json
@@ -17,7 +17,7 @@
             "arguments": ["--docker", "--wifi SiWx917"]
         }
     ],
-    "ble-side-channel": [
+    "lighting-app": [
         {
             "boards": ["BRD4187C"],
             "arguments": ["--docker", "--sl_enable_ble_side_channel"]

--- a/.github/silabs-builds-mg24.json
+++ b/.github/silabs-builds-mg24.json
@@ -20,7 +20,7 @@
     "lighting-app": [
         {
             "boards": ["BRD4187C"],
-            "arguments": ["--docker", "--sl_enable_ble_side_channel"]
+            "arguments": ["--docker", "sl_enable_ble_side_channel=true"]
         }
     ]
 }

--- a/.github/silabs-builds-mg24.json
+++ b/.github/silabs-builds-mg24.json
@@ -16,5 +16,11 @@
             "boards": ["BRD4187C"],
             "arguments": ["--docker", "--wifi SiWx917"]
         }
+    ],
+    "ble-side-channel": [
+        {
+            "boards": ["BRD4187C"],
+            "arguments": ["--docker", "--sl_enable_ble_side_channel"]
+        }
     ]
 }

--- a/.github/silabs-builds-mg24.json
+++ b/.github/silabs-builds-mg24.json
@@ -24,7 +24,7 @@
     "lighting-app": [
         {
             "boards": ["BRD4187C"],
-            "arguments": ["--docker", "sl_enable_ble_side_channel=true"]
+            "arguments": ["--docker", "sl_enable_ble_side_channel=true", "--clean"]
         }
     ]
 }

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -291,9 +291,6 @@ template("efr32_sdk") {
           "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/hci/release/libble_host_hci.a",
           "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/system/release/libble_host_system.a",
         ]
-        if (!sl_enable_ble_side_channel) {
-          libs += [ "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/ble_bgapi/release/libble_bgapi_stub_gatt_client.a" ]
-        }
       }
     }
 
@@ -656,6 +653,8 @@ template("efr32_sdk") {
       ]
 
       libs += [ "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/ble_bgapi/release/libble_bgapi_gatt_client.a" ]
+    } else if (!chip_enable_ble_rs911x) {
+      libs += [ "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/ble_bgapi/release/libble_bgapi_stub_gatt_client.a" ]
     }
     if (chip_build_libshell) {  # matter shell
       defines += [

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -284,7 +284,6 @@ template("efr32_sdk") {
           "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/bgstack/release/libble_host.a",
           "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/bgstack/release/libbondingdb_stub.a",
           "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/ble_bgapi/release/libble_bgapi.a",
-          "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/ble_bgapi/release/libble_bgapi_stub_gatt_client.a",
           "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/ble_system/release/libble_system.a",
           "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/connection_subrating/release/libble_host_connection_subrating_stub.a",
           "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/core/release/libble_host_core.a",
@@ -292,6 +291,9 @@ template("efr32_sdk") {
           "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/hci/release/libble_host_hci.a",
           "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/system/release/libble_host_system.a",
         ]
+        if (!sl_enable_ble_side_channel) {
+          libs += [ "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/ble_bgapi/release/libble_bgapi_stub_gatt_client.a" ]
+        }
       }
     }
 
@@ -652,6 +654,8 @@ template("efr32_sdk") {
         "SL_BT_ADVERTISER_CONFIG_H",
         "SL_BT_CONFIG_USER_ADVERTISERS=2",
       ]
+
+      libs += [ "${matter_support_root}/sdk-copies/protocol/bluetooth/build/gcc/cortex-m33/ble_host/ble_bgapi/release/libble_bgapi_gatt_client.a" ]
     }
     if (chip_build_libshell) {  # matter shell
       defines += [


### PR DESCRIPTION
#### Summary

This requires matter_support pr: https://github.com/SiliconLabsSoftware/matter_support/pull/140 to be merged beforehand.

 Modified build script to use gatt client libraries with the side-channel and the stubs otherwise.
