### PR TITLE
[SL-UP] Suppress misleading error logs from unimplemented SetPollingInterval API

### DIFF
--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -433,7 +433,8 @@ void ICDManager::UpdateOperationState(OperationalState state)
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 
         CHIP_ERROR err = DeviceLayer::ConnectivityMgr().SetPollingInterval(slowPollInterval);
-        if (err != CHIP_NO_ERROR)
+        // TODO: Handle error case after the SetPollingInterval feature is implemented.
+        if (err != CHIP_ERROR_NOT_IMPLEMENTED)
         {
             ChipLogError(AppServer, "Failed to set Slow Polling Interval: err %" CHIP_ERROR_FORMAT, err.Format());
         }
@@ -473,7 +474,8 @@ void ICDManager::UpdateOperationState(OperationalState state)
 
             CHIP_ERROR err =
                 DeviceLayer::ConnectivityMgr().SetPollingInterval(ICDConfigurationData::GetInstance().GetFastPollingInterval());
-            if (err != CHIP_NO_ERROR)
+            // TODO: Handle error case after the SetPollingInterval feature is implemented.
+            if (err != CHIP_ERROR_NOT_IMPLEMENTED)
             {
                 ChipLogError(AppServer, "Failed to set Fast Polling Interval: err %" CHIP_ERROR_FORMAT, err.Format());
             }

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -434,7 +434,7 @@ void ICDManager::UpdateOperationState(OperationalState state)
 
         CHIP_ERROR err = DeviceLayer::ConnectivityMgr().SetPollingInterval(slowPollInterval);
         // TODO: Handle error case after the SetPollingInterval feature is implemented.
-        if (err != CHIP_ERROR_NOT_IMPLEMENTED)
+        if (err != CHIP_ERROR_NOT_IMPLEMENTED && err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "Failed to set Slow Polling Interval: err %" CHIP_ERROR_FORMAT, err.Format());
         }
@@ -475,7 +475,7 @@ void ICDManager::UpdateOperationState(OperationalState state)
             CHIP_ERROR err =
                 DeviceLayer::ConnectivityMgr().SetPollingInterval(ICDConfigurationData::GetInstance().GetFastPollingInterval());
             // TODO: Handle error case after the SetPollingInterval feature is implemented.
-            if (err != CHIP_ERROR_NOT_IMPLEMENTED)
+            if (err != CHIP_ERROR_NOT_IMPLEMENTED && err != CHIP_NO_ERROR)
             {
                 ChipLogError(AppServer, "Failed to set Fast Polling Interval: err %" CHIP_ERROR_FORMAT, err.Format());
             }

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -433,8 +433,7 @@ void ICDManager::UpdateOperationState(OperationalState state)
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 
         CHIP_ERROR err = DeviceLayer::ConnectivityMgr().SetPollingInterval(slowPollInterval);
-        // TODO: Handle error case after the SetPollingInterval feature is implemented.
-        if (err != CHIP_ERROR_NOT_IMPLEMENTED && err != CHIP_NO_ERROR)
+        if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "Failed to set Slow Polling Interval: err %" CHIP_ERROR_FORMAT, err.Format());
         }
@@ -474,8 +473,7 @@ void ICDManager::UpdateOperationState(OperationalState state)
 
             CHIP_ERROR err =
                 DeviceLayer::ConnectivityMgr().SetPollingInterval(ICDConfigurationData::GetInstance().GetFastPollingInterval());
-            // TODO: Handle error case after the SetPollingInterval feature is implemented.
-            if (err != CHIP_ERROR_NOT_IMPLEMENTED && err != CHIP_NO_ERROR)
+            if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(AppServer, "Failed to set Fast Polling Interval: err %" CHIP_ERROR_FORMAT, err.Format());
             }

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -203,8 +203,8 @@ void ConnectivityManagerImpl::_OnWiFiStationProvisionChange()
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 CHIP_ERROR ConnectivityManagerImpl::_SetPollingInterval(System::Clock::Milliseconds32 pollingInterval)
 {
-    // TODO: This feature is not required in the current integration - stub for now.
-    // Revisit this once the full integration is planned and implement accordingly.
+    // TODO: This function is not used in the current integration - return no error to avoid having the ICDManager error log.
+    // Revisit this once we complete the ICD integration
     (void) pollingInterval;
     return CHIP_NO_ERROR;
 }

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -205,7 +205,6 @@ CHIP_ERROR ConnectivityManagerImpl::_SetPollingInterval(System::Clock::Milliseco
 {
     // TODO ICD
     (void) pollingInterval;
-    ChipLogError(DeviceLayer, "Set ICD Fast Polling on Silabs Wifi platform");
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER */

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -203,9 +203,10 @@ void ConnectivityManagerImpl::_OnWiFiStationProvisionChange()
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 CHIP_ERROR ConnectivityManagerImpl::_SetPollingInterval(System::Clock::Milliseconds32 pollingInterval)
 {
-    // TODO ICD
+    // TODO: This feature is not required in the current integration - stub for now.
+    // Revisit this once the full integration is planned and implement accordingly.
     (void) pollingInterval;
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    return CHIP_NO_ERROR;
 }
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER */
 


### PR DESCRIPTION
#### Summary
In ICD applications for the 917SoC, we observed misleading error logs originating from the `SetPollingInterval` API, despite the application functioning correctly. These logs stem from the `_SetPollingInterval` method in the Connectivity Manager, which currently returns `CHIP_ERROR_NOT_IMPLEMENTED` as the feature is not yet supported. The upper layer interprets this as a failure, resulting in unnecessary error messages.

This PR addresses the issue by:

- Adding a conditional check for `CHIP_ERROR_NOT_IMPLEMENTED` in the upper layer to suppress misleading logs.
- Ensuring that the absence of implementation does not trigger failure handling.
- Adding a TODO comment to revisit and update the error handling logic once the polling interval feature is fully implemented.

This cleanup improves log clarity and avoids confusion during debugging and validation.


#### Related issues
[MATTER-5337](https://jira.silabs.com/browse/MATTER-5337)

#### Testing

Built lock app locally, commissioned and confirmed that these logs are not seen.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
