### PR TITLE
[SL-UP] Add silabs sender boost configuration to platform configuration

### DIFF
--- a/src/platform/silabs/CHIPPlatformConfig.h
+++ b/src/platform/silabs/CHIPPlatformConfig.h
@@ -127,6 +127,10 @@ static_assert(CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE >= 3, "ICD Observers pool size
 
 #endif // defined(CHIP_CONFIG_ENABLE_ICD_SERVER) && CHIP_CONFIG_ENABLE_ICD_SERVER
 
+#ifndef CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST
+#define CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST (2500_ms32)
+#endif // CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST
+
 /**
  * @brief CHIP_SHELL_MAX_LINE_SIZE
  *
@@ -137,6 +141,7 @@ static_assert(CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE >= 3, "ICD Observers pool size
 #endif // CHIP_SHELL_MAX_LINE_SIZE
 
 // ==================== CMSISOS Configuration Overrides ====================
+
 #ifndef CHIP_CONFIG_CMSISOS_USE_STATIC_TASK
 #define CHIP_CONFIG_CMSISOS_USE_STATIC_TASK 1
 #endif

--- a/src/platform/silabs/CHIPPlatformConfig.h
+++ b/src/platform/silabs/CHIPPlatformConfig.h
@@ -141,7 +141,6 @@ static_assert(CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE >= 3, "ICD Observers pool size
 #endif // CHIP_SHELL_MAX_LINE_SIZE
 
 // ==================== CMSISOS Configuration Overrides ====================
-
 #ifndef CHIP_CONFIG_CMSISOS_USE_STATIC_TASK
 #define CHIP_CONFIG_CMSISOS_USE_STATIC_TASK 1
 #endif


### PR DESCRIPTION
#### Summary
PR adds the `CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST` configuration to the silabs platform configuration.
It sets the default configuration to 2.5 seconds.

The goal of adding this configuration is to reduce the overall speed of retries for Wi-Fi application. The sender boost configuration adds the configuration to all retries to slow them down. In other words, if the calculated retry is 1s, the device will retry 3.5s later (1s + sender boost). 

Currently, retries for wi-fi devices with ecosystems are in the milliseconds. In home environements, it is impossible to round trips sub 1s. The 2.5 second configuration was decided based on emperic tests in the office and in my home network to be the highest lowest value were there were no unecessary retries due to network latency.

For thread, it increases the matter default configuration from 1.5s to 2.5s. This helps avoid network congestion and harmanizes our configuration with Wi-Fi.

This change aims at reducing the overall number of retries but does not garantee anything since network topolgies and load differ. It is still possible to see retries due to network latency in extreme cases and that is normal.

#### Related issues
NA

#### Testing
1. Built the Wi-Fi lock app
2. Configured a subscription 
3. On sub reports, there are no retries

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
