### PR TITLE
[SL-TEMP] Updating the BLE Manager with the new TA update

### DIFF
--- a/src/platform/silabs/SiWx/ble/BLEManagerImpl.cpp
+++ b/src/platform/silabs/SiWx/ble/BLEManagerImpl.cpp
@@ -134,12 +134,11 @@ void rsi_ble_add_matter_service(void)
         new_serv_resp.serv_handler, new_serv_resp.start_handle + RSI_BLE_CHARACTERISTIC_RX_VALUE_HANDLE_LOCATION,
         custom_characteristic_RX,
         RSI_BLE_ATT_PROPERTY_WRITE | RSI_BLE_ATT_PROPERTY_READ, // Set read, write, write without response
-        data,
-        sizeof(data),
+        data, sizeof(data),
 #if (SL_MATTER_GN_BUILD == 0)
-            ATT_REC_MAINTAIN_IN_HOST
+        ATT_REC_MAINTAIN_IN_HOST
 #else
-            ATT_REC_IN_HOST
+        ATT_REC_IN_HOST
 #endif // (SL_MATTER_GN_BUILD == 0)
     );
 
@@ -937,8 +936,8 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(const SilabsBleWrapper::sl_wfx_msg_t 
         {
             ChipLogError(DeviceLayer, "Failed to set local CCCD att value: 0x%lx", static_cast<unsigned long>(status));
         }
-#endif  // (SL_MATTER_GN_BUILD == 0)
-        // If indications are not already enabled for the connection...
+#endif // (SL_MATTER_GN_BUILD == 0)
+       // If indications are not already enabled for the connection...
         if (!bleConnState->subscribed)
         {
             bleConnState->subscribed = 1;

--- a/src/platform/silabs/SiWx/ble/BLEManagerImpl.cpp
+++ b/src/platform/silabs/SiWx/ble/BLEManagerImpl.cpp
@@ -134,7 +134,14 @@ void rsi_ble_add_matter_service(void)
         new_serv_resp.serv_handler, new_serv_resp.start_handle + RSI_BLE_CHARACTERISTIC_RX_VALUE_HANDLE_LOCATION,
         custom_characteristic_RX,
         RSI_BLE_ATT_PROPERTY_WRITE | RSI_BLE_ATT_PROPERTY_READ, // Set read, write, write without response
-        data, sizeof(data), ATT_REC_IN_HOST);
+        data,
+        sizeof(data),
+#if (SL_MATTER_GN_BUILD == 0)
+            ATT_REC_MAINTAIN_IN_HOST
+#else
+            ATT_REC_IN_HOST
+#endif // (SL_MATTER_GN_BUILD == 0)
+    );
 
     constexpr uuid_t custom_characteristic_TX = { .size     = RSI_BLE_CUSTOM_CHARACTERISTIC_TX_SIZE,
                                                   .reserved = { RSI_BLE_CUSTOM_CHARACTERISTIC_TX_RESERVED },
@@ -886,6 +893,16 @@ void BLEManagerImpl::HandleWriteEvent(const SilabsBleWrapper::sl_wfx_msg_t & evt
     }
     else
     {
+#if (SL_MATTER_GN_BUILD == 0)
+        if (evt.rsi_ble_write.pkt_type == RSI_BLE_WRITE_REQUEST_EVENT)
+        {
+            int32_t status = rsi_ble_gatt_write_response(const_cast<uint8_t *>(evt.rsi_ble_write.dev_addr), 0);
+            if (status != RSI_SUCCESS)
+            {
+                ChipLogError(DeviceLayer, "Failed to send GATT write response: 0x%lx", static_cast<unsigned long>(status));
+            }
+        }
+#endif // (SL_MATTER_GN_BUILD == 0)
         HandleRXCharWrite(evt);
     }
 }
@@ -910,6 +927,17 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(const SilabsBleWrapper::sl_wfx_msg_t 
 
     if (isIndicationEnabled)
     {
+#if (SL_MATTER_GN_BUILD == 0)
+        // Update the CCCD value in the TA firmware so it allows indications/notifications.
+        // With the new TA firmware, the TA no longer auto-updates TA-maintained
+        // attribute values on writes the host must explicitly sync the CCCD state
+        uint8_t cccd_val[2] = { static_cast<uint8_t>(evt.rsi_ble_write.att_value[0] | 0x02), 0x00 };
+        int32_t status      = rsi_ble_set_local_att_value(rsi_ble_gatt_server_client_config_hndl, sizeof(cccd_val), cccd_val);
+        if (status != RSI_SUCCESS)
+        {
+            ChipLogError(DeviceLayer, "Failed to set local CCCD att value: 0x%lx", static_cast<unsigned long>(status));
+        }
+#endif  // (SL_MATTER_GN_BUILD == 0)
         // If indications are not already enabled for the connection...
         if (!bleConnState->subscribed)
         {


### PR DESCRIPTION
#### Summary
With the 4.1.0-ifc2, we saw the ble issues caused by the changes in TA firmware was done for Handling the BLE GATT characteristics properly depending upon the GATT records are HOST maintained or TA maintained.
Ticket: https://jira.silabs.com/browse/SI91X-20989

Making this SL-TEMP since it was breaking the backward capatibilty with the TA and BLE team said that it would be fixed in the IFC3, hence this would be reverted if fixed.

#### Related issues
NA

#### Testing
Tested commissioning locally with the IFC2 
