### PR TITLE
[SL-UP] Enabling BLE on EFR32 and Disabling 917 BLE

### DIFF
--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -153,8 +153,15 @@ CHIP_ERROR BLEManagerImpl::_Init()
     // SW timer for BLE timeouts and interval change.
     sbleAdvTimeoutTimer = osTimerNew(BleAdvTimeoutHandler, osTimerOnce, NULL, NULL);
 
+    // Preserve kSiLabsBLEStackInitialize: HandleBootEvent may have set it before _Init ran.
+    bool stackAlreadyBooted = mFlags.Has(Flags::kSiLabsBLEStackInitialize);
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
+    
+    if (stackAlreadyBooted)
+    {
+        mFlags.Set(Flags::kSiLabsBLEStackInitialize);
+    }
 
     // Check that an address was not already configured at boot.
     // This covers the init-shutdown-init case to comply with the BLE address change at boot only requirement

--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -157,7 +157,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     bool stackAlreadyBooted = mFlags.Has(Flags::kSiLabsBLEStackInitialize);
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
-    
+
     if (stackAlreadyBooted)
     {
         mFlags.Set(Flags::kSiLabsBLEStackInitialize);

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -125,7 +125,11 @@ const sl_wifi_device_configuration_t config = {
         IGNORE_REGION,
 #endif
     .boot_config = { .oper_mode = SL_SI91X_CLIENT_MODE,
+#if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                      .coex_mode = SL_SI91X_WLAN_BLE_MODE,
+#else
+                     .coex_mode = SL_SI91X_WLAN_ONLY_MODE,
+#endif
                      .feature_bit_map =
 #ifdef SLI_SI91X_MCU_INTERFACE
                          (SL_SI91X_FEAT_SECURITY_OPEN | SL_SI91X_FEAT_WPS_DISABLE),
@@ -140,22 +144,32 @@ const sl_wifi_device_configuration_t config = {
 #endif
                                                 | SL_SI91X_TCP_IP_FEAT_ICMP | SL_SI91X_TCP_IP_FEAT_EXTENSION_VALID),
                      .custom_feature_bit_map     = (SL_SI91X_CUSTOM_FEAT_EXTENTION_VALID | RSI_CUSTOM_FEATURE_BIT_MAP),
+
+#if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                      .ext_custom_feature_bit_map = (RSI_EXT_CUSTOM_FEATURE_BIT_MAP | (SL_SI91X_EXT_FEAT_BT_CUSTOM_FEAT_ENABLE)
+#else
+                     .ext_custom_feature_bit_map = (RSI_EXT_CUSTOM_FEATURE_BIT_MAP
+#endif
 #if (defined A2DP_POWER_SAVE_ENABLE)
                                                     | SL_SI91X_EXT_FEAT_XTAL_CLK_ENABLE(2)
-#endif
+#endif //A2DP_POWER_SAVE_ENABLE
                                                         ),
+#if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                      .bt_feature_bit_map = (RSI_BT_FEATURE_BITMAP
 #if (RSI_BT_GATT_ON_CLASSIC)
-                                            | SL_SI91X_BT_ATT_OVER_CLASSIC_ACL /* to support att over classic acl link */
+                                                    | SL_SI91X_BT_ATT_OVER_CLASSIC_ACL /* to support att over classic acl link */
+#endif // RSI_BT_GATT_ON_CLASSIC
+                                                     ),
+#else
+                     .bt_feature_bit_map         = 0,
 #endif
-                                            ),
 #ifdef RSI_PROCESS_MAX_RX_DATA
                      .ext_tcp_ip_feature_bit_map =
                          (RSI_EXT_TCPIP_FEATURE_BITMAP | SL_SI91X_CONFIG_FEAT_EXTENTION_VALID | SL_SI91X_EXT_TCP_MAX_RECV_LENGTH),
 #else
                      .ext_tcp_ip_feature_bit_map = (RSI_EXT_TCPIP_FEATURE_BITMAP | SL_SI91X_CONFIG_FEAT_EXTENTION_VALID),
 #endif
+#if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                      //! ENABLE_BLE_PROTOCOL in bt_feature_bit_map
                      .ble_feature_bit_map =
                          ((SL_SI91X_BLE_MAX_NBR_PERIPHERALS(RSI_BLE_MAX_NBR_PERIPHERALS) |
@@ -187,6 +201,10 @@ const sl_wifi_device_configuration_t config = {
                                                  | SL_SI91X_BLE_GATT_INIT
 #endif
                                                  ),
+#else
+                     .ble_feature_bit_map        = 0,
+                     .ble_ext_feature_bit_map    = 0,
+#endif
                      .config_feature_bit_map = (SL_SI91X_FEAT_SLEEP_GPIO_SEL_BITMAP | RSI_CONFIG_FEATURE_BITMAP) }
 };
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -143,7 +143,7 @@ const sl_wifi_device_configuration_t config = {
                                                 | SL_SI91X_TCP_IP_FEAT_DHCPV6_CLIENT | SL_SI91X_TCP_IP_FEAT_IPV6
 #endif
                                                 | SL_SI91X_TCP_IP_FEAT_ICMP | SL_SI91X_TCP_IP_FEAT_EXTENSION_VALID),
-                     .custom_feature_bit_map     = (SL_SI91X_CUSTOM_FEAT_EXTENTION_VALID | RSI_CUSTOM_FEATURE_BIT_MAP),
+                     .custom_feature_bit_map = (SL_SI91X_CUSTOM_FEAT_EXTENTION_VALID | RSI_CUSTOM_FEATURE_BIT_MAP),
 
 #if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                      .ext_custom_feature_bit_map = (RSI_EXT_CUSTOM_FEATURE_BIT_MAP | (SL_SI91X_EXT_FEAT_BT_CUSTOM_FEAT_ENABLE)
@@ -152,14 +152,14 @@ const sl_wifi_device_configuration_t config = {
 #endif
 #if (defined A2DP_POWER_SAVE_ENABLE)
                                                     | SL_SI91X_EXT_FEAT_XTAL_CLK_ENABLE(2)
-#endif //A2DP_POWER_SAVE_ENABLE
+#endif // A2DP_POWER_SAVE_ENABLE
                                                         ),
 #if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                      .bt_feature_bit_map = (RSI_BT_FEATURE_BITMAP
 #if (RSI_BT_GATT_ON_CLASSIC)
-                                                    | SL_SI91X_BT_ATT_OVER_CLASSIC_ACL /* to support att over classic acl link */
-#endif // RSI_BT_GATT_ON_CLASSIC
-                                                     ),
+                                            | SL_SI91X_BT_ATT_OVER_CLASSIC_ACL /* to support att over classic acl link */
+#endif                                                                         // RSI_BT_GATT_ON_CLASSIC
+                                            ),
 #else
                      .bt_feature_bit_map         = 0,
 #endif

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -56,6 +56,9 @@ declare_args() {
   # Disable AWS SDK OTA by default
   aws_sdk_ota = false
 
+  # Use BLE host on EFR32; false = BLE on NCP/SiWx
+  use_host_ble = false
+
   # Temperature Sensor support
   sl_enable_si70xx_sensor = false
 
@@ -70,8 +73,8 @@ declare_args() {
   # Enables LCD Qr Code on supported devices
   show_qr_code = !disable_lcd
 
-  # Enabling BLE on 917 SoC by default
-  sl_matter_enable_siwx_ble = use_SiWx917
+  # Enabling BLE on 917 when use_host_ble is false
+  sl_matter_enable_siwx_ble = use_SiWx917 && !use_host_ble
 }
 
 # TODO - This needs to be removed once multiplexing issues resolved

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -56,9 +56,6 @@ declare_args() {
   # Disable AWS SDK OTA by default
   aws_sdk_ota = false
 
-  # Use BLE host on EFR32; false = BLE on NCP/SiWx
-  use_host_ble = false
-
   # Temperature Sensor support
   sl_enable_si70xx_sensor = false
 
@@ -73,8 +70,9 @@ declare_args() {
   # Enables LCD Qr Code on supported devices
   show_qr_code = !disable_lcd
 
-  # Enabling BLE on 917 when use_host_ble is false
-  sl_matter_enable_siwx_ble = use_SiWx917 && !use_host_ble
+  # Enable BLE on SiWx917 (NCP or WiFi SoC).
+  # Set true when building SiWx917 as main SoC or when BLE should run on the NCP.
+  sl_matter_enable_siwx_ble = use_SiWx917
 }
 
 # TODO - This needs to be removed once multiplexing issues resolved


### PR DESCRIPTION
#### Summary

This Platform changes are done to provide option to enable host-side BLE on EFR32  and disable SiWx917 BLE

Changes
1. third_party/silabs/silabs_board.gni
New build arg use_host_ble (default false): when true, BLE runs on the EFR32 host (e.g. 917 NCP host BLE).
So BLE is either on the host (EFR32) or on NCP/SiWx, not both.

2. src/platform/silabs/efr32/BLEManagerImpl.cpp
Init flag handling: In _Init(), kSiLabsBLEStackInitialize is read before clearing flags and restored afterward so a boot event that sets it before _Init() (e.g. from HandleBootEvent) is not lost.

3. src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
Conditional BLE on SiWx: All SiWx BLE/coex and BT feature config is guarded by SLI_SI91X_ENABLE_BLE.


#### Related issues


#### Testing

Build the code , and did successful BLE commissioning using chip-tool.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes BLE/Wi‑Fi coex initialization and build-time feature selection across EFR32 and SiWx917; misconfiguration could impact commissioning/advertising or radio coexistence on affected boards.
> 
> **Overview**
> Adds a new GN build arg `use_host_ble` to choose whether BLE runs on the EFR32 host vs the SiWx917/NCP, and updates `sl_matter_enable_siwx_ble` so SiWx BLE is disabled when host BLE is selected.
> 
> Fixes EFR32 BLE init flag handling by preserving `kSiLabsBLEStackInitialize` across `_Init()` flag clearing, avoiding losing a pre-init boot event.
> 
> Updates SiWx Wi-Fi device configuration to **conditionally** enable BLE/WLAN coexistence and BLE/BT feature bitmaps only when `SLI_SI91X_ENABLE_BLE` is set; otherwise BLE-related fields are set to `0` and WLAN-only mode is used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7c805e45f15bff01f6690b6ccd9f6363d152a71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->