### PR TITLE
[SL-ONLY]Use existing string for tracing class to validate shell cmd

### DIFF
--- a/examples/platform/silabs/shell/tracing/TracingShellCommands.cpp
+++ b/examples/platform/silabs/shell/tracing/TracingShellCommands.cpp
@@ -34,11 +34,12 @@ using SilabsTracer       = Tracing::Silabs::SilabsTracer;
 
 TimeTraceOperation StringToTimeTraceOperation(const char * str)
 {
-    for (uint32_t ttOp = 0; ttOp < to_underlying(TimeTraceOperation::kNumTraces); ttOp++)
+    for (auto ttOp = 0; ttOp < to_underlying(TimeTraceOperation::kNumTraces); ttOp++)
     {
-        if (strcmp(str, TimeTraceOperationToString(static_cast<TimeTraceOperation>(ttOp))) == 0)
+        TimeTraceOperation op = static_cast<TimeTraceOperation>(ttOp);
+        if (strcmp(str, TimeTraceOperationToString(op)) == 0)
         {
-            return static_cast<TimeTraceOperation>(ttOp);
+            return op;
         }
     }
     return TimeTraceOperation::kNumTraces;


### PR DESCRIPTION
#### Summary
Small optimization to reuse the string defined in SilabsTracing.cpp for all TimeTraceOperation Enums values in the tracing shell commands arguments.

This makes it so you can add a new enum/string entry in 1 location SilabsTracing.cpp and make it available in shell commands without duplicating the string.

#### Related issues
N/A

#### Testing
Validate that the Shell tracing command can recognize all/any `TimeTraceOperation` string as defined in `TimeTraceOperationToString` from third_party/matter_sdk/src/platform/silabs/tracing/SilabsTracing.cpp
