### PR TITLE
[SL-TEMP] Disable the LI Sleep for the GA quality

### DIFF
--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -33,6 +33,9 @@ namespace {
  */
 CHIP_ERROR ConfigureLIBasedSleep()
 {
+    // TODO: revert this with actual fix https://jira.silabs.com/browse/MATTER-5341
+    return CHIP_ERROR_INTERNAL;
+
     sl_status_t status = ConfigureBroadcastFilter(true);
     VerifyOrReturnError(status == SL_STATUS_OK, MATTER_PLATFORM_ERROR(status),
                         ChipLogError(DeviceLayer, "Failed to configure broadcasts filter."));


### PR DESCRIPTION
#### Summary
Noticed in the IDM test cases, the subscription command is failed since it expects a discovery after the timeout happens, causing the command to fail. 

Disabling the LI sleep till it is fixed, https://jira.silabs.com/browse/MATTER-5341 created a task for this.
The commands due to which it is failing is

```
./chip-tool interactive start
basicinformation subscribe node-label 30 600 1 0 --keepSubscriptions 0
```
(Device go to LI sleep)
after 9min
`basicinformation subscribe location 30 600 1 0 --keepSubscriptions 0 (no mdns is needed for this)`
after 1 min 1st subscription is closed since keepSubscriptions is false.
`basicinformation write location CA 1 0 (mdns discovery which is failing since the device is in LI sleep)`


#### Related issues


#### Testing
Tested locally with 917SoC

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
