### PR TITLE
[SL-ONLY] Remove PSA macros to avoid build errors for AWS

### DIFF
--- a/src/platform/silabs/SiWx917/siwx917-chip-mbedtls-config.h
+++ b/src/platform/silabs/SiWx917/siwx917-chip-mbedtls-config.h
@@ -66,6 +66,13 @@
 #define MBEDTLS_SHA256_C
 #define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 
+// AWS integration does not currently rely on PSA Crypto APIs.
+// These macros are undefined to prevent PSA-related build errors.
+// TODO: Revisit and clean up these macro overrides during refactor.
+#undef MBEDTLS_PSA_CRYPTO_C
+#undef MBEDTLS_USE_PSA_CRYPTO
+#undef MBEDTLS_PSA_CRYPTO_CONFIG
+
 #endif // SL_MATTER_ENABLE_AWS
 
 #ifdef SL_MBEDTLS_USE_TINYCRYPT


### PR DESCRIPTION
#### Summary
This change disables PSA Crypto-related macros (MBEDTLS_PSA_CRYPTO_C, MBEDTLS_USE_PSA_CRYPTO, and MBEDTLS_PSA_CRYPTO_CONFIG) for AWS integration, as PSA APIs are not currently used in this context. The macros are undefined to prevent build-time conflicts and errors. A TODO has been added to revisit and clean up these overrides during future refactoring.

#### Related issues
[MATTER-5395](https://jira.silabs.com/browse/MATTER-5395)

#### Testing
Verified successful build of the AWS-enabled configuration with PSA macros undefined.
Verified that commissioning and commands work.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
