### PR TITLE
[SL-ONLY] Update restyle scripts to work with matter_sdk structure

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -10,9 +10,16 @@ concurrency:
 jobs:
   restyled:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - uses: restyled-io/actions/setup@v4
 
@@ -32,5 +39,4 @@ jobs:
           title: ${{ steps.restyler.outputs.restyled-title }}
           body: ${{ steps.restyler.outputs.restyled-body }}
           labels: "restyled"
-          reviewers: ${{ github.event.pull_request.user.login }}
           delete-branch: true

--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - uses: restyled-io/actions/setup@v4
 
@@ -39,4 +37,5 @@ jobs:
           title: ${{ steps.restyler.outputs.restyled-title }}
           body: ${{ steps.restyler.outputs.restyled-body }}
           labels: "restyled"
+          reviewers: ${{ github.event.pull_request.user.login }}
           delete-branch: true

--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -27,7 +27,7 @@
 #   ref     - Git reference to compare against (optional)
 #
 # Options:
-#   -d      - Sets container's log level to DEBUG, if unspecified the default log level will remain (info level)
+#   -d      - Sets container's log level to DEBUG, if unspecified, the default log level will remain (info level)
 #   -p      - Pulls the Docker image before running the restyle paths
 #
 # Reference Selection (when ref is not specified):

--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -23,9 +23,16 @@
 # Usage:
 #  restyle-diff.sh [-d] [-p] [ref]
 #
-# if unspecified, ref defaults to upstream/master (or master)
-# -d sets container's log level to DEBUG, if unspecified the default log level will remain (info level)
-# -p pulls the Docker image before running the restyle paths
+# Arguments:
+#   ref     - Git reference to compare against (optional)
+#
+# Options:
+#   -d      - Sets container's log level to DEBUG, if unspecified the default log level will remain (info level)
+#   -p      - Pulls the Docker image before running the restyle paths
+#
+# Reference Selection (when ref is not specified):
+#   - If origin is https://github.com/SiliconLabsSoftware/matter_sdk.git (main repo): uses origin/main
+#   - Otherwise (fork setup): uses upstream/main if upstream remote exists, otherwise defaults to main
 #
 
 here=${0%/*}
@@ -83,8 +90,15 @@ if [[ -z "$DOCKER_DEFAULT_PLATFORM" && "$(uname -sm)" == "Darwin arm64" ]]; then
 fi
 
 if [[ -z "$ref" ]]; then
-    ref="master"
-    git remote | grep -qxF upstream && ref="upstream/master"
+    # Check if origin points to the main repo
+    origin_url=$(git remote get-url origin 2>/dev/null || echo "")
+    if [[ "$origin_url" == "https://github.com/SiliconLabsSoftware/matter_sdk.git" ]]; then
+        ref="origin/main"
+    else
+        # Assume fork setup - use upstream/main if available, otherwise local main
+        ref="main"
+        git remote | grep -qxF upstream && ref="upstream/main"
+    fi
 fi
 
 if [[ $pull_image -eq 1 ]]; then

--- a/scripts/helpers/restyle_merge.sh
+++ b/scripts/helpers/restyle_merge.sh
@@ -20,7 +20,7 @@ set -x
 branch_name=$(git branch | grep "^*" | awk '{print $2}')
 
 # Check if origin points to the main repo
-	origin_url=$(git remote get-url origin 2>/dev/null || echo "")
+origin_url=$(git remote get-url origin 2>/dev/null || echo "")
 if [[ "$origin_url" == "https://github.com/SiliconLabsSoftware/matter_sdk.git" ]]; then
     # Main repo setup - fetch restyled branch from origin
     git fetch origin restyled/"$branch_name"

--- a/scripts/helpers/restyle_merge.sh
+++ b/scripts/helpers/restyle_merge.sh
@@ -19,7 +19,19 @@ set -x
 
 branch_name=$(git branch | grep "^*" | awk '{print $2}')
 
-git remote add upstream https://github.com/project-chip/connectedhomeip.git
-git fetch upstream restyled/"$branch_name"
-git merge --ff-only FETCH_HEAD
+# Check if origin points to the main repo
+	origin_url=$(git remote get-url origin 2>/dev/null || echo "")
+if [[ "$origin_url" == "https://github.com/SiliconLabsSoftware/matter_sdk.git" ]]; then
+    # Main repo setup - fetch restyled branch from origin
+    git fetch origin restyled/"$branch_name"
+    git merge --ff-only FETCH_HEAD
+else
+    # Fork setup - ensure upstream remote exists and use it
+    if ! git remote | grep -qxF upstream; then
+        git remote add upstream https://github.com/SiliconLabsSoftware/matter_sdk.git
+    fi
+    git fetch upstream restyled/"$branch_name"
+    git merge --ff-only FETCH_HEAD
+fi
+
 git push


### PR DESCRIPTION
#### Summary
PR updates the restyler tooling from CSA for it to work in the context of matter_sdk where the default branch is main and not master and that devs can be working directly on the matter_sdk or a fork.

The logic that is beeing added is detecting what kind of setup is being used and choosing the correct remote based on the git configuration.

PR also gives extra permissions to restyled action to be able to open PRs when a dev with write access pushes a PR that requires restyle - https://github.com/SiliconLabsSoftware/matter_sdk/pull/648
The downside of this we can't avoid the codeowners guetting a notification due to the limited features of github in this regard. We can see if this becomes a problem and remove PRs as a whole.

**restyle-diff changes**
1. If origin is this repo, main repo setup use origin as the remote
2. if origin is not this repo, check if upstream exists to use it
3. use local branch otherwise

**restyle_merge changes**
1. if origin is this repo, use main repo setup for the restyle branch.
2. if origin is not this repo, add or use upstream if present or not to find the restyle branch

#### Related issues

NA

#### Testing

**restyle-diff testing**
modyfied my local remote names for each edge case 

1. origin is the main repo
2. upstream is present without origin
3. neither upstream or origin are present

**restyle_merge**
The restyle failure is fixed with the script to validated it.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
