### PR TITLE
[CSA-CP] Update cluster revision default value in General commissioning cluster

### DIFF
--- a/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.matter
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.matter
@@ -2542,7 +2542,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.zap
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.zap
@@ -1432,7 +1432,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/closure-app/closure-common/closure-app.matter
+++ b/examples/closure-app/closure-common/closure-app.matter
@@ -2531,7 +2531,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/closure-app/closure-common/closure-app.zap
+++ b/examples/closure-app/closure-common/closure-app.zap
@@ -1503,7 +1503,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/dishwasher-app/silabs/data_model/dishwasher-thread-app.matter
+++ b/examples/dishwasher-app/silabs/data_model/dishwasher-thread-app.matter
@@ -2475,7 +2475,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/dishwasher-app/silabs/data_model/dishwasher-thread-app.zap
+++ b/examples/dishwasher-app/silabs/data_model/dishwasher-thread-app.zap
@@ -1444,7 +1444,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/dishwasher-app/silabs/data_model/dishwasher-wifi-app.matter
+++ b/examples/dishwasher-app/silabs/data_model/dishwasher-wifi-app.matter
@@ -2384,7 +2384,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/dishwasher-app/silabs/data_model/dishwasher-wifi-app.zap
+++ b/examples/dishwasher-app/silabs/data_model/dishwasher-wifi-app.zap
@@ -1444,7 +1444,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/light-switch-app/light-switch-common/icd-lit-light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/icd-lit-light-switch-app.matter
@@ -2988,7 +2988,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/light-switch-app/light-switch-common/icd-lit-light-switch-app.zap
+++ b/examples/light-switch-app/light-switch-common/icd-lit-light-switch-app.zap
@@ -1490,7 +1490,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -3112,7 +3112,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/light-switch-app/light-switch-common/light-switch-app.zap
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.zap
@@ -1490,7 +1490,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
@@ -2516,7 +2516,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
@@ -1386,7 +1386,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
@@ -2782,7 +2782,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
@@ -1386,7 +1386,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/lock-app/silabs/data_model/lock-app.matter
+++ b/examples/lock-app/silabs/data_model/lock-app.matter
@@ -3009,7 +3009,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/lock-app/silabs/data_model/lock-app.zap
+++ b/examples/lock-app/silabs/data_model/lock-app.zap
@@ -1652,7 +1652,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/pump-app/silabs/data_model/pump-thread-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-thread-app.matter
@@ -2197,7 +2197,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/pump-app/silabs/data_model/pump-thread-app.zap
+++ b/examples/pump-app/silabs/data_model/pump-thread-app.zap
@@ -1301,7 +1301,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/pump-app/silabs/data_model/pump-wifi-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-wifi-app.matter
@@ -2197,7 +2197,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/pump-app/silabs/data_model/pump-wifi-app.zap
+++ b/examples/pump-app/silabs/data_model/pump-wifi-app.zap
@@ -1301,7 +1301,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.matter
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.matter
@@ -1945,7 +1945,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.zap
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.zap
@@ -1415,7 +1415,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.matter
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.matter
@@ -1854,7 +1854,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.zap
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.zap
@@ -1415,7 +1415,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
+++ b/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
@@ -2362,7 +2362,7 @@ endpoint 0 {
     callback attribute locationCapability;
     callback attribute supportsConcurrentConnection;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.zap
+++ b/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.zap
@@ -1031,7 +1031,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -2542,7 +2542,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    callback attribute clusterRevision default = 1;
+    callback attribute clusterRevision default = 2;
 
     handle command ArmFailSafe;
     handle command ArmFailSafeResponse;

--- a/examples/window-app/common/window-app.zap
+++ b/examples/window-app/common/window-app.zap
@@ -1691,7 +1691,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,


### PR DESCRIPTION
#### Summary

This is a cherry-pick PR from CSA to update the default value in zap files for General Commissioning cluster.
CSA PR : https://github.com/project-chip/connectedhomeip/pull/40530

#### Related issues
MATTER-5267

#### Testing
Built lighting-app for 917SOC board, commissioned and verified that cluster revision value is '2' by sending a read command.

./chip-tool generalcommissioning read cluster-revision 1 1

Output : ClusterRevision: 2

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

