### PR TITLE
[SL-ONLY] Resync the zb datamodel after a zll_factory_new

### DIFF
--- a/examples/platform/silabs/cmp/ZigbeeCallbacks.cpp
+++ b/examples/platform/silabs/cmp/ZigbeeCallbacks.cpp
@@ -42,6 +42,7 @@
 #include "AppConfig.h"
 #include "sl_cmp_config.h"
 
+#include "MultiProtocolDataModelHelper.h"
 #include "ZigbeeCallbacks.h"
 
 #if SL_MATTER_CMP_SECURE_ZIGBEE
@@ -303,3 +304,13 @@ extern "C" void zb_ble_dmp_print_ble_connections(void)
     (void) index;
 }
 #endif
+
+extern "C" void sl_zigbee_af_zll_commissioning_common_reset_to_factory_new_cb(void)
+{
+#ifdef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
+#if defined(GENERATED_MULTI_PROTOCOL_ATTRIBUTE_MAPPING) && defined(SL_CATALOG_MULTIPROTOCOL_ZIGBEE_MATTER_COMMON_PRESENT)
+    // need to resync matter datamodel to zb data model
+    MultiProtocolDataModel::Initialize();
+#endif // defined(GENERATED_MULTI_PROTOCOL_ATTRIBUTE_MAPPING) && defined(SL_CATALOG_MULTIPROTOCOL_ZIGBEE_MATTER_COMMON_PRESENT)
+#endif // SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
+}


### PR DESCRIPTION
This is a Cherry-pick of  #885

#### Summary
To do execute a touchlink setup between the Zigbee light and switch, Zigbee needs to put the device in factory new state without a reboot. This doesn't affect the Matter DM. 

We want to preserve the state of the light so we need to resync the Matter DM to the ZB DM after its factory new call.

ZB has a callback for the factory new (sl_zigbee_af_zll_commissioning_common_reset_to_factory_new_cb)
where we can call our datamodel sync.


#### Related issues
fixes MATTER-6160

#### Testing
Commission CMP light with ZB switch. Toggle light on. 
with cli call:
`plugin zll-commissioning reset` (on switch and light)
start touchlink setup
`plugin zll-commissioning link` (on switch)
Read the light OnOff state. Validate its still reads ON.
