### PR TITLE
[SL-UP] Fixing the 917SoC clock to 1000

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -153,7 +153,11 @@ extern uint32_t SystemCoreClock;
 #define configUSE_TICKLESS_IDLE 0
 #endif // SL_CATALOG_POWER_MANAGER_PRESENT
 
+#if SLI_SI91X_MCU_INTERFACE
+#define configTICK_RATE_HZ (1000)
+#else // For EFR32
 #define configTICK_RATE_HZ (1024)
+#endif // SLI_SI91X_MCU_INTERFACE
 
 /* Definition used by Keil to replace default system clock source. */
 #define configOVERRIDE_DEFAULT_TICK_CONFIGURATION 1


### PR DESCRIPTION
#### Summary

With the tick rate set to 1024, there is a drift in the device clock. 917SoC uses 40MHz clock by default, and the tick rate has to be set to 1000 for the systick configuration to be exactly set to 1ms. In this PR, the tick rate for SOC is being updated to 1000.

#### Related issues
[MATTER-5395](https://jira.silabs.com/browse/MATTER-5395)

#### Testing
Tested the device clock timings in lighting app and lock app after this change by opening a commissioning window with 200secs timer and ensured that the window is getting closed exactly after the given time.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
