### PR TITLE
[SL-UP] Reset retry interval on WiFi connection notification

### DIFF
--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -163,6 +163,8 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
     wifiConfig.security = WFX_SEC_WPA2;
 
     ChipLogProgress(NetworkProvisioning, "Setting up connection for WiFi SSID: %.*s", static_cast<int>(ssidLen), ssid);
+    // Resetting the retry connection state machine for a new access point connection
+    WifiInterface::GetInstance().ResetScheduledConnectionAttempts();
     // Configure the WFX WiFi interface.
     WifiInterface::GetInstance().SetWifiCredentials(wifiConfig);
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled));

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -164,7 +164,7 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
 
     ChipLogProgress(NetworkProvisioning, "Setting up connection for WiFi SSID: %.*s", static_cast<int>(ssidLen), ssid);
     // Resetting the retry connection state machine for a new access point connection
-    WifiInterface::GetInstance().ResetScheduledConnectionAttempts();
+    WifiInterface::GetInstance().ResetConnectionRetryInterval();
     // Configure the WFX WiFi interface.
     WifiInterface::GetInstance().SetWifiCredentials(wifiConfig);
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled));

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -106,6 +106,7 @@ void WifiInterface::NotifyConnection(const MacAddress & ap)
     evt.body.channel = wfx_rsi.ap_chan;
 #endif
     std::copy(ap.begin(), ap.end(), evt.body.mac);
+    retryInterval = kWlanMinRetryIntervalsInSec;
 
     HandleWFXSystemEvent((sl_wfx_generic_message_t *) &evt);
 }

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -108,7 +108,7 @@ void WifiInterface::NotifyConnection(const MacAddress & ap)
     std::copy(ap.begin(), ap.end(), evt.body.mac);
     // Resetting the retry connection state machine for a successful connection
     // NOTE: This is required in case an access point gets disconnected after a successful connection.
-    ResetScheduledConnectionAttempts();
+    ResetConnectionRetryInterval();
 
     HandleWFXSystemEvent((sl_wfx_generic_message_t *) &evt);
 }
@@ -179,7 +179,7 @@ void WifiInterface::ScheduleConnectionAttempt()
     retryInterval += retryInterval;
 }
 
-void WifiInterface::ResetScheduledConnectionAttempts()
+void WifiInterface::ResetConnectionRetryInterval()
 {
     ChipLogDetail(DeviceLayer, "ScheduleConnectionAttempts: Resetting state to default");
     retryInterval = kWlanMinRetryIntervalsInSec;

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -106,7 +106,9 @@ void WifiInterface::NotifyConnection(const MacAddress & ap)
     evt.body.channel = wfx_rsi.ap_chan;
 #endif
     std::copy(ap.begin(), ap.end(), evt.body.mac);
-    retryInterval = kWlanMinRetryIntervalsInSec;
+    // Resetting the retry connection state machine for a successful connection
+    // NOTE: This is required in case an access point gets disconnected after a successful connection.
+    ResetScheduledConnectionAttempts();
 
     HandleWFXSystemEvent((sl_wfx_generic_message_t *) &evt);
 }

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -177,6 +177,12 @@ void WifiInterface::ScheduleConnectionAttempt()
     retryInterval += retryInterval;
 }
 
+void WifiInterface::ResetScheduledConnectionAttempts()
+{
+    ChipLogDetail(DeviceLayer, "ScheduleConnectionAttempts: Resetting state to default");
+    retryInterval = kWlanMinRetryIntervalsInSec;
+}
+
 } // namespace Silabs
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -354,9 +354,9 @@ public:
     }
 
     /**
-     * @brief Function will reset the state of the reconnection attempts with the Access Point
+     * @brief Function resets reconnection attempt interval back to the minimum value
      */
-    void ResetScheduledConnectionAttempts();
+    void ResetConnectionRetryInterval();
 
 protected:
     /**

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -353,6 +353,11 @@ public:
         return static_cast<uint32_t>(1UL << chip::to_underlying(chip::app::Clusters::NetworkCommissioning::WiFiBandEnum::k2g4));
     }
 
+    /**
+     * @brief Function will reset the state of the reconnection attempts with the Access Point 
+     */
+    void ResetScheduledConnectionAttempts();
+
 protected:
     /**
      * @brief Function notifies the PlatformManager that an IPv6 event occured on the WiFi interface.

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -354,7 +354,7 @@ public:
     }
 
     /**
-     * @brief Function will reset the state of the reconnection attempts with the Access Point 
+     * @brief Function will reset the state of the reconnection attempts with the Access Point
      */
     void ResetScheduledConnectionAttempts();
 


### PR DESCRIPTION
#### Summary

The retry timer is not getting reset on a successful connection after a retry, thus consecutive retry attempts are set as per the existing timer value.

#### Related issues

NOJIRA

#### Testing

This was tested by rebooting the access point.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
