### PR TITLE
[SL-ONLY] Adds check for power state change for invoking low-level power save APIs

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -837,6 +837,8 @@ sl_status_t WifiInterfaceImpl::TriggerPlatformWifiDisconnection()
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration configuration, uint32_t listenInterval)
 {
+    VerifyOrReturnError(currentPowerSaveConfiguration != configuration, CHIP_NO_ERROR);
+
     int32_t error = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
     VerifyOrReturnError(error == RSI_SUCCESS, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: %ld", error));
@@ -851,6 +853,7 @@ CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveCo
     VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile failed: 0x%lx", status));
 
+    currentPowerSaveConfiguration = configuration;
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -463,6 +463,7 @@ sl_si91x_performance_profile_t ConvertPowerSaveConfiguration(PowerSaveInterface:
         profile = ASSOCIATED_POWER_SAVE;
         break;
     case PowerSaveInterface::PowerSaveConfiguration::kDeepSleep:
+    case PowerSaveInterface::PowerSaveConfiguration::kListenIntervalSleep:
         profile = DEEP_SLEEP_WITH_RAM_RETENTION;
         break;
     default:

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -460,10 +460,10 @@ sl_si91x_performance_profile_t ConvertPowerSaveConfiguration(PowerSaveInterface:
         profile = HIGH_PERFORMANCE;
         break;
     case PowerSaveInterface::PowerSaveConfiguration::kConnectedSleep:
+    case PowerSaveInterface::PowerSaveConfiguration::kLIConnectedSleep:
         profile = ASSOCIATED_POWER_SAVE;
         break;
     case PowerSaveInterface::PowerSaveConfiguration::kDeepSleep:
-    case PowerSaveInterface::PowerSaveConfiguration::kListenIntervalSleep:
         profile = DEEP_SLEEP_WITH_RAM_RETENTION;
         break;
     default:

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -837,7 +837,11 @@ sl_status_t WifiInterfaceImpl::TriggerPlatformWifiDisconnection()
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration configuration, uint32_t listenInterval)
 {
-    VerifyOrReturnValue(currentPowerSaveConfiguration != configuration, CHIP_NO_ERROR);
+    if (currentPowerSaveConfiguration == configuration)
+    {
+        // Power save configuration is already set, nothing to do
+        return CHIP_NO_ERROR;
+    }
 
     int32_t error = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
     VerifyOrReturnError(error == RSI_SUCCESS, CHIP_ERROR_INTERNAL,

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -837,7 +837,7 @@ sl_status_t WifiInterfaceImpl::TriggerPlatformWifiDisconnection()
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration configuration, uint32_t listenInterval)
 {
-    VerifyOrReturnError(currentPowerSaveConfiguration != configuration, CHIP_NO_ERROR);
+    VerifyOrReturnValue(currentPowerSaveConfiguration != configuration, CHIP_NO_ERROR);
 
     int32_t error = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
     VerifyOrReturnError(error == RSI_SUCCESS, CHIP_ERROR_INTERNAL,

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -838,11 +838,8 @@ sl_status_t WifiInterfaceImpl::TriggerPlatformWifiDisconnection()
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration configuration, uint32_t listenInterval)
 {
-    if (mCurrentPowerSaveConfiguration == configuration)
-    {
-        // Power save configuration is already set, nothing to do
-        return CHIP_NO_ERROR;
-    }
+    // Power save configuration is already set, nothing to do
+    VerifyOrReturnValue(mCurrentPowerSaveConfiguration != configuration, CHIP_NO_ERROR);
 
     int32_t error = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
     VerifyOrReturnError(error == RSI_SUCCESS, CHIP_ERROR_INTERNAL,

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -838,7 +838,7 @@ sl_status_t WifiInterfaceImpl::TriggerPlatformWifiDisconnection()
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration configuration, uint32_t listenInterval)
 {
-    if (currentPowerSaveConfiguration == configuration)
+    if (mCurrentPowerSaveConfiguration == configuration)
     {
         // Power save configuration is already set, nothing to do
         return CHIP_NO_ERROR;
@@ -858,7 +858,7 @@ CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveCo
     VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile failed: 0x%lx", status));
 
-    currentPowerSaveConfiguration = configuration;
+    mCurrentPowerSaveConfiguration = configuration;
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/silabs/wifi/icd/PowerSaveInterface.h
+++ b/src/platform/silabs/wifi/icd/PowerSaveInterface.h
@@ -34,9 +34,10 @@ public:
 
     enum class PowerSaveConfiguration : uint8_t
     {
-        kHighPerformance = 0,
-        kDeepSleep       = 1,
-        kConnectedSleep  = 2,
+        kHighPerformance     = 0,
+        kDeepSleep           = 1,
+        kConnectedSleep      = 2,
+        kListenIntervalSleep = 3,
     };
 
     /**

--- a/src/platform/silabs/wifi/icd/PowerSaveInterface.h
+++ b/src/platform/silabs/wifi/icd/PowerSaveInterface.h
@@ -34,10 +34,10 @@ public:
 
     enum class PowerSaveConfiguration : uint8_t
     {
-        kHighPerformance     = 0,
-        kDeepSleep           = 1,
-        kConnectedSleep      = 2,
-        kListenIntervalSleep = 3,
+        kHighPerformance  = 0,
+        kDeepSleep        = 1,
+        kConnectedSleep   = 2,
+        kLIConnectedSleep = 3,
     };
 
     /**

--- a/src/platform/silabs/wifi/icd/PowerSaveInterface.h
+++ b/src/platform/silabs/wifi/icd/PowerSaveInterface.h
@@ -38,11 +38,7 @@ public:
         kDeepSleep       = 1,
         kConnectedSleep  = 2,
     };
-protected:
-    // Default power save configuration is High Performance
-    PowerSaveConfiguration currentPowerSaveConfiguration = PowerSaveConfiguration::kHighPerformance;
 
-public:
     /**
      * @brief Configures the underlying platform to the requested power save mode.
      *
@@ -70,6 +66,10 @@ public:
      *                                                         or if it is a non-supported configuration
      */
     virtual CHIP_ERROR ConfigureBroadcastFilter(bool enableBroadcastFilter) { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+
+protected:
+    // Default power save configuration is High Performance
+    PowerSaveConfiguration currentPowerSaveConfiguration = PowerSaveConfiguration::kHighPerformance;
 };
 
 } // namespace Silabs

--- a/src/platform/silabs/wifi/icd/PowerSaveInterface.h
+++ b/src/platform/silabs/wifi/icd/PowerSaveInterface.h
@@ -38,9 +38,11 @@ public:
         kDeepSleep       = 1,
         kConnectedSleep  = 2,
     };
+protected:
     // Default power save configuration is High Performance
     PowerSaveConfiguration currentPowerSaveConfiguration = PowerSaveConfiguration::kHighPerformance;
 
+public:
     /**
      * @brief Configures the underlying platform to the requested power save mode.
      *

--- a/src/platform/silabs/wifi/icd/PowerSaveInterface.h
+++ b/src/platform/silabs/wifi/icd/PowerSaveInterface.h
@@ -69,8 +69,8 @@ public:
     virtual CHIP_ERROR ConfigureBroadcastFilter(bool enableBroadcastFilter) { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
 
 protected:
-    // Default power save configuration is High Performance as the device starts in high power mode and low power modes need to be explicitly
-    // configured
+    // Default power save configuration is High Performance as the device starts in high power mode and low power modes need to be
+    // explicitly configured
     PowerSaveConfiguration mCurrentPowerSaveConfiguration = PowerSaveConfiguration::kHighPerformance;
 };
 

--- a/src/platform/silabs/wifi/icd/PowerSaveInterface.h
+++ b/src/platform/silabs/wifi/icd/PowerSaveInterface.h
@@ -38,6 +38,8 @@ public:
         kDeepSleep       = 1,
         kConnectedSleep  = 2,
     };
+    // Default power save configuration is High Performance
+    PowerSaveConfiguration currentPowerSaveConfiguration = PowerSaveConfiguration::kHighPerformance;
 
     /**
      * @brief Configures the underlying platform to the requested power save mode.

--- a/src/platform/silabs/wifi/icd/PowerSaveInterface.h
+++ b/src/platform/silabs/wifi/icd/PowerSaveInterface.h
@@ -71,7 +71,7 @@ public:
 protected:
     // Default power save configuration is High Performance as the device starts in high power mode and low power modes need to be explicitly
     // configured
-    PowerSaveConfiguration currentPowerSaveConfiguration = PowerSaveConfiguration::kHighPerformance;
+    PowerSaveConfiguration mCurrentPowerSaveConfiguration = PowerSaveConfiguration::kHighPerformance;
 };
 
 } // namespace Silabs

--- a/src/platform/silabs/wifi/icd/PowerSaveInterface.h
+++ b/src/platform/silabs/wifi/icd/PowerSaveInterface.h
@@ -69,7 +69,8 @@ public:
     virtual CHIP_ERROR ConfigureBroadcastFilter(bool enableBroadcastFilter) { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
 
 protected:
-    // Default power save configuration is High Performance
+    // Default power save configuration is High Performance as the device starts in high power mode and low power modes need to be explicitly
+    // configured
     PowerSaveConfiguration currentPowerSaveConfiguration = PowerSaveConfiguration::kHighPerformance;
 };
 

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -162,7 +162,7 @@ CHIP_ERROR WifiSleepManager::ConfigureLIBasedSleep()
 
     // Allowing the device to go to sleep must be the last actions to avoid configuration failures.
     ReturnLogErrorOnFailure(
-        mPowerSaveInterface->ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration::kConnectedSleep,
+        mPowerSaveInterface->ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration::kListenIntervalSleep,
                                                 chip::ICDConfigurationData::GetInstance().GetSlowPollingInterval().count()));
 
     return CHIP_NO_ERROR;

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -162,7 +162,7 @@ CHIP_ERROR WifiSleepManager::ConfigureLIBasedSleep()
 
     // Allowing the device to go to sleep must be the last actions to avoid configuration failures.
     ReturnLogErrorOnFailure(
-        mPowerSaveInterface->ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration::kListenIntervalSleep,
+        mPowerSaveInterface->ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration::kLIConnectedSleep,
                                                 chip::ICDConfigurationData::GetInstance().GetSlowPollingInterval().count()));
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Summary

The application was not maintaining the state of the power profile of the device; thus it was invoking power profiles unnecessarily. This PR brings in a variable to maintain the current state of the device and only invoke low-level API in case the power profile changes.


#### Related issues

[MATTER-5404](https://jira.silabs.com/browse/MATTER-5404)

#### Testing

Testing done using the SOC and verified by adding debug statements in the code flow.

```
[00:00:00.006][info  ][DL] Starting scheduler
[00:00:00.005][info  ][DL] ==================================================
[00:00:00.009][info  ][DL] SL-Lock starting
[00:00:00.011][info  ][DL] ==================================================
[00:00:00.012][info  ][DL] Init CHIP Stack
[00:00:02.353][detail][DL] [PWR] Configuring power save: 0 with listen interval: 0
[00:00:02.356][detail][DL] [PWR] Power save configuration already set
...
[00:00:02.852][detail][DL] [PWR] Configuring power save: 0 with listen interval: 0
[00:00:02.853][detail][DL] [PWR] Power save configuration already set
...
[00:00:02.882][detail][DL] [PWR] Configuring power save: 2 with listen interval: 0
...
[00:00:02.895][detail][DL] [PWR] Configuring power save: 0 with listen interval: 0
...
[00:00:07.424][detail][DL] [PWR] Configuring power save: 2 with listen interval: 0
...
[00:00:07.497][detail][DL] [PWR] Configuring power save: 2 with listen interval: 0
[00:00:07.498][detail][DL] [PWR] Power save configuration already set
...
[00:04:52.188][detail][DL] [PWR] Configuring power save: 2 with listen interval: 0
[00:04:52.189][detail][DL] [PWR] Power save configuration already set
...
[00:04:55.280][detail][DL] [PWR] Configuring power save: 2 with listen interval: 0
[00:04:55.281][detail][DL] [PWR] Power save configuration already set
...
[00:08:16.173][detail][DL] [PWR] Configuring power save: 2 with listen interval: 0
[00:08:16.174][detail][DL] [PWR] Power save configuration already set
...
[00:08:16.393][detail][DL] [PWR] Configuring power save: 2 with listen interval: 0
[00:08:16.394][detail][DL] [PWR] Power save configuration already set
... <subscript>
[00:08:16.579][detail][DL] [PWR] Configuring power save: 3 with listen interval: 3000
... <subscribed>
... <subscription end>
[00:18:16.405][detail][DL] [PWR] Configuring power save: 2 with listen interval: 0
... <send command>
[00:18:58.486][detail][DL] [PWR] Configuring power save: 2 with listen interval: 0
[00:18:58.487][detail][DL] [PWR] Power save configuration already set
...
[00:18:59.357][detail][DL] [PWR] Configuring power save: 2 with listen interval: 0
[00:18:59.358][detail][DL] [PWR] Power save configuration already set
```

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
