### PR TITLE
[SL-UP]Adding test event key config header to provision flash

### DIFF
--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -29,7 +29,11 @@
 #ifdef SL_MATTER_ENABLE_OTA_ENCRYPTION
 #include <platform/silabs/multi-ota/OtaTlvEncryptionKey.h>
 #endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
-
+#ifndef NDEBUG
+#if defined(SL_MATTER_TEST_EVENT_TRIGGER_ENABLED) && (SL_MATTER_GN_BUILD == 0)
+#include <sl_matter_test_event_trigger_config.h>
+#endif // defined(SL_MATTER_TEST_EVENT_TRIGGER_ENABLED) && (SL_MATTER_GN_BUILD == 0)
+#endif // NDEBUG
 #include <app/TestEventTriggerDelegate.h>
 
 #if !(SL_MATTER_GN_BUILD || defined(SL_PROVISION_GENERATOR))


### PR DESCRIPTION
#### Summary

This pull request introduces minor changes to the `ProvisionStorageFlash.cpp` file, focused on conditional inclusion of test configuration headers for debug builds. The update ensures that test event trigger configuration is only included when specific build flags are set and the build is not a release build.

Test configuration header inclusion for debug builds:

* Added conditional inclusion of `sl_matter_test_event_trigger_config.h` for builds where `SL_MATTER_TEST_EVENT_TRIGGER_ENABLED` is defined, `SL_MATTER_GN_BUILD` is 0, and the build is not a release build (`NDEBUG` not defined).

#### Testing

Built the GN build and Matter Extension closure app and validated against test scripts.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
