### PR TITLE
[SL-UP] Fix init crash with WiFi-ncp platforms. 

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -214,10 +214,20 @@ void ApplicationStart(void * unused)
 
 void SilabsMatterConfig::AppInit()
 {
+#ifdef SL_WIFI
+    // Init Chip memory management before the stack for Wi-Fi platforms
+    // Because OpenThread needs to use memory allocation during its Key operations, we initialize the memory management for thread
+    // and set the allocation functions inside sl_ot_create_instance, which is called earlier by sl_system_init.
+    mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
+    VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+#endif // SL_WIFI
+
     GetPlatform().Init();
+
 #ifdef HEAP_MONITORING
     DisplayMemoryUsage();
 #endif
+
     sMainTaskHandle = osThreadNew(ApplicationStart, nullptr, &kMainTaskAttr);
     ChipLogProgress(DeviceLayer, "Starting scheduler");
     VerifyOrDie(sMainTaskHandle); // We can't proceed if the Main Task creation failed.
@@ -256,11 +266,6 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     ChipLogProgress(DeviceLayer, "Init CHIP Stack");
 
 #ifdef SL_WIFI
-    // Init Chip memory management before the stack
-    // Because OpenThread needs to use memory allocation during its Key operations, we initialize the memory management for thread
-    // and set the allocation functions inside sl_ot_create_instance, which is called earlier by sl_system_init.
-    mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
-    ReturnErrorOnFailure(chip::Platform::MemoryInit());
     ReturnErrorOnFailure(WifiInterface::GetInstance().InitWiFiStack());
     // Needs to be done post InitWifiStack for 917.
     // TODO move it in InitWiFiStack


### PR DESCRIPTION
#### Summary
With pr https://github.com/SiliconLabsSoftware/matter_sdk/pull/603
We now run the Migration at an earlier stage on EFR32 platforms.
For WiFi ncp builds, the Matter MemoryInit was not done yet which led to an assert and crash when allocating memory during a migration function.

In this PR Set mbedtls platforms callbacks and call MemoryInit earlier for wifi platforms jsut before the Platform Init which will possibly run Migrations for EFR32.
For EFR32. The same `mbedtls_platform_set_calloc_free `and `MemoryInit()` is done even ealier when we call sl_ot_create_instance during sl_system inits.


Lastly, for 917 SoC NVM3 can only be used once TA is sync with M4 therefore all the migrations are done a bit later after `InitWiFiStack`. Doing the chip::Platform::MemoryInit() doesn't do any harm 
#### Related issues
fixes https://jira.silabs.com/browse/MATTER-5478

#### Testing
build and flahs 4187c + 917 ncp. Devices boot and complete migration/init calls
Build and flash 917 SoC. No regression is seen.

