### PR TITLE
Update CLA Validation Bot Triggers 

### DIFF
--- a/.github/workflows/CLA-Assistant.yml
+++ b/.github/workflows/CLA-Assistant.yml
@@ -15,7 +15,11 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'silabs-matter-ci-bot' }}
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.user.login != 'dependabot[bot]' &&
+       github.event.pull_request.user.login != 'silabs-matter-ci-bot')
+       
     steps:
       - name: Create CLA Assistant Lite bot token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
#### Summary
Currently, daily PRs opened by `silabs-matter-ci-bot` to sync with latest CSA main trigger the CLA validation workflow. This behavior is not desired, as it will check for CSA users in the CLA validation database and send them emails as they have not signed. 

This happens because current implementation checks for `github.actor`, which in this case would be the user for the latest commit that is pulled in by this PR (not either bot), causing this workflow to trigger. 

Updated the if condition to check for PRs opened by either bot, rather than `github.actor`. This will ensure that any PR opened by either bot in this repo, regardless of the commits that are included, will not trigger the CLA Validation workflow. 

#### Testing
In `matter_extension_private` repo, opened test PR from Copilot and included this user in if condition in CLA workflow (see Copilot [PR](https://github.com/SiliconLabsSoftware/matter_extension_private/pull/16) and test CLA [implementation](https://github.com/SiliconLabsSoftware/matter_extension_private/pull/14/files#diff-63fce2f704373de2a9026139060146b3c7770860aeeceb033edbead359d615fd) here). With this test, the Copilot PR skipped the CLA Validation workflow step (see [here](https://github.com/SiliconLabsSoftware/matter_extension_private/actions/runs/18048668094)) which is desired behavior. 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
