### PR TITLE
[SL-UP]Bump thermostat cluster revision to 9

### DIFF
--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -2870,7 +2870,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0x123;
-    ram      attribute clusterRevision default = 8;
+    ram      attribute clusterRevision default = 9;
 
     handle command SetpointRaiseLower;
     handle command SetActivePresetRequest;

--- a/examples/thermostat/thermostat-common/thermostat.zap
+++ b/examples/thermostat/thermostat-common/thermostat.zap
@@ -5291,7 +5291,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "8",
+              "defaultValue": "9",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,


### PR DESCRIPTION
#### Summary
CLuster revision update was missed for the thermostat app. It needed to be updated to revision 9.
Update the Zap file, and run the regen for the .matter

#### Related issues
[MATTER-5403](https://jira.silabs.com/browse/MATTER-5403)

#### Testing
chiptool commission and read of the cluster revision.
```
[1758063577.370] [17922:17924] [TOO] Endpoint: 1 Cluster: 0x0000_0201 Attribute 0x0000_FFFD DataVersion: 176242170
[1758063577.373] [17922:17924] [TOO]   ClusterRevision: 9
```
