### PR TITLE
[SL-ONLY] Config file override to support IPV4 support for Matter AWS SLC build.

### DIFF
--- a/examples/platform/silabs/matter_aws/matter_aws_interface/include/sl_matter_wifi_config.h
+++ b/examples/platform/silabs/matter_aws/matter_aws_interface/include/sl_matter_wifi_config.h
@@ -1,0 +1,15 @@
+#ifndef SL_MATTER_WIFI_CONFIG
+#define SL_MATTER_WIFI_CONFIG
+
+// <<< Use Configuration Wizard in Context Menu >>>
+// <q WIFI_ENABLE_SECURITY_WPA3_TRANSITION > Enable WPA3 support for WiFi
+// <i> Enables support for WPA3 security support for WiFi
+// <i> Default: 1
+#define WIFI_ENABLE_SECURITY_WPA3_TRANSITION 1
+
+// <q CHIP_DEVICE_CONFIG_ENABLE_IPV4 > Enable IPv4 support
+// <i> Enabled IPv4 support
+#define CHIP_DEVICE_CONFIG_ENABLE_IPV4 1
+
+// <<< end of configuration section >>>
+#endif // SL_MATTER_WIFI_CONFIG


### PR DESCRIPTION
#### Summary
This PR adds a new config file which over-rides the default one to enable IPV4 support for Matter AWS in SLC build. 
This file is only needed for SLC build system as the "CHIP_DEVICE_CONFIG_ENABLE_IPV4" macro definition in gn system is handled with the build flags.

#### Related issues
[MATTER-5390](https://jira.silabs.com/browse/MATTER-5390)

#### Testing
Tested the Matter AWS build locally by enabling the matter_aws component in SLC build.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
