### PR TITLE
[CSA-CP] Matter Shell fixing for the refrigerator devices

### DIFF
--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -28,8 +28,7 @@ constexpr uint8_t kRefEndpointId = 1;
 
 using namespace chip;
 using namespace chip::app;
-using namespace Clusters::RefrigeratorAlarm;
-using namespace Clusters::TemperatureControl;
+using namespace chip::app::Clusters;
 using Shell::Engine;
 using Shell::shell_command_t;
 using Shell::streamer_get;


### PR DESCRIPTION
#### Summary
Refrigerator app shell build was failing with the v1.4.2 merge
Cherry-pick of the PR:
https://github.com/project-chip/connectedhomeip/pull/40197

#### Testing
Run and build with shell enabled with the 917SoC