### PR TITLE
[SL-ONLY] Enclosing the include file in tracing define

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -106,7 +106,9 @@ extern "C" {
 #include <stdint.h>
 #include <stdio.h>
 
+#if defined(TRACING_RUNTIME_STATS) && TRACING_RUNTIME_STATS == 1
 #include <platform/silabs/tracing/SilabsTracingConfig.h>
+#endif // TRACING_RUNTIME_STATS
 
 #ifdef SLI_SI91X_MCU_INTERFACE
 #include "si91x_device.h"


### PR DESCRIPTION
#### Summary
The copy contents step was failing after SilabsTracingConfig.h was added in FreeRTOSConfig.h file without the define check

#### Testing
Passing build on the matter extension with copy-contents enabled.
