### PR TITLE
[SL-UP] Optimize region_code setting for wifi apps.

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -110,13 +110,9 @@ sl_net_wifi_lwip_context_t wifi_client_context;
 #endif // SLI_SI91X_LWIP_HOSTED_NETWORK_STACK
 sl_wifi_security_t security = SL_WIFI_SECURITY_UNKNOWN;
 
-// TODO : Temporary work-around for wifi-init failure in 917NCP ACX module board(BRD4357A). Can be removed after
-// Wiseconnect fixes region code for all ACX module boards.
-#ifdef ACX_MODULE_BOARD
-#define REGION_CODE IGNORE_REGION
-#else
+#ifndef REGION_CODE
 #define REGION_CODE US
-#endif // ACX_MODULE_BOARD
+#endif // !def REGION_CODE
 
 const sl_wifi_device_configuration_t config = {
     .boot_option = LOAD_NWP_FW,

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -617,7 +617,7 @@ template("efr32_sdk") {
       if (use_SiWx917_module) {
         defines += [
           "USE_BYPASS_CLOCK=1",
-          "ACX_MODULE_BOARD=1",
+          "SL_SI91X_ACX_MODULE=1",
         ]
       }
 


### PR DESCRIPTION
#### Summary
Region code value in wifi config object is set to US by default (supports wifi channels 1-11), this leads to commissioning failure if the AP is set to channel 13 (EU region).

Fixed this issue in this PR by adding a condition to check if REGION_CODE is being defined by the user in pre-processor instructions and setting it to US only if it is not defined by user.
Also, removed the region_code dependency with 917NCP ACX module board(brd4357a) by adding "SL_SI91x_ACX_MODULE" for brd4357a build.

#### Related issues
[MATTER-4719](https://jira.silabs.com/browse/MATTER-4719)

#### Testing
Tested NCP and SOC builds with these changes and verified that commissioning and commands are working as expected.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase
