### PR TITLE
[SL-UP] Software Update BootReason

### DIFF
--- a/src/platform/silabs/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/ConfigurationManagerImpl.cpp
@@ -39,6 +39,13 @@
 #include "ZigbeeCallbacks.h"
 #endif // SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 
+#if !SLI_SI91X_MCU_INTERFACE
+extern "C" {
+#include "btl_interface.h"
+#include "btl_reset_info.h"
+}
+#endif // !SLI_SI91X_MCU_INTERFACE
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -148,6 +155,14 @@ CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
     matterBootCause = BootReasonType::kUnspecified;
 #endif
 
+#if !SLI_SI91X_MCU_INTERFACE
+    BootloaderResetCause_t testBootReason = bootloader_getResetReason();
+    if (matterBootCause == BootReasonType::kSoftwareReset && testBootReason.reason == BOOTLOADER_RESET_REASON_BOOTLOAD &&
+        testBootReason.signature == BOOTLOADER_RESET_SIGNATURE_VALID)
+    {
+        matterBootCause = BootReasonType::kSoftwareUpdateCompleted;
+    }
+#endif
     bootReason = to_underlying(matterBootCause);
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
Added a check on the values set at the OTA reset to determine if the underlying reboot cause was a software update.


#### Related issues

https://jira.silabs.com/browse/MATTER-5177

#### Testing

Simulating a software update and printing the value at boot, showed expected values.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
