### PR TITLE
[SL-ONLY] Add platform app zap to failure regen automation

### DIFF
--- a/.github/workflows/silabs-zap-failure-regen.yaml
+++ b/.github/workflows/silabs-zap-failure-regen.yaml
@@ -65,7 +65,9 @@ jobs:
                     ./scripts/tools/zap/generate.py examples/template/silabs/template_DataModel_config/sl_template.zap &&
                     ./scripts/tools/zap/generate.py examples/onoff-plug-app/silabs/data_model/onoff-plug-app.zap &&
                     ./scripts/tools/zap/generate.py examples/fan-control-app/silabs/data_model/fan-control-wifi-app.zap &&
-                    ./scripts/tools/zap/generate.py examples/multi-sensor-app/silabs/data_model/multi-sensor-wifi-app.zap
+                    ./scripts/tools/zap/generate.py examples/multi-sensor-app/silabs/data_model/multi-sensor-wifi-app.zap &&
+                    ./scripts/tools/zap/generate.py examples/base-platform-app/silabs/data_model/platform-thread-app.zap &&
+                    ./scripts/tools/zap/generate.py examples/base-platform-app/silabs/data_model/platform-thread-icd-app.zap
                   '
 
             - name: Commit ZAP regeneration


### PR DESCRIPTION
#### Summary

When the platform app was added to the matter_sdk, zap files were not added to ZAP failure regen automation.
https://github.com/SiliconLabsSoftware/matter_sdk/actions/runs/17993518271/job/51188360383?pr=637

It was not added because no ones this is here.

#### Testing

CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
