### PR TITLE
[SL-UP] Increase KvsKeyMapCleanup stack to address overflow risk

### DIFF
--- a/src/platform/silabs/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.cpp
@@ -62,7 +62,10 @@ CHIP_ERROR KeyValueStoreManagerImpl::Init(void)
     }
     ReturnErrorOnFailure(error);
 
-    constexpr osThreadAttr_t attr = { .name = "KvsKeyMapCleanupTask", .stack_size = 512 /* bytes */, .priority = osPriorityLow7 };
+    // On series 3, nvm3 security can use up to ~1100 bytes of stack during read/write operations.
+    // Provide enough stack for all platforms. The KvsKeyMapCleanupTask is deleted once the cleanup is completed and the allocated
+    // stack is freed.
+    constexpr osThreadAttr_t attr = { .name = "KvsKeyMapCleanupTask", .stack_size = 1536 /* bytes */, .priority = osPriorityLow7 };
     if (osThreadNew(KvsKeyMapCleanup, nullptr, &attr) == nullptr)
     {
         // We don't need to crash and force a reboot. we will retry at the next reboot


### PR DESCRIPTION
#### Summary
On Series 3, nvm3 secure API can sometimes use up to 1100 bytes on the stack.
`KvsKeyMapCleanupTask` is a task that runs once at init and can execute multiple nvm3 read or write successively.
In a rare occurrence, on power cycling of the device, a Stack overflow of this task occurred.

This PR increases the KvsKeyMapCleanupTask stack size to 1536 bytes, a 1024-byte increase. While this is targeted at series 3 use case, we can safely apply it to all our platforms and avoid conditional/configuration logic.
The stack of the task is dynamically allocated, and the task is deleted once the cleanup is completed, freeing the 1536 bytes allocated.

#### Related issues
MATTER-5377
MATTER-5397

#### Testing
Tested by building and running the init sequence on Series 2, Series 3 and 917 soc and verifying the task stack usage watermarks before task deletion

