### PR TITLE
[SL-TEMP] Adds fix to sl_net_up handling to prevent duplicate join failure event

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -437,8 +437,11 @@ sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLe
     // we ignore it and wait for the sl_net_up to complete.
     if (wfx_rsi.dev_state.Has(WifiState::kStationConnecting))
     {
-        wfx_rsi.dev_state.Clear(
-            WifiState::kStationConnecting) if (SL_WIFI_CHECK_IF_EVENT_FAILED(event)) return SL_STATUS_IN_PROGRESS;
+        wfx_rsi.dev_state.Clear(WifiState::kStationConnecting);
+        if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
+        {
+            return SL_STATUS_IN_PROGRESS;
+        }
     }
 
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -480,14 +480,14 @@ sl_status_t JoinWifiNetwork(void)
 
     if(!(wfx_rsi.dev_state.Has(WifiState::kStationConnecting)))
     {
-        // TODO: Remove this check once the sl_net_up is fixed, sl_net_up is not completely synchronous 
+        // TODO: Remove this check once the sl_net_up is fixed, sl_net_up is not completely synchronous
         // and issue is mostly seen on OPEN access points
 
         // sl_net_up can return SL_STATUS_SUCCESS, even if the join callback has been called
         // If the state has changed, it means that the join callback has already been called
         // rejoin already started, so we should not proceed with further processing
         ChipLogDetail(DeviceLayer, "JoinCallback already called, skipping further processing");
-    
+
         status = SL_STATUS_FAIL;
     }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -435,10 +435,10 @@ sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLe
     sl_status_t status = SL_STATUS_OK;
     // If the failed event is encountered when sl_net_up is in-progress,
     // we ignore it and wait for the sl_net_up to complete.
-    if (wfx_rsi.dev_state.Has(WifiState::kStationConnecting)) {
-        wfx_rsi.dev_state.Clear(WifiState::kStationConnecting)
-        if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
-            return SL_STATUS_IN_PROGRESS;
+    if (wfx_rsi.dev_state.Has(WifiState::kStationConnecting))
+    {
+        wfx_rsi.dev_state.Clear(
+            WifiState::kStationConnecting) if (SL_WIFI_CHECK_IF_EVENT_FAILED(event)) return SL_STATUS_IN_PROGRESS;
     }
 
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
@@ -478,7 +478,7 @@ sl_status_t JoinWifiNetwork(void)
 
     status = sl_net_up((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE, SL_NET_DEFAULT_WIFI_CLIENT_PROFILE_ID);
 
-    if(!(wfx_rsi.dev_state.Has(WifiState::kStationConnecting)))
+    if (!(wfx_rsi.dev_state.Has(WifiState::kStationConnecting)))
     {
         // TODO: Remove this check once the sl_net_up is fixed, sl_net_up is not completely synchronous
         // and issue is mostly seen on OPEN access points

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -471,6 +471,19 @@ sl_status_t JoinWifiNetwork(void)
 
     status = sl_net_up((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE, SL_NET_DEFAULT_WIFI_CLIENT_PROFILE_ID);
 
+    if(!(wfx_rsi.dev_state.Has(WifiState::kStationConnecting)))
+    {
+        // TODO: Remove this check once the sl_net_up is fixed, sl_net_up is not completely synchronous 
+        // and issue is mostly seen on OPEN access points
+
+        // sl_net_up can return SL_STATUS_SUCCESS, even if the join callback has been called
+        // If the state has changed, it means that the join callback has already been called
+        // rejoin already started, so we should not proceed with further processing
+        ChipLogDetail(DeviceLayer, "JoinCallback already called, skipping further processing");
+    
+        return SL_STATUS_FAIL;
+    }
+
     if (status == SL_STATUS_OK)
     {
 #if CHIP_CONFIG_ENABLE_ICD_SERVER


### PR DESCRIPTION
#### Summary

The issue is seen when `sl_net_up` has successfully joined the WiFi access point, and is in the process of IP negotiation, specially SLAAC. During this SLAAC DAD process if the WiFi disconnects and the application receives a `JoinFailure` callback, the application has no way to abort the process. The `sl_net_up` in the IP negotiation process is not sensitive to the lower layer connection. This will cause `sl_net_up` to report a `SL_STATUS_OK` even when things are not.

A proper fix from Wiseconnect SDK is expected in 4.0.0, hence raising a SL-TEMP.
Currently tried to fix the condition by checking the state of the device before proceeding with the status obtained from `sl_net_up`.

#### Testing

Done locally.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
