### PR TITLE
[SL-ONLY] Update dependabot to only trigger updates on silabs repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "SiliconLabsSoftware/matter_build_action"
+
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
@@ -26,4 +33,3 @@ updates:
     allow:
       - dependency-name: "third_party/silabs/matter_support"
     target-branch: "release_2.6-1.4"
-  


### PR DESCRIPTION
#### Summary

PR updates dependabot to only trigger updates for matter_support since it is the only repos that can change without additionnal changes from a developper.

All other updates are not wanted for a release branch and the updates should comme from upstream for the rest

#### Related issues

TBU

#### Testing

None required

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
