### PR TITLE
[SL-UP] Added migration function for Manufacturing Date.

### DIFF
--- a/src/platform/silabs/MigrationManager.cpp
+++ b/src/platform/silabs/MigrationManager.cpp
@@ -50,6 +50,7 @@ static migrationData_t migrationTable[] = {
     { .migrationGroup = 3, .migrationFunc = MigrateCounterConfigs },
     { .migrationGroup = 4, .migrationFunc = MigrateHardwareVersion },
     { .migrationGroup = 5, .migrationFunc = MigrateS3Certificates },
+    { .migrationGroup = 5, .migrationFunc = MigrateManufacturingDate },
     // add any additional migration neccesary. migrationGroup should stay equal if done in the same commit or increment by 1 for
     // each new entry.
 };
@@ -232,6 +233,23 @@ void MigrateS3Certificates()
         provision.GetStorage().SetCertificationDeclaration(cdBufferSpan);
     }
 #endif //_SILICON_LABS_32B_SERIES_3
+}
+
+void MigrateManufacturingDate()
+{
+    constexpr size_t kOldDateLen = 10; // yyyy-mm-dd
+    constexpr size_t kNewDateLen = 8;  // yyyymmdd
+    char temp[kOldDateLen + 1];
+    size_t outLen = 0;
+
+    CHIP_ERROR err = SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_ManufacturingDate, temp, sizeof(temp), outLen);
+    if ((CHIP_NO_ERROR == err) && (kOldDateLen == outLen) && ('-' == temp[4]) && ('-' == temp[7]))
+    {
+        char compact[kNewDateLen + 1] = { 0 };
+        snprintf(compact, sizeof(compact), "%.4s%.2s%.2s", temp, temp + 5, temp + 8);
+        TEMPORARY_RETURN_IGNORED SilabsConfig::WriteConfigValueStr(SilabsConfig::kConfigKey_ManufacturingDate, compact,
+                                                                   kNewDateLen);
+    }
 }
 
 } // namespace Silabs

--- a/src/platform/silabs/MigrationManager.h
+++ b/src/platform/silabs/MigrationManager.h
@@ -48,6 +48,7 @@ void MigrateDacProvider(void);
 void MigrateCounterConfigs(void);
 void MigrateHardwareVersion(void);
 void MigrateS3Certificates(void);
+void MigrateManufacturingDate(void);
 
 } // namespace Silabs
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Summary

If manufacturing date has the wrong format, the device fails on startup. Old devices used the wrong format yyyy-mm-dd, so the new parser fails in those cases.

Since EFR32 use ProvisionStorageDefault, but 917 use ProvisionStorageFlash, migration from the new format to the new format should be made in the common ProvisionStorage.cpp.

THIS CHANGE HAS NO EFFECT ON SI917.

#### Related issues

[MATTER-6255](https://jira.silabs.com/browse/MATTER-6255)

#### Testing

Old format provisioned
After first boot, the date was read back from NVM3, verifying the new format
Tested on EFR32 (successful) and Si917 (no effect).

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
