### PR TITLE
[SL-ONLY] Buffering the packets until device is connected

### DIFF
--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -50,6 +50,10 @@ buildconfig_header("inet_buildconfig") {
     "INET_CONFIG_ENABLE_TCP_ENDPOINT=${chip_inet_config_enable_tcp_endpoint}",
     "INET_CONFIG_ENABLE_UDP_ENDPOINT=${chip_inet_config_enable_udp_endpoint}",
     "HAVE_LWIP_RAW_BIND_NETIF=true",
+
+    # [SL-ONLY] Queuing the UDP packets for till the netif is not up
+    "SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY=${silabs_inet_config_udp_lwip_queue_until_netif_ready}",
+    "SILABS_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE=${silabs_inet_config_udp_lwip_deferred_send_queue_size}",
   ]
 
   if (chip_inet_project_config_include != "") {

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -51,7 +51,7 @@ buildconfig_header("inet_buildconfig") {
     "INET_CONFIG_ENABLE_UDP_ENDPOINT=${chip_inet_config_enable_udp_endpoint}",
     "HAVE_LWIP_RAW_BIND_NETIF=true",
 
-    # [SL-ONLY] Queuing the UDP packets for till the netif is not up
+    # [SL-ONLY] Queuing the UDP packets for until the netif is up
     "SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY=${silabs_inet_config_udp_lwip_queue_until_netif_ready}",
     "SILABS_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE=${silabs_inet_config_udp_lwip_deferred_send_queue_size}",
   ]

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -193,6 +193,12 @@ static_library("inet") {
 
     if (!chip_system_config_use_network_framework) {
       sources += [ "UDPEndPointImpl${chip_system_config_inet}.cpp" ]
+      if (chip_system_config_inet == "LwIP") {
+        sources += [
+          "DeferredUdpSendQueueLwIP.cpp",
+          "DeferredUdpSendQueueLwIP.h",
+        ]
+      }
     }
   }
 

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -52,8 +52,8 @@ buildconfig_header("inet_buildconfig") {
     "HAVE_LWIP_RAW_BIND_NETIF=true",
 
     # [SL-ONLY] Queuing the UDP packets for until the netif is up
-    "SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY=${silabs_inet_config_udp_lwip_queue_until_netif_ready}",
-    "SILABS_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE=${silabs_inet_config_udp_lwip_deferred_send_queue_size}",
+    "SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY=${sl_inet_config_udp_lwip_queue_until_netif_ready}",
+    "SL_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE=${sl_inet_config_udp_lwip_deferred_send_queue_size}",
   ]
 
   if (chip_inet_project_config_include != "") {

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -187,6 +187,7 @@ static_library("inet") {
     #  - UDPEndPointImplSockets.cpp
     #  - UDPEndPointImplSockets.h
     sources += [
+      "DeferredUdpSendRing.h",
       "BasicPacketFilters.h",
       "EndpointQueueFilter.h",
       "UDPEndPoint.cpp",

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -187,8 +187,8 @@ static_library("inet") {
     #  - UDPEndPointImplSockets.cpp
     #  - UDPEndPointImplSockets.h
     sources += [
-      "DeferredUdpSendRing.h",
       "BasicPacketFilters.h",
+      "DeferredUdpSendRing.h",
       "EndpointQueueFilter.h",
       "UDPEndPoint.cpp",
       "UDPEndPoint.h",

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -198,7 +198,7 @@ static_library("inet") {
 
     if (!chip_system_config_use_network_framework) {
       sources += [ "UDPEndPointImpl${chip_system_config_inet}.cpp" ]
-      if (chip_system_config_inet == "LwIP") {
+      if (sl_inet_config_udp_lwip_queue_until_netif_ready) {
         sources += [
           "DeferredUdpSendQueueLwIP.cpp",
           "DeferredUdpSendQueueLwIP.h",

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -51,7 +51,7 @@ buildconfig_header("inet_buildconfig") {
     "INET_CONFIG_ENABLE_UDP_ENDPOINT=${chip_inet_config_enable_udp_endpoint}",
     "HAVE_LWIP_RAW_BIND_NETIF=true",
 
-    # [SL-ONLY] Queuing the UDP packets for until the netif is up
+    # [SL-ONLY] Queuing the UDP packets until the netif is up
     "SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY=${sl_inet_config_udp_lwip_queue_until_netif_ready}",
     "SL_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE=${sl_inet_config_udp_lwip_deferred_send_queue_size}",
   ]

--- a/src/inet/DeferredUdpSendQueueLwIP.cpp
+++ b/src/inet/DeferredUdpSendQueueLwIP.cpp
@@ -19,6 +19,7 @@
 
 #if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
+#include <inet/DeferredUdpSendRing.h>
 #include <inet/EndPointStateLwIP.h>
 #include <inet/IPAddress.h>
 #include <inet/IPPacketInfo.h>
@@ -26,7 +27,6 @@
 #include <inet/UDPEndPointImplLwIP.h>
 
 #include <lib/support/CodeUtils.h>
-#include <lib/support/FixedBuffer.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #include <lwip/err.h>
@@ -56,48 +56,7 @@ struct DeferredUdpSlot
     System::PacketBufferHandle msg;
 };
 
-struct DeferredUdpRing
-{
-    chip::FixedBuffer<DeferredUdpSlot, kDeferredQueueCapacity> slots{};
-    size_t head  = 0;
-    size_t count = 0;
-
-    bool Empty() const { return count == 0; }
-
-    void PushBack(DeferredUdpSlot && slot)
-    {
-        if (count == kDeferredQueueCapacity)
-        {
-            ChipLogDetail(Inet, "Deferred UDP queue full: dropping head");
-            slots[head] = DeferredUdpSlot{};
-            head        = (head + 1) % kDeferredQueueCapacity;
-            --count;
-        }
-        const size_t idx = (head + count) % kDeferredQueueCapacity;
-        slots[idx]       = std::move(slot);
-        ++count;
-    }
-
-    DeferredUdpSlot PopFront()
-    {
-        DeferredUdpSlot out = std::move(slots[head]);
-        slots[head]         = DeferredUdpSlot{};
-        head                = (head + 1) % kDeferredQueueCapacity;
-        --count;
-        return out;
-    }
-};
-
-/** Swap ring state (head, count) and per-slot storage without copying whole FixedBuffer (avoids copy-only path). */
-void SwapDeferredRings(DeferredUdpRing & a, DeferredUdpRing & b)
-{
-    std::swap(a.head, b.head);
-    std::swap(a.count, b.count);
-    for (size_t i = 0; i < kDeferredQueueCapacity; ++i)
-    {
-        std::swap(a.slots[i], b.slots[i]);
-    }
-}
+using DeferredUdpRing = DeferredUdpSendRing<DeferredUdpSlot, kDeferredQueueCapacity>;
 
 DeferredUdpRing gDeferredRing;
 
@@ -184,7 +143,10 @@ CHIP_ERROR DeferredUdpSendQueueLwIP::Enqueue(UDPEndPointImplLwIP * self, const I
     slot.msg      = std::move(msg);
 
     ChipLogDetail(Inet, "UDP send deferred (waiting for netif)");
-
+    if (gDeferredRing.IsFull())
+    {
+        ChipLogDetail(Inet, "Deferred UDP queue full: dropping head");
+    }
     gDeferredRing.PushBack(std::move(slot));
     return CHIP_NO_ERROR;
 }
@@ -192,7 +154,7 @@ CHIP_ERROR DeferredUdpSendQueueLwIP::Enqueue(UDPEndPointImplLwIP * self, const I
 void DeferredUdpSendQueueLwIP::PurgeForEndpoint(UDPEndPointImplLwIP * self)
 {
     UDPEndPoint * asBase = static_cast<UDPEndPoint *>(self);
-    const size_t n       = gDeferredRing.count;
+    const size_t n       = gDeferredRing.ActiveCount();
     for (size_t i = 0; i < n; ++i)
     {
         DeferredUdpSlot slot = gDeferredRing.PopFront();
@@ -209,7 +171,7 @@ void DeferredUdpSendQueueLwIP::Flush()
     assertChipStackLockedByCurrentThread();
 
     DeferredUdpRing pending{};
-    SwapDeferredRings(gDeferredRing, pending);
+    SwapDeferredUdpSendRings(gDeferredRing, pending);
 
     while (!pending.Empty())
     {

--- a/src/inet/DeferredUdpSendQueueLwIP.cpp
+++ b/src/inet/DeferredUdpSendQueueLwIP.cpp
@@ -111,7 +111,6 @@ bool IsNetifUsable(struct netif * netif)
     return netif != nullptr && netif_is_up(netif) && netif_is_link_up(netif);
 }
 
-#if LWIP_IPV6
 bool NetifHasValidIpv6Address(struct netif * netif)
 {
     VerifyOrReturnValue(netif != nullptr, false);
@@ -124,22 +123,14 @@ bool NetifHasValidIpv6Address(struct netif * netif)
     }
     return false;
 }
-#endif
 
 bool IsNetifReadyForOutboundUdp(struct netif * netif, const IPAddress & dest)
 {
     VerifyOrReturnValue(IsNetifUsable(netif), false);
-#if LWIP_IPV6
     if (dest.IsIPv6())
     {
         return NetifHasValidIpv6Address(netif);
     }
-#else
-    if (dest.IsIPv6())
-    {
-        return false;
-    }
-#endif
 #if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
     if (dest.IsIPv4())
     {

--- a/src/inet/DeferredUdpSendQueueLwIP.cpp
+++ b/src/inet/DeferredUdpSendQueueLwIP.cpp
@@ -1,0 +1,267 @@
+/*
+ *
+ *    Copyright (c) 2020-2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <inet/DeferredUdpSendQueueLwIP.h>
+
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+
+#include <inet/EndPointStateLwIP.h>
+#include <inet/IPAddress.h>
+#include <inet/IPPacketInfo.h>
+#include <inet/UDPEndPoint.h>
+#include <inet/UDPEndPointImplLwIP.h>
+
+#include <lib/support/CodeUtils.h>
+#include <lib/support/FixedBuffer.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+#include <lwip/err.h>
+#include <lwip/ip.h>
+#include <lwip/netif.h>
+
+#include <platform/LockTracker.h>
+
+#include <utility>
+
+namespace chip {
+namespace Inet {
+
+namespace {
+
+#ifndef NETIF_FOREACH
+#define NETIF_FOREACH(netif) for ((netif) = netif_list; (netif) != nullptr; (netif) = (netif)->next)
+#endif
+
+constexpr size_t kDeferredQueueCapacity = INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE;
+static_assert(kDeferredQueueCapacity > 0, "INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE must be > 0");
+
+struct DeferredUdpSlot
+{
+    UDPEndPointHandle epHandle;
+    IPPacketInfo pktInfo;
+    System::PacketBufferHandle msg;
+};
+
+struct DeferredUdpRing
+{
+    chip::FixedBuffer<DeferredUdpSlot, kDeferredQueueCapacity> slots{};
+    size_t head  = 0;
+    size_t count = 0;
+
+    bool Empty() const { return count == 0; }
+
+    void PushBack(DeferredUdpSlot && slot)
+    {
+        if (count == kDeferredQueueCapacity)
+        {
+            const DeferredUdpSlot & dropped = slots[head];
+            char dropDest[IPAddress::kMaxStringLength];
+            dropped.pktInfo.DestAddress.ToString(dropDest);
+            ChipLogProgress(Inet, "Deferred UDP queue full: dropping head dest %s port %u len %u", dropDest, dropped.pktInfo.DestPort,
+                            static_cast<unsigned>(dropped.msg->TotalLength()));
+            slots[head] = DeferredUdpSlot{};
+            head        = (head + 1) % kDeferredQueueCapacity;
+            --count;
+        }
+        const size_t idx = (head + count) % kDeferredQueueCapacity;
+        slots[idx]       = std::move(slot);
+        ++count;
+    }
+
+    DeferredUdpSlot PopFront()
+    {
+        DeferredUdpSlot out = std::move(slots[head]);
+        slots[head]         = DeferredUdpSlot{};
+        head                = (head + 1) % kDeferredQueueCapacity;
+        --count;
+        return out;
+    }
+};
+
+/** Swap ring state (head, count) and per-slot storage without copying whole FixedBuffer (avoids copy-only path). */
+void SwapDeferredRings(DeferredUdpRing & a, DeferredUdpRing & b)
+{
+    using std::swap;
+    swap(a.head, b.head);
+    swap(a.count, b.count);
+    for (size_t i = 0; i < kDeferredQueueCapacity; ++i)
+    {
+        swap(a.slots[i], b.slots[i]);
+    }
+}
+
+DeferredUdpRing gDeferredRing;
+
+bool IsNetifUsable(struct netif * netif)
+{
+    return netif != nullptr && netif_is_up(netif) && netif_is_link_up(netif);
+}
+
+#if LWIP_IPV6
+bool NetifHasValidIpv6Address(struct netif * netif)
+{
+    VerifyOrReturnValue(netif != nullptr, false);
+    for (u8_t idx = 0; idx < LWIP_IPV6_NUM_ADDRESSES; ++idx)
+    {
+        if (ip6_addr_ispreferred(netif_ip6_addr_state(netif, idx)))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+#endif
+
+bool IsNetifReadyForOutboundUdp(struct netif * netif, const IPAddress & dest)
+{
+    VerifyOrReturnValue(IsNetifUsable(netif), false);
+#if LWIP_IPV6
+    if (dest.IsIPv6())
+    {
+        return NetifHasValidIpv6Address(netif);
+    }
+#else
+    if (dest.IsIPv6())
+    {
+        return false;
+    }
+#endif
+#if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
+    if (dest.IsIPv4())
+    {
+        return !ip4_addr_isany(netif_ip4_addr(netif));
+    }
+#endif
+    return false;
+}
+
+bool IsOutboundNetifReadyForUdp(const IPPacketInfo & pktInfo)
+{
+    const InterfaceId & intfId  = pktInfo.Interface;
+    const IPAddress & dest     = pktInfo.DestAddress;
+
+    if (intfId.IsPresent())
+    {
+        return IsNetifReadyForOutboundUdp(intfId.GetPlatformInterface(), dest);
+    }
+
+    if (IsNetifReadyForOutboundUdp(netif_default, dest))
+    {
+        return true;
+    }
+
+    struct netif * netif = nullptr;
+    NETIF_FOREACH(netif)
+    {
+        if (IsNetifReadyForOutboundUdp(netif, dest))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+} // namespace
+
+CHIP_ERROR DeferredUdpSendQueueLwIP::ProbeDefer(const IPPacketInfo & pktInfo, bool & outShouldDefer)
+{
+    outShouldDefer  = false;
+    err_t probeErr = EndPointStateLwIP::RunOnTCPIPRet([&]() -> err_t {
+        outShouldDefer = !IsOutboundNetifReadyForUdp(pktInfo);
+        return ERR_OK;
+    });
+    VerifyOrReturnError(probeErr == ERR_OK, chip::System::MapErrorLwIP(probeErr));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeferredUdpSendQueueLwIP::Enqueue(UDPEndPointImplLwIP * self, const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
+{
+    DeferredUdpSlot slot;
+    slot.epHandle = UDPEndPointHandle(static_cast<UDPEndPoint *>(self));
+    slot.pktInfo  = *pktInfo;
+    slot.msg      = std::move(msg);
+
+    char destStr[IPAddress::kMaxStringLength];
+    pktInfo->DestAddress.ToString(destStr);
+    ChipLogProgress(Inet, "UDP send deferred (waiting for netif): dest %s port %u len %u", destStr, pktInfo->DestPort,
+                    static_cast<unsigned>(slot.msg->TotalLength()));
+
+    gDeferredRing.PushBack(std::move(slot));
+    return CHIP_NO_ERROR;
+}
+
+void DeferredUdpSendQueueLwIP::PurgeForEndpoint(UDPEndPointImplLwIP * self)
+{
+    UDPEndPoint * asBase = static_cast<UDPEndPoint *>(self);
+    const size_t n       = gDeferredRing.count;
+    for (size_t i = 0; i < n; ++i)
+    {
+        DeferredUdpSlot slot = gDeferredRing.PopFront();
+        if (!slot.epHandle.IsNull() && slot.epHandle == *asBase)
+        {
+            continue;
+        }
+        gDeferredRing.PushBack(std::move(slot));
+    }
+}
+
+void DeferredUdpSendQueueLwIP::Flush()
+{
+    assertChipStackLockedByCurrentThread();
+
+    DeferredUdpRing pending{};
+    SwapDeferredRings(gDeferredRing, pending);
+
+    while (!pending.Empty())
+    {
+        DeferredUdpSlot slot = pending.PopFront();
+
+        bool ready     = false;
+        err_t probeErr = EndPointStateLwIP::RunOnTCPIPRet([&]() -> err_t {
+            ready = IsOutboundNetifReadyForUdp(slot.pktInfo);
+            return ERR_OK;
+        });
+        if (probeErr != ERR_OK)
+        {
+            ChipLogError(Inet, "DeferredUdpSendQueueLwIP::Flush: RunOnTCPIPRet failed: %d", static_cast<int>(probeErr));
+            gDeferredRing.PushBack(std::move(slot));
+            while (!pending.Empty())
+            {
+                gDeferredRing.PushBack(pending.PopFront());
+            }
+            return;
+        }
+
+        if (!ready)
+        {
+            gDeferredRing.PushBack(std::move(slot));
+            continue;
+        }
+
+        if (!slot.epHandle.IsNull())
+        {
+            auto * impl = static_cast<UDPEndPointImplLwIP *>(slot.epHandle.operator->());
+            (void) impl->FlushOneDeferred(&slot.pktInfo, std::move(slot.msg));
+        }
+    }
+}
+
+} // namespace Inet
+} // namespace chip
+
+#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY

--- a/src/inet/DeferredUdpSendQueueLwIP.cpp
+++ b/src/inet/DeferredUdpSendQueueLwIP.cpp
@@ -68,11 +68,7 @@ struct DeferredUdpRing
     {
         if (count == kDeferredQueueCapacity)
         {
-            const DeferredUdpSlot & dropped = slots[head];
-            char dropDest[IPAddress::kMaxStringLength];
-            dropped.pktInfo.DestAddress.ToString(dropDest);
-            ChipLogProgress(Inet, "Deferred UDP queue full: dropping head dest %s port %u len %u", dropDest,
-                            dropped.pktInfo.DestPort, static_cast<unsigned>(dropped.msg->TotalLength()));
+            ChipLogDetail(Inet, "Deferred UDP queue full: dropping head");
             slots[head] = DeferredUdpSlot{};
             head        = (head + 1) % kDeferredQueueCapacity;
             --count;
@@ -111,7 +107,7 @@ bool IsNetifUsable(struct netif * netif)
     return netif != nullptr && netif_is_up(netif) && netif_is_link_up(netif);
 }
 
-bool NetifHasValidIpv6Address(struct netif * netif)
+bool NetifHasPreferredIpv6Address(struct netif * netif)
 {
     VerifyOrReturnValue(netif != nullptr, false);
     for (u8_t idx = 0; idx < LWIP_IPV6_NUM_ADDRESSES; ++idx)
@@ -129,7 +125,7 @@ bool IsNetifReadyForOutboundUdp(struct netif * netif, const IPAddress & dest)
     VerifyOrReturnValue(IsNetifUsable(netif), false);
     if (dest.IsIPv6())
     {
-        return NetifHasValidIpv6Address(netif);
+        return NetifHasPreferredIpv6Address(netif);
     }
 #if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
     if (dest.IsIPv4())
@@ -188,10 +184,7 @@ CHIP_ERROR DeferredUdpSendQueueLwIP::Enqueue(UDPEndPointImplLwIP * self, const I
     slot.pktInfo  = *pktInfo;
     slot.msg      = std::move(msg);
 
-    char destStr[IPAddress::kMaxStringLength];
-    pktInfo->DestAddress.ToString(destStr);
-    ChipLogProgress(Inet, "UDP send deferred (waiting for netif): dest %s port %u len %u", destStr, pktInfo->DestPort,
-                    static_cast<unsigned>(slot.msg->TotalLength()));
+    ChipLogDetail(Inet, "UDP send deferred (waiting for netif)");
 
     gDeferredRing.PushBack(std::move(slot));
     return CHIP_NO_ERROR;

--- a/src/inet/DeferredUdpSendQueueLwIP.cpp
+++ b/src/inet/DeferredUdpSendQueueLwIP.cpp
@@ -177,6 +177,9 @@ void DeferredUdpSendQueueLwIP::Flush()
     {
         DeferredUdpSlot slot = pending.PopFront();
 
+        // Probe each deferred slot independently. A prior ProbeDefer in SendMsgImpl only covered
+        // the current outgoing pktInfo, while pending entries may target other interfaces/routes.
+        // Also, link/address state can legitimately change between calls.
         bool ready     = false;
         err_t probeErr = EndPointStateLwIP::RunOnTCPIPRet([&]() -> err_t {
             ready = IsOutboundNetifReadyForUdp(slot.pktInfo);

--- a/src/inet/DeferredUdpSendQueueLwIP.cpp
+++ b/src/inet/DeferredUdpSendQueueLwIP.cpp
@@ -127,12 +127,12 @@ bool IsNetifReadyForOutboundUdp(struct netif * netif, const IPAddress & dest)
     {
         return NetifHasPreferredIpv6Address(netif);
     }
-#if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
+#if INET_CONFIG_ENABLE_IPV4
     if (dest.IsIPv4())
     {
         return !ip4_addr_isany(netif_ip4_addr(netif));
     }
-#endif
+#endif // INET_CONFIG_ENABLE_IPV4
     return false;
 }
 

--- a/src/inet/DeferredUdpSendQueueLwIP.cpp
+++ b/src/inet/DeferredUdpSendQueueLwIP.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2025 Project CHIP Authors
+ *    Copyright (c) 2020-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/inet/DeferredUdpSendQueueLwIP.cpp
+++ b/src/inet/DeferredUdpSendQueueLwIP.cpp
@@ -17,7 +17,7 @@
 
 #include <inet/DeferredUdpSendQueueLwIP.h>
 
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
 #include <inet/EndPointStateLwIP.h>
 #include <inet/IPAddress.h>
@@ -46,8 +46,8 @@ namespace {
 #define NETIF_FOREACH(netif) for ((netif) = netif_list; (netif) != nullptr; (netif) = (netif)->next)
 #endif
 
-constexpr size_t kDeferredQueueCapacity = INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE;
-static_assert(kDeferredQueueCapacity > 0, "INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE must be > 0");
+constexpr size_t kDeferredQueueCapacity = SILABS_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE;
+static_assert(kDeferredQueueCapacity > 0, "SILABS_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE must be > 0");
 
 struct DeferredUdpSlot
 {
@@ -249,4 +249,4 @@ void DeferredUdpSendQueueLwIP::Flush()
 } // namespace Inet
 } // namespace chip
 
-#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#endif // SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY

--- a/src/inet/DeferredUdpSendQueueLwIP.cpp
+++ b/src/inet/DeferredUdpSendQueueLwIP.cpp
@@ -71,8 +71,8 @@ struct DeferredUdpRing
             const DeferredUdpSlot & dropped = slots[head];
             char dropDest[IPAddress::kMaxStringLength];
             dropped.pktInfo.DestAddress.ToString(dropDest);
-            ChipLogProgress(Inet, "Deferred UDP queue full: dropping head dest %s port %u len %u", dropDest, dropped.pktInfo.DestPort,
-                            static_cast<unsigned>(dropped.msg->TotalLength()));
+            ChipLogProgress(Inet, "Deferred UDP queue full: dropping head dest %s port %u len %u", dropDest,
+                            dropped.pktInfo.DestPort, static_cast<unsigned>(dropped.msg->TotalLength()));
             slots[head] = DeferredUdpSlot{};
             head        = (head + 1) % kDeferredQueueCapacity;
             --count;
@@ -151,7 +151,7 @@ bool IsNetifReadyForOutboundUdp(struct netif * netif, const IPAddress & dest)
 
 bool IsOutboundNetifReadyForUdp(const IPPacketInfo & pktInfo)
 {
-    const InterfaceId & intfId  = pktInfo.Interface;
+    const InterfaceId & intfId = pktInfo.Interface;
     const IPAddress & dest     = pktInfo.DestAddress;
 
     if (intfId.IsPresent())
@@ -180,7 +180,7 @@ bool IsOutboundNetifReadyForUdp(const IPPacketInfo & pktInfo)
 
 CHIP_ERROR DeferredUdpSendQueueLwIP::ProbeDefer(const IPPacketInfo & pktInfo, bool & outShouldDefer)
 {
-    outShouldDefer  = false;
+    outShouldDefer = false;
     err_t probeErr = EndPointStateLwIP::RunOnTCPIPRet([&]() -> err_t {
         outShouldDefer = !IsOutboundNetifReadyForUdp(pktInfo);
         return ERR_OK;
@@ -189,7 +189,8 @@ CHIP_ERROR DeferredUdpSendQueueLwIP::ProbeDefer(const IPPacketInfo & pktInfo, bo
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DeferredUdpSendQueueLwIP::Enqueue(UDPEndPointImplLwIP * self, const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
+CHIP_ERROR DeferredUdpSendQueueLwIP::Enqueue(UDPEndPointImplLwIP * self, const IPPacketInfo * pktInfo,
+                                             System::PacketBufferHandle && msg)
 {
     DeferredUdpSlot slot;
     slot.epHandle = UDPEndPointHandle(static_cast<UDPEndPoint *>(self));

--- a/src/inet/DeferredUdpSendQueueLwIP.cpp
+++ b/src/inet/DeferredUdpSendQueueLwIP.cpp
@@ -17,7 +17,7 @@
 
 #include <inet/DeferredUdpSendQueueLwIP.h>
 
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
 #include <inet/EndPointStateLwIP.h>
 #include <inet/IPAddress.h>
@@ -46,8 +46,8 @@ namespace {
 #define NETIF_FOREACH(netif) for ((netif) = netif_list; (netif) != nullptr; (netif) = (netif)->next)
 #endif
 
-constexpr size_t kDeferredQueueCapacity = SILABS_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE;
-static_assert(kDeferredQueueCapacity > 0, "SILABS_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE must be > 0");
+constexpr size_t kDeferredQueueCapacity = SL_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE;
+static_assert(kDeferredQueueCapacity > 0, "SL_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE must be > 0");
 
 struct DeferredUdpSlot
 {
@@ -91,12 +91,11 @@ struct DeferredUdpRing
 /** Swap ring state (head, count) and per-slot storage without copying whole FixedBuffer (avoids copy-only path). */
 void SwapDeferredRings(DeferredUdpRing & a, DeferredUdpRing & b)
 {
-    using std::swap;
-    swap(a.head, b.head);
-    swap(a.count, b.count);
+    std::swap(a.head, b.head);
+    std::swap(a.count, b.count);
     for (size_t i = 0; i < kDeferredQueueCapacity; ++i)
     {
-        swap(a.slots[i], b.slots[i]);
+        std::swap(a.slots[i], b.slots[i]);
     }
 }
 
@@ -249,4 +248,4 @@ void DeferredUdpSendQueueLwIP::Flush()
 } // namespace Inet
 } // namespace chip
 
-#endif // SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#endif // SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY

--- a/src/inet/DeferredUdpSendQueueLwIP.h
+++ b/src/inet/DeferredUdpSendQueueLwIP.h
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2020-2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * Outbound UDP send deferral for LwIP (bounded FIFO, fixed storage).
+ * Keeps queue mechanics out of UDPEndPointImplLwIP.cpp.
+ */
+
+#pragma once
+
+#include <inet/InetConfig.h>
+
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+
+#include <lib/core/CHIPError.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace Inet {
+
+struct IPPacketInfo;
+class UDPEndPointImplLwIP;
+
+class DeferredUdpSendQueueLwIP
+{
+public:
+    /**
+     * If the netif is not ready for this destination, set outShouldDefer true so the send should be
+     * queued. Returns a mapped CHIP error if the TCPIP thread bridge fails.
+     */
+    static CHIP_ERROR ProbeDefer(const IPPacketInfo & pktInfo, bool & outShouldDefer);
+
+    static CHIP_ERROR Enqueue(UDPEndPointImplLwIP * self, const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg);
+
+    static void PurgeForEndpoint(UDPEndPointImplLwIP * self);
+
+    static void Flush();
+};
+
+} // namespace Inet
+} // namespace chip
+
+#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY

--- a/src/inet/DeferredUdpSendQueueLwIP.h
+++ b/src/inet/DeferredUdpSendQueueLwIP.h
@@ -24,7 +24,7 @@
 
 #include <inet/InetConfig.h>
 
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
 #include <lib/core/CHIPError.h>
 #include <system/SystemPacketBuffer.h>
@@ -54,4 +54,4 @@ public:
 } // namespace Inet
 } // namespace chip
 
-#endif // SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#endif // SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY

--- a/src/inet/DeferredUdpSendQueueLwIP.h
+++ b/src/inet/DeferredUdpSendQueueLwIP.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2025 Project CHIP Authors
+ *    Copyright (c) 2020-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/inet/DeferredUdpSendQueueLwIP.h
+++ b/src/inet/DeferredUdpSendQueueLwIP.h
@@ -24,7 +24,7 @@
 
 #include <inet/InetConfig.h>
 
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
 #include <lib/core/CHIPError.h>
 #include <system/SystemPacketBuffer.h>
@@ -54,4 +54,4 @@ public:
 } // namespace Inet
 } // namespace chip
 
-#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#endif // SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY

--- a/src/inet/DeferredUdpSendRing.h
+++ b/src/inet/DeferredUdpSendRing.h
@@ -1,0 +1,81 @@
+/*
+ *
+ *    Copyright (c) 2020-2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * Fixed-capacity FIFO ring used by DeferredUdpSendQueueLwIP. Header-only so
+ * queue mechanics can be covered by host unit tests without LwIP.
+ */
+
+#pragma once
+
+#include <lib/support/FixedBuffer.h>
+
+#include <cstddef>
+#include <utility>
+
+namespace chip {
+namespace Inet {
+
+template <typename Slot, size_t Capacity>
+struct DeferredUdpSendRing
+{
+    static_assert(Capacity > 0, "DeferredUdpSendRing capacity must be > 0");
+
+    chip::FixedBuffer<Slot, Capacity> slots{};
+    size_t head  = 0;
+    size_t count = 0;
+
+    bool Empty() const { return count == 0; }
+    bool IsFull() const { return count == Capacity; }
+    size_t ActiveCount() const { return count; }
+
+    void PushBack(Slot && slot)
+    {
+        if (count == Capacity)
+        {
+            slots[head] = Slot{};
+            head        = (head + 1) % Capacity;
+            --count;
+        }
+        const size_t idx = (head + count) % Capacity;
+        slots[idx]       = std::move(slot);
+        ++count;
+    }
+
+    Slot PopFront()
+    {
+        Slot out = std::move(slots[head]);
+        slots[head] = Slot{};
+        head        = (head + 1) % Capacity;
+        --count;
+        return out;
+    }
+};
+
+template <typename Slot, size_t Capacity>
+void SwapDeferredUdpSendRings(DeferredUdpSendRing<Slot, Capacity> & a, DeferredUdpSendRing<Slot, Capacity> & b)
+{
+    std::swap(a.head, b.head);
+    std::swap(a.count, b.count);
+    for (size_t i = 0; i < Capacity; ++i)
+    {
+        std::swap(a.slots[i], b.slots[i]);
+    }
+}
+
+} // namespace Inet
+} // namespace chip

--- a/src/inet/DeferredUdpSendRing.h
+++ b/src/inet/DeferredUdpSendRing.h
@@ -16,8 +16,28 @@
  */
 
 /**
- * Fixed-capacity FIFO ring used by DeferredUdpSendQueueLwIP. Header-only so
- * queue mechanics can be covered by host unit tests without LwIP.
+ * Bounded FIFO queue with fixed-capacity storage indexed in a circle.
+ *
+ * This is one data structure, not two: logical behavior is a queue (enqueue at
+ * the back, dequeue from the front). `head` and `count` map that queue onto a
+ * fixed `FixedBuffer` by wrapping indices modulo `Capacity`, which is the
+ * usual ring-buffer indexing trick for a fixed array.
+ *
+ * `PushBack` / `PopFront` are the standard names for enqueue/dequeue at the
+ * two ends of that FIFO. A low-level ring API might expose only head/tail
+ * indices; here we expose the queue operations callers need.
+ *
+ * After `PopFront`, the vacated cell is assigned `Slot{}` so the slot in the
+ * array is empty until reused. That is optional for some `Slot` types once
+ * moved-from, but it keeps array cells in a known state and matches types whose
+ * moved-from state still holds resources until reassigned or destroyed.
+ *
+ * `PopFront` returns `Slot` by value: the returned object is constructed from
+ * the slot contents (move), then returned to the caller (NRVO or move). It is
+ * not a reference into ring storage; the caller owns the returned `Slot`.
+ *
+ * Storage mechanics are in this header so host unit tests can cover them
+ * without LwIP.
  */
 
 #pragma once
@@ -43,6 +63,7 @@ struct DeferredUdpSendRing
     bool IsFull() const { return count == Capacity; }
     size_t ActiveCount() const { return count; }
 
+    // Enqueue at the logical tail (may drop oldest entry when full).
     void PushBack(Slot && slot)
     {
         if (count == Capacity)
@@ -56,9 +77,10 @@ struct DeferredUdpSendRing
         ++count;
     }
 
+    // Dequeue from the logical head; returned value is owned by the caller.
     Slot PopFront()
     {
-        Slot out = std::move(slots[head]);
+        Slot out    = std::move(slots[head]);
         slots[head] = Slot{};
         head        = (head + 1) % Capacity;
         --count;

--- a/src/inet/DeferredUdpSendRing.h
+++ b/src/inet/DeferredUdpSendRing.h
@@ -66,7 +66,7 @@ struct DeferredUdpSendRing
     // Enqueue at the logical tail (may drop oldest entry when full).
     void PushBack(Slot && slot)
     {
-        if (count == Capacity)
+        if (IsFull())
         {
             slots[head] = Slot{};
             head        = (head + 1) % Capacity;

--- a/src/inet/EndPointStateLwIP.h
+++ b/src/inet/EndPointStateLwIP.h
@@ -33,26 +33,32 @@ struct tcp_pcb;
 namespace chip {
 namespace Inet {
 
-    /**
-     * Definitions shared by all LwIP EndPoint classes.
-     */
-    class DLL_EXPORT EndPointStateLwIP {
-    protected:
-        EndPointStateLwIP()
-            : mLwIPEndPointType(LwIPEndPointType::Unknown)
-        {
-        }
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+class DeferredUdpSendQueueLwIP;
+#endif
 
-        enum class LwIPEndPointType : uint8_t {
-            Unknown = 0,
-            UDP = 1,
-            TCP = 2
-        } mLwIPEndPointType;
+/**
+ * Definitions shared by all LwIP EndPoint classes.
+ */
+class DLL_EXPORT EndPointStateLwIP
+{
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    friend class DeferredUdpSendQueueLwIP;
+#endif
+protected:
+    EndPointStateLwIP() : mLwIPEndPointType(LwIPEndPointType::Unknown) {}
 
-        // Synchronously runs a function within the TCPIP task's context.
-        static void RunOnTCPIP(std::function<void()>);
-        static err_t RunOnTCPIPRet(std::function<err_t()>);
-    };
+    enum class LwIPEndPointType : uint8_t
+    {
+        Unknown = 0,
+        UDP     = 1,
+        TCP     = 2
+    } mLwIPEndPointType;
+
+    // Synchronously runs a function within the TCPIP task's context.
+    static void RunOnTCPIP(std::function<void()>);
+    static err_t RunOnTCPIPRet(std::function<err_t()>);
+};
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/EndPointStateLwIP.h
+++ b/src/inet/EndPointStateLwIP.h
@@ -33,25 +33,26 @@ struct tcp_pcb;
 namespace chip {
 namespace Inet {
 
-/**
- * Definitions shared by all LwIP EndPoint classes.
- */
-class DLL_EXPORT EndPointStateLwIP
-{
-protected:
-    EndPointStateLwIP() : mLwIPEndPointType(LwIPEndPointType::Unknown) {}
+    /**
+     * Definitions shared by all LwIP EndPoint classes.
+     */
+    class DLL_EXPORT EndPointStateLwIP {
+    protected:
+        EndPointStateLwIP()
+            : mLwIPEndPointType(LwIPEndPointType::Unknown)
+        {
+        }
 
-    enum class LwIPEndPointType : uint8_t
-    {
-        Unknown = 0,
-        UDP     = 1,
-        TCP     = 2
-    } mLwIPEndPointType;
+        enum class LwIPEndPointType : uint8_t {
+            Unknown = 0,
+            UDP = 1,
+            TCP = 2
+        } mLwIPEndPointType;
 
-    // Synchronously runs a function within the TCPIP task's context.
-    static void RunOnTCPIP(std::function<void()>);
-    static err_t RunOnTCPIPRet(std::function<err_t()>);
-};
+        // Synchronously runs a function within the TCPIP task's context.
+        static void RunOnTCPIP(std::function<void()>);
+        static err_t RunOnTCPIPRet(std::function<err_t()>);
+    };
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/EndPointStateLwIP.h
+++ b/src/inet/EndPointStateLwIP.h
@@ -33,7 +33,7 @@ struct tcp_pcb;
 namespace chip {
 namespace Inet {
 
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 class DeferredUdpSendQueueLwIP;
 #endif
 
@@ -42,7 +42,7 @@ class DeferredUdpSendQueueLwIP;
  */
 class DLL_EXPORT EndPointStateLwIP
 {
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     friend class DeferredUdpSendQueueLwIP;
 #endif
 protected:

--- a/src/inet/EndPointStateLwIP.h
+++ b/src/inet/EndPointStateLwIP.h
@@ -33,7 +33,7 @@ struct tcp_pcb;
 namespace chip {
 namespace Inet {
 
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 class DeferredUdpSendQueueLwIP;
 #endif
 
@@ -42,7 +42,7 @@ class DeferredUdpSendQueueLwIP;
  */
 class DLL_EXPORT EndPointStateLwIP
 {
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     friend class DeferredUdpSendQueueLwIP;
 #endif
 protected:

--- a/src/inet/InetConfig.h
+++ b/src/inet/InetConfig.h
@@ -295,4 +295,29 @@
 #define INET_CONFIG_UDP_SOCKET_MREQN 0
 #endif
 
+/**
+ *  @def INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+ *
+ *  @brief
+ *    When set (1), the LwIP UDP endpoint defers outbound sends until at least one
+ *    LwIP netif is up with link up (operational IP interface). Queued sends are flushed
+ *    when a new send runs while the interface is ready, or when FlushDeferredSendQueue()
+ *    is called (for example after Thread attach or Wi-Fi association with IP).
+ *
+ */
+#ifndef INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#define INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY 1
+#endif
+
+/**
+ *  @def INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE
+ *
+ *  @brief
+ *    Maximum number of outbound UDP datagrams held when INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY is enabled.
+ *
+ */
+#ifndef INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE
+#define INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE 32
+#endif
+
 // clang-format on

--- a/src/inet/InetConfig.h
+++ b/src/inet/InetConfig.h
@@ -295,29 +295,4 @@
 #define INET_CONFIG_UDP_SOCKET_MREQN 0
 #endif
 
-/**
- *  @def INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
- *
- *  @brief
- *    When set (1), the LwIP UDP endpoint defers outbound sends until at least one
- *    LwIP netif is up with link up (operational IP interface). Queued sends are flushed
- *    when a new send runs while the interface is ready, or when FlushDeferredSendQueue()
- *    is called (for example after Thread attach or Wi-Fi association with IP).
- *
- */
-#ifndef INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
-#define INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY 1
-#endif
-
-/**
- *  @def INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE
- *
- *  @brief
- *    Maximum number of outbound UDP datagrams held when INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY is enabled.
- *
- */
-#ifndef INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE
-#define INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE 32
-#endif
-
 // clang-format on

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -67,9 +67,15 @@ namespace Inet {
 
 namespace {
 
+// Fallback for LwIP versions that do not provide NETIF_FOREACH (pre-2.1 or with LWIP_SINGLE_NETIF).
+// Matches the upstream signature: the caller declares the loop variable.
+#ifndef NETIF_FOREACH
+#define NETIF_FOREACH(netif) for ((netif) = netif_list; (netif) != nullptr; (netif) = (netif)->next)
+#endif
+
 struct DeferredUdpSlot
 {
-    UDPEndPointHandle ep;
+    UDPEndPointHandle epHandle;
     IPPacketInfo pktInfo;
     System::PacketBufferHandle msg;
 };
@@ -83,7 +89,6 @@ bool IsNetifUsable(struct netif * netif)
     return netif != nullptr && netif_is_up(netif) && netif_is_link_up(netif);
 }
 
-#if LWIP_IPV6
 bool NetifHasValidIpv6Address(struct netif * netif)
 {
     if (netif == nullptr)
@@ -99,7 +104,6 @@ bool NetifHasValidIpv6Address(struct netif * netif)
     }
     return false;
 }
-#endif // LWIP_IPV6
 
 bool IsNetifReadyForOutboundUdp(struct netif * netif, const IPAddress & dest)
 {
@@ -107,12 +111,10 @@ bool IsNetifReadyForOutboundUdp(struct netif * netif, const IPAddress & dest)
     {
         return false;
     }
-#if LWIP_IPV6
     if (dest.IsIPv6())
     {
         return NetifHasValidIpv6Address(netif);
     }
-#endif // LWIP_IPV6
 #if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
     if (dest.IsIPv4())
     {
@@ -137,7 +139,6 @@ bool IsOutboundNetifReadyForUdp(const IPPacketInfo & pktInfo)
         return true;
     }
 
-#if defined(NETIF_FOREACH)
     struct netif * netif = nullptr;
     NETIF_FOREACH(netif)
     {
@@ -146,15 +147,6 @@ bool IsOutboundNetifReadyForUdp(const IPPacketInfo & pktInfo)
             return true;
         }
     }
-#else
-    for (struct netif * netif = netif_list; netif != nullptr; netif = netif->next)
-    {
-        if (IsNetifReadyForOutboundUdp(netif, dest))
-        {
-            return true;
-        }
-    }
-#endif
 
     return false;
 }
@@ -172,7 +164,7 @@ CHIP_ERROR EnqueueDeferredUdpSend(UDPEndPointImplLwIP * self, const IPPacketInfo
     }
 
     DeferredUdpSlot slot;
-    slot.ep      = UDPEndPointHandle(static_cast<UDPEndPoint *>(self));
+    slot.epHandle      = UDPEndPointHandle(static_cast<UDPEndPoint *>(self));
     slot.pktInfo = *pktInfo;
     slot.msg     = std::move(msg);
 
@@ -190,7 +182,7 @@ void PurgeDeferredUdpSendsForEndpoint(UDPEndPointImplLwIP * self)
     UDPEndPoint * asBase = static_cast<UDPEndPoint *>(self);
     for (auto it = gDeferredUdpQueue.begin(); it != gDeferredUdpQueue.end();)
     {
-        if (!it->ep.IsNull() && it->ep == *asBase)
+        if (!it->epHandle.IsNull() && it->epHandle == *asBase)
         {
             it = gDeferredUdpQueue.erase(it);
         }
@@ -426,9 +418,9 @@ void UDPEndPointImplLwIP::FlushDeferredSendQueue()
             continue;
         }
 
-        if (!slot.ep.IsNull())
+        if (!slot.epHandle.IsNull())
         {
-            auto * impl = static_cast<UDPEndPointImplLwIP *>(slot.ep.operator->());
+            auto * impl = static_cast<UDPEndPointImplLwIP *>(slot.epHandle.operator->());
             if (impl->mState != State::kClosed && impl->mUDP != nullptr)
             {
                 (void) impl->PerformLwIPUdpSend(&slot.pktInfo, std::move(slot.msg));
@@ -569,8 +561,8 @@ CHIP_ERROR UDPEndPointImplLwIP::GetPCB(IPAddressType addrType)
 void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, const ip_addr_t * addr,
                                                 u16_t port)
 {
-    UDPEndPointImplLwIP * ep = static_cast<UDPEndPointImplLwIP *>(arg);
-    if (ep->mState == State::kClosed)
+    UDPEndPointImplLwIP * epHandle = static_cast<UDPEndPointImplLwIP *>(arg);
+    if (epHandle->mState == State::kClosed)
     {
         return;
     }
@@ -609,7 +601,7 @@ void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb
     auto filterOutcome = EndpointQueueFilter::FilterOutcome::kAllowPacket;
     if (sQueueFilter != nullptr)
     {
-        filterOutcome = sQueueFilter->FilterBeforeEnqueue(ep, *(pktInfo.get()), buf);
+        filterOutcome = sQueueFilter->FilterBeforeEnqueue(epHandle, *(pktInfo.get()), buf);
     }
 
     if (filterOutcome != EndpointQueueFilter::FilterOutcome::kAllowPacket)
@@ -620,14 +612,14 @@ void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb
 
     // Increase mDelayReleaseCount to delay release of this UDP EndPoint while the HandleDataReceived call is
     // pending on it.
-    ep->mDelayReleaseCount++;
+    epHandle->mDelayReleaseCount++;
 
-    CHIP_ERROR err = ep->GetSystemLayer().ScheduleLambda(
-        [ep, p = System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(buf), pktInfo = pktInfo.get()] {
-            ep->mDelayReleaseCount--;
+    CHIP_ERROR err = epHandle->GetSystemLayer().ScheduleLambda(
+        [epHandle, p = System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(buf), pktInfo = pktInfo.get()] {
+            epHandle->mDelayReleaseCount--;
 
             auto handle = System::PacketBufferHandle::Adopt(p);
-            ep->HandleDataReceived(std::move(handle), pktInfo);
+            epHandle->HandleDataReceived(std::move(handle), pktInfo);
         });
 
     if (err == CHIP_NO_ERROR)
@@ -643,11 +635,11 @@ void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb
         // the packet is basically dequeued, if it tries to keep track of the lifecycle.
         if (sQueueFilter != nullptr)
         {
-            (void) sQueueFilter->FilterAfterDequeue(ep, *(pktInfo.get()), buf);
+            (void) sQueueFilter->FilterAfterDequeue(epHandle, *(pktInfo.get()), buf);
             ChipLogError(Inet, "Dequeue ERROR err = %" CHIP_ERROR_FORMAT, err.Format());
         }
 
-        ep->mDelayReleaseCount--;
+        epHandle->mDelayReleaseCount--;
     }
 }
 

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -97,7 +97,7 @@ bool NetifHasValidIpv6Address(struct netif * netif)
     }
     for (u8_t idx = 0; idx < LWIP_IPV6_NUM_ADDRESSES; ++idx)
     {
-        if (ip6_addr_isvalid(netif_ip6_addr_state(netif, idx)))
+        if (ip6_addr_ispreferred(netif_ip6_addr_state(netif, idx)))
         {
             return true;
         }

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -380,8 +380,8 @@ CHIP_ERROR UDPEndPointImplLwIP::GetPCB(IPAddressType addrType)
 void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, const ip_addr_t * addr,
                                                 u16_t port)
 {
-    UDPEndPointImplLwIP * epHandle = static_cast<UDPEndPointImplLwIP *>(arg);
-    if (epHandle->mState == State::kClosed)
+    UDPEndPointImplLwIP * ep = static_cast<UDPEndPointImplLwIP *>(arg);
+    if (ep->mState == State::kClosed)
     {
         return;
     }
@@ -420,7 +420,7 @@ void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb
     auto filterOutcome = EndpointQueueFilter::FilterOutcome::kAllowPacket;
     if (sQueueFilter != nullptr)
     {
-        filterOutcome = sQueueFilter->FilterBeforeEnqueue(epHandle, *(pktInfo.get()), buf);
+        filterOutcome = sQueueFilter->FilterBeforeEnqueue(ep, *(pktInfo.get()), buf);
     }
 
     if (filterOutcome != EndpointQueueFilter::FilterOutcome::kAllowPacket)
@@ -431,14 +431,14 @@ void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb
 
     // Increase mDelayReleaseCount to delay release of this UDP EndPoint while the HandleDataReceived call is
     // pending on it.
-    epHandle->mDelayReleaseCount++;
+    ep->mDelayReleaseCount++;
 
-    CHIP_ERROR err = epHandle->GetSystemLayer().ScheduleLambda(
-        [epHandle, p = System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(buf), pktInfo = pktInfo.get()] {
-            epHandle->mDelayReleaseCount--;
+    CHIP_ERROR err = ep->GetSystemLayer().ScheduleLambda(
+        [ep, p = System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(buf), pktInfo = pktInfo.get()] {
+            ep->mDelayReleaseCount--;
 
             auto handle = System::PacketBufferHandle::Adopt(p);
-            epHandle->HandleDataReceived(std::move(handle), pktInfo);
+            ep->HandleDataReceived(std::move(handle), pktInfo);
         });
 
     if (err == CHIP_NO_ERROR)
@@ -454,11 +454,11 @@ void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb
         // the packet is basically dequeued, if it tries to keep track of the lifecycle.
         if (sQueueFilter != nullptr)
         {
-            (void) sQueueFilter->FilterAfterDequeue(epHandle, *(pktInfo.get()), buf);
+            (void) sQueueFilter->FilterAfterDequeue(ep, *(pktInfo.get()), buf);
             ChipLogError(Inet, "Dequeue ERROR err = %" CHIP_ERROR_FORMAT, err.Format());
         }
 
-        epHandle->mDelayReleaseCount--;
+        ep->mDelayReleaseCount--;
     }
 }
 

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -182,7 +182,7 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
 {
     assertChipStackLockedByCurrentThread();
 
-    err_t lwipErr = ERR_OK;
+    err_t lwipErr              = ERR_OK;
     const IPAddress & destAddr = pktInfo->DestAddress;
 
     // Send the message to the specified address/port.

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -23,7 +23,9 @@
 
 #include <inet/UDPEndPointImplLwIP.h>
 
-#include <deque>
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#include <inet/DeferredUdpSendQueueLwIP.h>
+#endif
 
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -62,140 +64,6 @@ static_assert(LWIP_VERSION_MAJOR > 1, "CHIP requires LwIP 2.0 or later");
 
 namespace chip {
 namespace Inet {
-
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
-
-namespace {
-
-// Fallback for LwIP versions that do not provide NETIF_FOREACH (pre-2.1 or with LWIP_SINGLE_NETIF).
-// Matches the upstream signature: the caller declares the loop variable.
-#ifndef NETIF_FOREACH
-#define NETIF_FOREACH(netif) for ((netif) = netif_list; (netif) != nullptr; (netif) = (netif)->next)
-#endif
-
-struct DeferredUdpSlot
-{
-    UDPEndPointHandle epHandle;
-    IPPacketInfo pktInfo;
-    System::PacketBufferHandle msg;
-};
-
-// FIFO of deferred UDP sends, bounded to INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE.
-// Enqueue drops the oldest entry on overflow; purge/flush erase matching entries in place.
-std::deque<DeferredUdpSlot> gDeferredUdpQueue;
-
-bool IsNetifUsable(struct netif * netif)
-{
-    return netif != nullptr && netif_is_up(netif) && netif_is_link_up(netif);
-}
-
-bool NetifHasValidIpv6Address(struct netif * netif)
-{
-    if (netif == nullptr)
-    {
-        return false;
-    }
-    for (u8_t idx = 0; idx < LWIP_IPV6_NUM_ADDRESSES; ++idx)
-    {
-        if (ip6_addr_ispreferred(netif_ip6_addr_state(netif, idx)))
-        {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool IsNetifReadyForOutboundUdp(struct netif * netif, const IPAddress & dest)
-{
-    if (!IsNetifUsable(netif))
-    {
-        return false;
-    }
-    if (dest.IsIPv6())
-    {
-        return NetifHasValidIpv6Address(netif);
-    }
-#if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
-    if (dest.IsIPv4())
-    {
-        return !ip4_addr_isany(netif_ip4_addr(netif));
-    }
-#endif // INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
-    return true;
-}
-
-bool IsOutboundNetifReadyForUdp(const IPPacketInfo & pktInfo)
-{
-    const InterfaceId & intfId = pktInfo.Interface;
-    const IPAddress & dest     = pktInfo.DestAddress;
-
-    if (intfId.IsPresent())
-    {
-        return IsNetifReadyForOutboundUdp(intfId.GetPlatformInterface(), dest);
-    }
-
-    if (IsNetifReadyForOutboundUdp(netif_default, dest))
-    {
-        return true;
-    }
-
-    struct netif * netif = nullptr;
-    NETIF_FOREACH(netif)
-    {
-        if (IsNetifReadyForOutboundUdp(netif, dest))
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-CHIP_ERROR EnqueueDeferredUdpSend(UDPEndPointImplLwIP * self, const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
-{
-    if (gDeferredUdpQueue.size() >= INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE)
-    {
-        const DeferredUdpSlot & head = gDeferredUdpQueue.front();
-        char dropDest[IPAddress::kMaxStringLength];
-        head.pktInfo.DestAddress.ToString(dropDest);
-        ChipLogProgress(Inet, "Deferred UDP queue full: dropping head dest %s port %u len %u", dropDest, head.pktInfo.DestPort,
-                        static_cast<unsigned>(head.msg->TotalLength()));
-        gDeferredUdpQueue.pop_front();
-    }
-
-    DeferredUdpSlot slot;
-    slot.epHandle = UDPEndPointHandle(static_cast<UDPEndPoint *>(self));
-    slot.pktInfo  = *pktInfo;
-    slot.msg      = std::move(msg);
-
-    char destStr[IPAddress::kMaxStringLength];
-    pktInfo->DestAddress.ToString(destStr);
-    ChipLogProgress(Inet, "UDP send deferred (waiting for netif): dest %s port %u len %u", destStr, pktInfo->DestPort,
-                    static_cast<unsigned>(slot.msg->TotalLength()));
-
-    gDeferredUdpQueue.push_back(std::move(slot));
-    return CHIP_NO_ERROR;
-}
-
-void PurgeDeferredUdpSendsForEndpoint(UDPEndPointImplLwIP * self)
-{
-    UDPEndPoint * asBase = static_cast<UDPEndPoint *>(self);
-    for (auto it = gDeferredUdpQueue.begin(); it != gDeferredUdpQueue.end();)
-    {
-        if (!it->epHandle.IsNull() && it->epHandle == *asBase)
-        {
-            it = gDeferredUdpQueue.erase(it);
-        }
-        else
-        {
-            ++it;
-        }
-    }
-}
-
-} // namespace
-
-#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
 EndpointQueueFilter * UDPEndPointImplLwIP::sQueueFilter = nullptr;
 
@@ -297,21 +165,15 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
     }
 
 #if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
-    FlushDeferredSendQueue();
-
-    bool defer          = false;
-    err_t deferProbeErr = RunOnTCPIPRet([&]() -> err_t {
-        defer = !IsOutboundNetifReadyForUdp(*pktInfo);
-        return ERR_OK;
-    });
-    if (deferProbeErr != ERR_OK)
+    // Defer if the netif is not ready for this destination; otherwise drain earlier deferrals first.
+    bool shouldDefer = false;
+    CHIP_ERROR deferProbeErr = DeferredUdpSendQueueLwIP::ProbeDefer(*pktInfo, shouldDefer);
+    VerifyOrReturnError(deferProbeErr == CHIP_NO_ERROR, deferProbeErr);
+    if (shouldDefer)
     {
-        return chip::System::MapErrorLwIP(deferProbeErr);
+        return DeferredUdpSendQueueLwIP::Enqueue(this, pktInfo, std::move(msg));
     }
-    if (defer)
-    {
-        return EnqueueDeferredUdpSend(this, pktInfo, std::move(msg));
-    }
+    DeferredUdpSendQueueLwIP::Flush();
 #endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
     return PerformLwIPUdpSend(pktInfo, std::move(msg));
@@ -329,9 +191,9 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
     // If a source address has been specified, temporarily override the local_ip of the PCB.
     // This results in LwIP using the given address being as the source address for the generated
     // packet, as if the PCB had been bound to that address.
-    const IPAddress & srcAddr  = pktInfo->SrcAddress;
-    const uint16_t & destPort  = pktInfo->DestPort;
-    const InterfaceId & intfId = pktInfo->Interface;
+    const IPAddress &     srcAddr  = pktInfo->SrcAddress;
+    const uint16_t &      destPort = pktInfo->DestPort;
+    const InterfaceId &   intfId   = pktInfo->Interface;
 
     ip_addr_t lwipSrcAddr  = srcAddr.ToLwIPAddr();
     ip_addr_t lwipDestAddr = destAddr.ToLwIPAddr();
@@ -363,7 +225,7 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
     if (lwipErr == ERR_RTE)
     {
         ChipLogProgress(Inet, "UDP send deferred (no route yet, ERR_RTE): dest %s port %u len %u", destStr, destPort, payloadLen);
-        return EnqueueDeferredUdpSend(this, pktInfo, std::move(msg));
+        return DeferredUdpSendQueueLwIP::Enqueue(this, pktInfo, std::move(msg));
     }
 #endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
@@ -379,54 +241,18 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
 }
 
 #if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+CHIP_ERROR UDPEndPointImplLwIP::FlushOneDeferred(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
+{
+    if (mState == State::kClosed || mUDP == nullptr)
+    {
+        return CHIP_NO_ERROR;
+    }
+    return PerformLwIPUdpSend(pktInfo, std::move(msg));
+}
+
 void UDPEndPointImplLwIP::FlushDeferredSendQueue()
 {
-    assertChipStackLockedByCurrentThread();
-
-    // Take ownership of the current queue locally. This guarantees each entry is visited
-    // exactly once per flush call, and is safe if PerformLwIPUdpSend re-enqueues on ERR_RTE
-    // (those go into the now-empty gDeferredUdpQueue without affecting our iteration).
-    std::deque<DeferredUdpSlot> pending;
-    pending.swap(gDeferredUdpQueue);
-
-    while (!pending.empty())
-    {
-        DeferredUdpSlot slot = std::move(pending.front());
-        pending.pop_front();
-
-        bool ready     = false;
-        err_t probeErr = RunOnTCPIPRet([&]() -> err_t {
-            ready = IsOutboundNetifReadyForUdp(slot.pktInfo);
-            return ERR_OK;
-        });
-        if (probeErr != ERR_OK)
-        {
-            ChipLogError(Inet, "FlushDeferredSendQueue: RunOnTCPIPRet failed: %d", static_cast<int>(probeErr));
-            // Restore remaining entries to the global queue preserving order, then bail.
-            gDeferredUdpQueue.push_back(std::move(slot));
-            while (!pending.empty())
-            {
-                gDeferredUdpQueue.push_back(std::move(pending.front()));
-                pending.pop_front();
-            }
-            return;
-        }
-
-        if (!ready)
-        {
-            gDeferredUdpQueue.push_back(std::move(slot)); // try again on the next flush
-            continue;
-        }
-
-        if (!slot.epHandle.IsNull())
-        {
-            auto * impl = static_cast<UDPEndPointImplLwIP *>(slot.epHandle.operator->());
-            if (impl->mState != State::kClosed && impl->mUDP != nullptr)
-            {
-                (void) impl->PerformLwIPUdpSend(&slot.pktInfo, std::move(slot.msg));
-            }
-        }
-    }
+    DeferredUdpSendQueueLwIP::Flush();
 }
 #else
 void UDPEndPointImplLwIP::FlushDeferredSendQueue() {}
@@ -437,7 +263,7 @@ void UDPEndPointImplLwIP::CloseImpl()
     assertChipStackLockedByCurrentThread();
 
 #if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
-    PurgeDeferredUdpSendsForEndpoint(this);
+    DeferredUdpSendQueueLwIP::PurgeForEndpoint(this);
 #endif
 
     // Since UDP PCB is released synchronously here, but UDP endpoint itself might have to wait

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -27,14 +27,10 @@
 #include <inet/DeferredUdpSendQueueLwIP.h>
 #endif
 
-#include <lib/support/CodeUtils.h>
-#include <lib/support/logging/CHIPLogging.h>
-
 #if INET_CONFIG_ENABLE_IPV4
 #include <lwip/igmp.h>
 #endif // INET_CONFIG_ENABLE_IPV4
 
-#include <lwip/err.h>
 #include <lwip/init.h>
 #include <lwip/ip.h>
 #include <lwip/mld6.h>
@@ -227,7 +223,6 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
 
     if (lwipErr != ERR_OK)
     {
-        ChipLogError(Inet, "UDP send failed: %" CHIP_ERROR_FORMAT, chip::System::MapErrorLwIP(lwipErr).Format());
         return chip::System::MapErrorLwIP(lwipErr);
     }
     return CHIP_NO_ERROR;

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -23,7 +23,7 @@
 
 #include <inet/UDPEndPointImplLwIP.h>
 
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 #include <inet/DeferredUdpSendQueueLwIP.h>
 #endif
 
@@ -163,7 +163,7 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
         return res;
     }
 
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     // Defer if the netif is not ready for this destination; otherwise drain earlier deferrals first.
     bool shouldDefer         = false;
     CHIP_ERROR deferProbeErr = DeferredUdpSendQueueLwIP::ProbeDefer(*pktInfo, shouldDefer);
@@ -173,7 +173,7 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
         return DeferredUdpSendQueueLwIP::Enqueue(this, pktInfo, std::move(msg));
     }
     DeferredUdpSendQueueLwIP::Flush();
-#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#endif // SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
     return PerformLwIPUdpSend(pktInfo, std::move(msg));
 }
@@ -217,13 +217,13 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
 
     ip_addr_copy(mUDP->local_ip, boundAddr);
 
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     if (lwipErr == ERR_RTE)
     {
         ChipLogDetail(Inet, "UDP send deferred (no route yet, ERR_RTE)");
         return DeferredUdpSendQueueLwIP::Enqueue(this, pktInfo, std::move(msg));
     }
-#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#endif // SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
     if (lwipErr != ERR_OK)
     {
@@ -232,7 +232,7 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
     return CHIP_NO_ERROR;
 }
 
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 CHIP_ERROR UDPEndPointImplLwIP::FlushOneDeferred(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
 {
     if (mState == State::kClosed || mUDP == nullptr)
@@ -248,13 +248,13 @@ void UDPEndPointImplLwIP::FlushDeferredSendQueue()
 }
 #else
 void UDPEndPointImplLwIP::FlushDeferredSendQueue() {}
-#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#endif // SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
 void UDPEndPointImplLwIP::CloseImpl()
 {
     assertChipStackLockedByCurrentThread();
 
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     DeferredUdpSendQueueLwIP::PurgeForEndpoint(this);
 #endif
 

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -197,8 +197,8 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
 
     ip_addr_t lwipSrcAddr  = srcAddr.ToLwIPAddr();
     ip_addr_t lwipDestAddr = destAddr.ToLwIPAddr();
-    ip_addr_t boundAddr;
 
+    ip_addr_t boundAddr;
     ip_addr_copy(boundAddr, mUDP->local_ip);
 
     if (!ip_addr_isany(&lwipSrcAddr))
@@ -217,26 +217,19 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
 
     ip_addr_copy(mUDP->local_ip, boundAddr);
 
-    const unsigned payloadLen = static_cast<unsigned>(msg->TotalLength());
-    char destStr[IPAddress::kMaxStringLength];
-    destAddr.ToString(destStr);
-
 #if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     if (lwipErr == ERR_RTE)
     {
-        ChipLogProgress(Inet, "UDP send deferred (no route yet, ERR_RTE): dest %s port %u len %u", destStr, destPort, payloadLen);
+        ChipLogDetail(Inet, "UDP send deferred (no route yet, ERR_RTE)");
         return DeferredUdpSendQueueLwIP::Enqueue(this, pktInfo, std::move(msg));
     }
 #endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
     if (lwipErr != ERR_OK)
     {
-        ChipLogError(Inet, "UDP send failed: dest %s port %u len %u lwip err %d", destStr, destPort, payloadLen,
-                     static_cast<int>(lwipErr));
+        ChipLogError(Inet, "UDP send failed: %" CHIP_ERROR_FORMAT, chip::System::MapErrorLwIP(lwipErr).Format());
         return chip::System::MapErrorLwIP(lwipErr);
     }
-
-    ChipLogProgress(Inet, "UDP send: dest %s port %u len %u", destStr, destPort, payloadLen);
     return CHIP_NO_ERROR;
 }
 

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -23,7 +23,7 @@
 
 #include <inet/UDPEndPointImplLwIP.h>
 
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 #include <inet/DeferredUdpSendQueueLwIP.h>
 #endif
 
@@ -163,7 +163,7 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
         return res;
     }
 
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     // Defer if the netif is not ready for this destination; otherwise drain earlier deferrals first.
     bool shouldDefer         = false;
     CHIP_ERROR deferProbeErr = DeferredUdpSendQueueLwIP::ProbeDefer(*pktInfo, shouldDefer);
@@ -173,7 +173,7 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
         return DeferredUdpSendQueueLwIP::Enqueue(this, pktInfo, std::move(msg));
     }
     DeferredUdpSendQueueLwIP::Flush();
-#endif // SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#endif // SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
     return PerformLwIPUdpSend(pktInfo, std::move(msg));
 }
@@ -217,13 +217,13 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
 
     ip_addr_copy(mUDP->local_ip, boundAddr);
 
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     if (lwipErr == ERR_RTE)
     {
         ChipLogDetail(Inet, "UDP send deferred (no route yet, ERR_RTE)");
         return DeferredUdpSendQueueLwIP::Enqueue(this, pktInfo, std::move(msg));
     }
-#endif // SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#endif // SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
     if (lwipErr != ERR_OK)
     {
@@ -232,7 +232,7 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
     return CHIP_NO_ERROR;
 }
 
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 CHIP_ERROR UDPEndPointImplLwIP::FlushOneDeferred(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
 {
     if (mState == State::kClosed || mUDP == nullptr)
@@ -248,13 +248,13 @@ void UDPEndPointImplLwIP::FlushDeferredSendQueue()
 }
 #else
 void UDPEndPointImplLwIP::FlushDeferredSendQueue() {}
-#endif // SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#endif // SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
 void UDPEndPointImplLwIP::CloseImpl()
 {
     assertChipStackLockedByCurrentThread();
 
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     DeferredUdpSendQueueLwIP::PurgeForEndpoint(this);
 #endif
 

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -165,6 +165,8 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
 
 #if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     // Defer if the netif is not ready for this destination; otherwise drain earlier deferrals first.
+    // Flush still re-evaluates readiness per deferred entry because the queue may contain packets for
+    // different interfaces/destinations than pktInfo, and netif state can change between probes.
     bool shouldDefer         = false;
     CHIP_ERROR deferProbeErr = DeferredUdpSendQueueLwIP::ProbeDefer(*pktInfo, shouldDefer);
     VerifyOrReturnError(deferProbeErr == CHIP_NO_ERROR, deferProbeErr);

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -23,10 +23,16 @@
 
 #include <inet/UDPEndPointImplLwIP.h>
 
+#include <deque>
+
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+
 #if INET_CONFIG_ENABLE_IPV4
 #include <lwip/igmp.h>
 #endif // INET_CONFIG_ENABLE_IPV4
 
+#include <lwip/err.h>
 #include <lwip/init.h>
 #include <lwip/ip.h>
 #include <lwip/mld6.h>
@@ -56,6 +62,148 @@ static_assert(LWIP_VERSION_MAJOR > 1, "CHIP requires LwIP 2.0 or later");
 
 namespace chip {
 namespace Inet {
+
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+
+namespace {
+
+struct DeferredUdpSlot
+{
+    UDPEndPointHandle ep;
+    IPPacketInfo pktInfo;
+    System::PacketBufferHandle msg;
+};
+
+// FIFO of deferred UDP sends, bounded to INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE.
+// Enqueue drops the oldest entry on overflow; purge/flush erase matching entries in place.
+std::deque<DeferredUdpSlot> gDeferredUdpQueue;
+
+bool IsNetifUsable(struct netif * netif)
+{
+    return netif != nullptr && netif_is_up(netif) && netif_is_link_up(netif);
+}
+
+#if LWIP_IPV6
+bool NetifHasValidIpv6Address(struct netif * netif)
+{
+    if (netif == nullptr)
+    {
+        return false;
+    }
+    for (u8_t idx = 0; idx < LWIP_IPV6_NUM_ADDRESSES; ++idx)
+    {
+        if (ip6_addr_isvalid(netif_ip6_addr_state(netif, idx)))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+#endif // LWIP_IPV6
+
+bool IsNetifReadyForOutboundUdp(struct netif * netif, const IPAddress & dest)
+{
+    if (!IsNetifUsable(netif))
+    {
+        return false;
+    }
+#if LWIP_IPV6
+    if (dest.IsIPv6())
+    {
+        return NetifHasValidIpv6Address(netif);
+    }
+#endif // LWIP_IPV6
+#if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
+    if (dest.IsIPv4())
+    {
+        return !ip4_addr_isany(netif_ip4_addr(netif));
+    }
+#endif // INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
+    return true;
+}
+
+bool IsOutboundNetifReadyForUdp(const IPPacketInfo & pktInfo)
+{
+    const InterfaceId & intfId = pktInfo.Interface;
+    const IPAddress & dest    = pktInfo.DestAddress;
+
+    if (intfId.IsPresent())
+    {
+        return IsNetifReadyForOutboundUdp(intfId.GetPlatformInterface(), dest);
+    }
+
+    if (IsNetifReadyForOutboundUdp(netif_default, dest))
+    {
+        return true;
+    }
+
+#if defined(NETIF_FOREACH)
+    struct netif * netif = nullptr;
+    NETIF_FOREACH(netif)
+    {
+        if (IsNetifReadyForOutboundUdp(netif, dest))
+        {
+            return true;
+        }
+    }
+#else
+    for (struct netif * netif = netif_list; netif != nullptr; netif = netif->next)
+    {
+        if (IsNetifReadyForOutboundUdp(netif, dest))
+        {
+            return true;
+        }
+    }
+#endif
+
+    return false;
+}
+
+CHIP_ERROR EnqueueDeferredUdpSend(UDPEndPointImplLwIP * self, const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
+{
+    if (gDeferredUdpQueue.size() >= INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE)
+    {
+        const DeferredUdpSlot & head = gDeferredUdpQueue.front();
+        char dropDest[IPAddress::kMaxStringLength];
+        head.pktInfo.DestAddress.ToString(dropDest);
+        ChipLogProgress(Inet, "Deferred UDP queue full: dropping head dest %s port %u len %u", dropDest,
+                        head.pktInfo.DestPort, static_cast<unsigned>(head.msg->TotalLength()));
+        gDeferredUdpQueue.pop_front();
+    }
+
+    DeferredUdpSlot slot;
+    slot.ep      = UDPEndPointHandle(static_cast<UDPEndPoint *>(self));
+    slot.pktInfo = *pktInfo;
+    slot.msg     = std::move(msg);
+
+    char destStr[IPAddress::kMaxStringLength];
+    pktInfo->DestAddress.ToString(destStr);
+    ChipLogProgress(Inet, "UDP send deferred (waiting for netif): dest %s port %u len %u", destStr, pktInfo->DestPort,
+                    static_cast<unsigned>(slot.msg->TotalLength()));
+
+    gDeferredUdpQueue.push_back(std::move(slot));
+    return CHIP_NO_ERROR;
+}
+
+void PurgeDeferredUdpSendsForEndpoint(UDPEndPointImplLwIP * self)
+{
+    UDPEndPoint * asBase = static_cast<UDPEndPoint *>(self);
+    for (auto it = gDeferredUdpQueue.begin(); it != gDeferredUdpQueue.end();)
+    {
+        if (!it->ep.IsNull() && it->ep == *asBase)
+        {
+            it = gDeferredUdpQueue.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+} // namespace
+
+#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
 EndpointQueueFilter * UDPEndPointImplLwIP::sQueueFilter = nullptr;
 
@@ -150,15 +298,38 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
         VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_NO_MEMORY);
     }
 
-    CHIP_ERROR res = CHIP_NO_ERROR;
-    err_t lwipErr  = ERR_VAL;
-
-    // Make sure we have the appropriate type of PCB based on the destination address.
-    res = GetPCB(destAddr.Type());
+    CHIP_ERROR res = GetPCB(destAddr.Type());
     if (res != CHIP_NO_ERROR)
     {
         return res;
     }
+
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    FlushDeferredSendQueue();
+
+    bool defer = false;
+    err_t deferProbeErr = RunOnTCPIPRet([&]() -> err_t {
+        defer = !IsOutboundNetifReadyForUdp(*pktInfo);
+        return ERR_OK;
+    });
+    if (deferProbeErr != ERR_OK)
+    {
+        return chip::System::MapErrorLwIP(deferProbeErr);
+    }
+    if (defer)
+    {
+        return EnqueueDeferredUdpSend(this, pktInfo, std::move(msg));
+    }
+#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+
+    return PerformLwIPUdpSend(pktInfo, std::move(msg));
+}
+
+CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
+{
+    assertChipStackLockedByCurrentThread();
+
+    const IPAddress & destAddr = pktInfo->DestAddress;
 
     // Send the message to the specified address/port.
     // If an outbound interface has been specified, call a specific version of the UDP sendto()
@@ -166,14 +337,14 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
     // If a source address has been specified, temporarily override the local_ip of the PCB.
     // This results in LwIP using the given address being as the source address for the generated
     // packet, as if the PCB had been bound to that address.
-    const IPAddress & srcAddr  = pktInfo->SrcAddress;
-    const uint16_t & destPort  = pktInfo->DestPort;
+    const IPAddress & srcAddr   = pktInfo->SrcAddress;
+    const uint16_t & destPort    = pktInfo->DestPort;
     const InterfaceId & intfId = pktInfo->Interface;
 
-    ip_addr_t lwipSrcAddr  = srcAddr.ToLwIPAddr();
-    ip_addr_t lwipDestAddr = destAddr.ToLwIPAddr();
-
+    ip_addr_t lwipSrcAddr   = srcAddr.ToLwIPAddr();
+    ip_addr_t lwipDestAddr  = destAddr.ToLwIPAddr();
     ip_addr_t boundAddr;
+
     ip_addr_copy(boundAddr, mUDP->local_ip);
 
     if (!ip_addr_isany(&lwipSrcAddr))
@@ -181,7 +352,7 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
         ip_addr_copy(mUDP->local_ip, lwipSrcAddr);
     }
 
-    lwipErr = RunOnTCPIPRet([this, &intfId, &msg, &lwipDestAddr, destPort]() {
+    err_t lwipErr = RunOnTCPIPRet([this, &intfId, &msg, &lwipDestAddr, destPort]() {
         if (intfId.IsPresent())
         {
             return udp_sendto_if(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort,
@@ -192,17 +363,90 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
 
     ip_addr_copy(mUDP->local_ip, boundAddr);
 
+    const unsigned payloadLen = static_cast<unsigned>(msg->TotalLength());
+    char destStr[IPAddress::kMaxStringLength];
+    destAddr.ToString(destStr);
+
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    if (lwipErr == ERR_RTE)
+    {
+        ChipLogProgress(Inet, "UDP send deferred (no route yet, ERR_RTE): dest %s port %u len %u", destStr, destPort, payloadLen);
+        return EnqueueDeferredUdpSend(this, pktInfo, std::move(msg));
+    }
+#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+
     if (lwipErr != ERR_OK)
     {
-        res = chip::System::MapErrorLwIP(lwipErr);
+        ChipLogError(Inet, "UDP send failed: dest %s port %u len %u lwip err %d", destStr, destPort, payloadLen,
+                     static_cast<int>(lwipErr));
+        return chip::System::MapErrorLwIP(lwipErr);
     }
 
-    return res;
+    ChipLogProgress(Inet, "UDP send: dest %s port %u len %u", destStr, destPort, payloadLen);
+    return CHIP_NO_ERROR;
 }
+
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+void UDPEndPointImplLwIP::FlushDeferredSendQueue()
+{
+    assertChipStackLockedByCurrentThread();
+
+    // Take ownership of the current queue locally. This guarantees each entry is visited
+    // exactly once per flush call, and is safe if PerformLwIPUdpSend re-enqueues on ERR_RTE
+    // (those go into the now-empty gDeferredUdpQueue without affecting our iteration).
+    std::deque<DeferredUdpSlot> pending;
+    pending.swap(gDeferredUdpQueue);
+
+    while (!pending.empty())
+    {
+        DeferredUdpSlot slot = std::move(pending.front());
+        pending.pop_front();
+
+        bool ready         = false;
+        err_t probeErr = RunOnTCPIPRet([&]() -> err_t {
+            ready = IsOutboundNetifReadyForUdp(slot.pktInfo);
+            return ERR_OK;
+        });
+        if (probeErr != ERR_OK)
+        {
+            ChipLogError(Inet, "FlushDeferredSendQueue: RunOnTCPIPRet failed: %d", static_cast<int>(probeErr));
+            // Restore remaining entries to the global queue preserving order, then bail.
+            gDeferredUdpQueue.push_back(std::move(slot));
+            while (!pending.empty())
+            {
+                gDeferredUdpQueue.push_back(std::move(pending.front()));
+                pending.pop_front();
+            }
+            return;
+        }
+
+        if (!ready)
+        {
+            gDeferredUdpQueue.push_back(std::move(slot)); // try again on the next flush
+            continue;
+        }
+
+        if (!slot.ep.IsNull())
+        {
+            auto * impl = static_cast<UDPEndPointImplLwIP *>(slot.ep.operator->());
+            if (impl->mState != State::kClosed && impl->mUDP != nullptr)
+            {
+                (void) impl->PerformLwIPUdpSend(&slot.pktInfo, std::move(slot.msg));
+            }
+        }
+    }
+}
+#else
+void UDPEndPointImplLwIP::FlushDeferredSendQueue() {}
+#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
 void UDPEndPointImplLwIP::CloseImpl()
 {
     assertChipStackLockedByCurrentThread();
+
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    PurgeDeferredUdpSendsForEndpoint(this);
+#endif
 
     // Since UDP PCB is released synchronously here, but UDP endpoint itself might have to wait
     // for destruction asynchronously, there could be more allocated UDP endpoints than UDP PCBs.

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -127,7 +127,7 @@ bool IsNetifReadyForOutboundUdp(struct netif * netif, const IPAddress & dest)
 bool IsOutboundNetifReadyForUdp(const IPPacketInfo & pktInfo)
 {
     const InterfaceId & intfId = pktInfo.Interface;
-    const IPAddress & dest    = pktInfo.DestAddress;
+    const IPAddress & dest     = pktInfo.DestAddress;
 
     if (intfId.IsPresent())
     {
@@ -158,15 +158,15 @@ CHIP_ERROR EnqueueDeferredUdpSend(UDPEndPointImplLwIP * self, const IPPacketInfo
         const DeferredUdpSlot & head = gDeferredUdpQueue.front();
         char dropDest[IPAddress::kMaxStringLength];
         head.pktInfo.DestAddress.ToString(dropDest);
-        ChipLogProgress(Inet, "Deferred UDP queue full: dropping head dest %s port %u len %u", dropDest,
-                        head.pktInfo.DestPort, static_cast<unsigned>(head.msg->TotalLength()));
+        ChipLogProgress(Inet, "Deferred UDP queue full: dropping head dest %s port %u len %u", dropDest, head.pktInfo.DestPort,
+                        static_cast<unsigned>(head.msg->TotalLength()));
         gDeferredUdpQueue.pop_front();
     }
 
     DeferredUdpSlot slot;
-    slot.epHandle      = UDPEndPointHandle(static_cast<UDPEndPoint *>(self));
-    slot.pktInfo = *pktInfo;
-    slot.msg     = std::move(msg);
+    slot.epHandle = UDPEndPointHandle(static_cast<UDPEndPoint *>(self));
+    slot.pktInfo  = *pktInfo;
+    slot.msg      = std::move(msg);
 
     char destStr[IPAddress::kMaxStringLength];
     pktInfo->DestAddress.ToString(destStr);
@@ -299,7 +299,7 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
 #if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     FlushDeferredSendQueue();
 
-    bool defer = false;
+    bool defer          = false;
     err_t deferProbeErr = RunOnTCPIPRet([&]() -> err_t {
         defer = !IsOutboundNetifReadyForUdp(*pktInfo);
         return ERR_OK;
@@ -329,12 +329,12 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
     // If a source address has been specified, temporarily override the local_ip of the PCB.
     // This results in LwIP using the given address being as the source address for the generated
     // packet, as if the PCB had been bound to that address.
-    const IPAddress & srcAddr   = pktInfo->SrcAddress;
-    const uint16_t & destPort    = pktInfo->DestPort;
+    const IPAddress & srcAddr  = pktInfo->SrcAddress;
+    const uint16_t & destPort  = pktInfo->DestPort;
     const InterfaceId & intfId = pktInfo->Interface;
 
-    ip_addr_t lwipSrcAddr   = srcAddr.ToLwIPAddr();
-    ip_addr_t lwipDestAddr  = destAddr.ToLwIPAddr();
+    ip_addr_t lwipSrcAddr  = srcAddr.ToLwIPAddr();
+    ip_addr_t lwipDestAddr = destAddr.ToLwIPAddr();
     ip_addr_t boundAddr;
 
     ip_addr_copy(boundAddr, mUDP->local_ip);
@@ -394,7 +394,7 @@ void UDPEndPointImplLwIP::FlushDeferredSendQueue()
         DeferredUdpSlot slot = std::move(pending.front());
         pending.pop_front();
 
-        bool ready         = false;
+        bool ready     = false;
         err_t probeErr = RunOnTCPIPRet([&]() -> err_t {
             ready = IsOutboundNetifReadyForUdp(slot.pktInfo);
             return ERR_OK;

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -166,7 +166,7 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
 
 #if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     // Defer if the netif is not ready for this destination; otherwise drain earlier deferrals first.
-    bool shouldDefer = false;
+    bool shouldDefer         = false;
     CHIP_ERROR deferProbeErr = DeferredUdpSendQueueLwIP::ProbeDefer(*pktInfo, shouldDefer);
     VerifyOrReturnError(deferProbeErr == CHIP_NO_ERROR, deferProbeErr);
     if (shouldDefer)
@@ -191,9 +191,9 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
     // If a source address has been specified, temporarily override the local_ip of the PCB.
     // This results in LwIP using the given address being as the source address for the generated
     // packet, as if the PCB had been bound to that address.
-    const IPAddress &     srcAddr  = pktInfo->SrcAddress;
-    const uint16_t &      destPort = pktInfo->DestPort;
-    const InterfaceId &   intfId   = pktInfo->Interface;
+    const IPAddress & srcAddr  = pktInfo->SrcAddress;
+    const uint16_t & destPort  = pktInfo->DestPort;
+    const InterfaceId & intfId = pktInfo->Interface;
 
     ip_addr_t lwipSrcAddr  = srcAddr.ToLwIPAddr();
     ip_addr_t lwipDestAddr = destAddr.ToLwIPAddr();

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -154,7 +154,10 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
         VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_NO_MEMORY);
     }
 
-    CHIP_ERROR res = GetPCB(destAddr.Type());
+    CHIP_ERROR res = CHIP_NO_ERROR;
+
+    // Make sure we have the appropriate type of PCB based on the destination address.
+    res = GetPCB(destAddr.Type());
     if (res != CHIP_NO_ERROR)
     {
         return res;
@@ -179,6 +182,7 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
 {
     assertChipStackLockedByCurrentThread();
 
+    err_t lwipErr = ERR_OK;
     const IPAddress & destAddr = pktInfo->DestAddress;
 
     // Send the message to the specified address/port.
@@ -202,7 +206,7 @@ CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo,
         ip_addr_copy(mUDP->local_ip, lwipSrcAddr);
     }
 
-    err_t lwipErr = RunOnTCPIPRet([this, &intfId, &msg, &lwipDestAddr, destPort]() {
+    lwipErr = RunOnTCPIPRet([this, &intfId, &msg, &lwipDestAddr, destPort]() {
         if (intfId.IsPresent())
         {
             return udp_sendto_if(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort,

--- a/src/inet/UDPEndPointImplLwIP.h
+++ b/src/inet/UDPEndPointImplLwIP.h
@@ -30,13 +30,13 @@
 namespace chip {
 namespace Inet {
 
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 class DeferredUdpSendQueueLwIP;
 #endif
 
 class UDPEndPointImplLwIP : public UDPEndPoint, public EndPointStateLwIP
 {
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     friend class DeferredUdpSendQueueLwIP;
 #endif
 
@@ -81,7 +81,7 @@ private:
     void CloseImpl() override;
 
     CHIP_ERROR PerformLwIPUdpSend(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
-#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     CHIP_ERROR FlushOneDeferred(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
 #endif
 

--- a/src/inet/UDPEndPointImplLwIP.h
+++ b/src/inet/UDPEndPointImplLwIP.h
@@ -30,65 +30,76 @@
 namespace chip {
 namespace Inet {
 
-class UDPEndPointImplLwIP : public UDPEndPoint, public EndPointStateLwIP
-{
-public:
-    UDPEndPointImplLwIP(EndPointManager<UDPEndPoint> & endPointManager) : UDPEndPoint(endPointManager), mUDP(nullptr) {}
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    class DeferredUdpSendQueueLwIP;
+#endif
 
-    // UDPEndPoint overrides.
-    CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback) override;
-    InterfaceId GetBoundInterface() const override;
-    uint16_t GetBoundPort() const override;
+    class UDPEndPointImplLwIP : public UDPEndPoint, public EndPointStateLwIP {
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+        friend class DeferredUdpSendQueueLwIP;
+#endif
 
-    /**
-     * @brief Set the queue filter for all UDP endpoints
-     *
-     * Responsibility is on the caller to avoid changing the filter while packets are being
-     * processed. Setting the queue filter to `nullptr` disables the filtering.
-     *
-     * NOTE: There is only one EndpointQueueFilter instance settable. However it's possible
-     *       to create an instance of EndpointQueueFilter that combines several other
-     *       EndpointQueueFilter by composition to achieve the effect of multiple filters.
-     *
-     * @param queueFilter - queue filter instance to set, owned by caller
-     */
-    static void SetQueueFilter(EndpointQueueFilter * queueFilter) { sQueueFilter = queueFilter; }
+    public:
+        UDPEndPointImplLwIP(EndPointManager<UDPEndPoint> & endPointManager)
+            : UDPEndPoint(endPointManager)
+            , mUDP(nullptr)
+        {
+        }
 
-    /**
-     * Drain outbound UDP datagrams deferred while no operational LwIP netif was available.
-     * Must be called on the Matter chip thread. Safe to call when deferral is disabled (no-op).
-     */
-    static void FlushDeferredSendQueue();
+        // UDPEndPoint overrides.
+        CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback) override;
+        InterfaceId GetBoundInterface() const override;
+        uint16_t GetBoundPort() const override;
 
-private:
-    // UDPEndPoint overrides.
+        /**
+         * @brief Set the queue filter for all UDP endpoints
+         *
+         * Responsibility is on the caller to avoid changing the filter while packets are being
+         * processed. Setting the queue filter to `nullptr` disables the filtering.
+         *
+         * NOTE: There is only one EndpointQueueFilter instance settable. However it's possible
+         *       to create an instance of EndpointQueueFilter that combines several other
+         *       EndpointQueueFilter by composition to achieve the effect of multiple filters.
+         *
+         * @param queueFilter - queue filter instance to set, owned by caller
+         */
+        static void SetQueueFilter(EndpointQueueFilter * queueFilter) { sQueueFilter = queueFilter; }
+
+        /**
+         * Drain outbound UDP datagrams deferred while no operational LwIP netif was available.
+         * Must be called on the Matter chip thread. Safe to call when deferral is disabled (no-op).
+         */
+        static void FlushDeferredSendQueue();
+
+    private:
+        // UDPEndPoint overrides.
 #if INET_CONFIG_ENABLE_IPV4
-    CHIP_ERROR IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
+        CHIP_ERROR IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
 #endif // INET_CONFIG_ENABLE_IPV4
-    CHIP_ERROR IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
-    CHIP_ERROR BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port, InterfaceId interfaceId) override;
-    CHIP_ERROR BindInterfaceImpl(IPAddressType addressType, InterfaceId interfaceId) override;
-    CHIP_ERROR ListenImpl() override;
-    CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg) override;
-    void CloseImpl() override;
+        CHIP_ERROR IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
+        CHIP_ERROR BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port, InterfaceId interfaceId) override;
+        CHIP_ERROR BindInterfaceImpl(IPAddressType addressType, InterfaceId interfaceId) override;
+        CHIP_ERROR ListenImpl() override;
+        CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg) override;
+        void CloseImpl() override;
 
-    CHIP_ERROR PerformLwIPUdpSend(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
+        CHIP_ERROR PerformLwIPUdpSend(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
 
-    static struct netif * FindNetifFromInterfaceId(InterfaceId aInterfaceId);
-    static CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId);
+        static struct netif * FindNetifFromInterfaceId(InterfaceId aInterfaceId);
+        static CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId);
 
-    void HandleDataReceived(System::PacketBufferHandle && msg, IPPacketInfo * pktInfo);
+        void HandleDataReceived(System::PacketBufferHandle && msg, IPPacketInfo * pktInfo);
 
-    CHIP_ERROR GetPCB(IPAddressType addrType4);
-    static void LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, const ip_addr_t * addr, u16_t port);
+        CHIP_ERROR GetPCB(IPAddressType addrType4);
+        static void LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, const ip_addr_t * addr, u16_t port);
 
-    udp_pcb * mUDP; // LwIP User datagram protocol (UDP) control block.
-    std::atomic_int mDelayReleaseCount{ 0 };
+        udp_pcb * mUDP; // LwIP User datagram protocol (UDP) control block.
+        std::atomic_int mDelayReleaseCount { 0 };
 
-    static EndpointQueueFilter * sQueueFilter;
-};
+        static EndpointQueueFilter * sQueueFilter;
+    };
 
-using UDPEndPointImpl = UDPEndPointImplLwIP;
+    using UDPEndPointImpl = UDPEndPointImplLwIP;
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/UDPEndPointImplLwIP.h
+++ b/src/inet/UDPEndPointImplLwIP.h
@@ -54,6 +54,12 @@ public:
      */
     static void SetQueueFilter(EndpointQueueFilter * queueFilter) { sQueueFilter = queueFilter; }
 
+    /**
+     * Drain outbound UDP datagrams deferred while no operational LwIP netif was available.
+     * Must be called on the Matter chip thread. Safe to call when deferral is disabled (no-op).
+     */
+    static void FlushDeferredSendQueue();
+
 private:
     // UDPEndPoint overrides.
 #if INET_CONFIG_ENABLE_IPV4
@@ -65,6 +71,8 @@ private:
     CHIP_ERROR ListenImpl() override;
     CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg) override;
     void CloseImpl() override;
+
+    CHIP_ERROR PerformLwIPUdpSend(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
 
     static struct netif * FindNetifFromInterfaceId(InterfaceId aInterfaceId);
     static CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId);

--- a/src/inet/UDPEndPointImplLwIP.h
+++ b/src/inet/UDPEndPointImplLwIP.h
@@ -84,6 +84,9 @@ namespace Inet {
         void CloseImpl() override;
 
         CHIP_ERROR PerformLwIPUdpSend(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+        CHIP_ERROR FlushOneDeferred(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
+#endif
 
         static struct netif * FindNetifFromInterfaceId(InterfaceId aInterfaceId);
         static CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId);

--- a/src/inet/UDPEndPointImplLwIP.h
+++ b/src/inet/UDPEndPointImplLwIP.h
@@ -30,13 +30,13 @@
 namespace chip {
 namespace Inet {
 
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 class DeferredUdpSendQueueLwIP;
 #endif
 
 class UDPEndPointImplLwIP : public UDPEndPoint, public EndPointStateLwIP
 {
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     friend class DeferredUdpSendQueueLwIP;
 #endif
 
@@ -81,7 +81,7 @@ private:
     void CloseImpl() override;
 
     CHIP_ERROR PerformLwIPUdpSend(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
-#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#if SILABS_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
     CHIP_ERROR FlushOneDeferred(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
 #endif
 

--- a/src/inet/UDPEndPointImplLwIP.h
+++ b/src/inet/UDPEndPointImplLwIP.h
@@ -31,78 +31,75 @@ namespace chip {
 namespace Inet {
 
 #if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
-    class DeferredUdpSendQueueLwIP;
+class DeferredUdpSendQueueLwIP;
 #endif
 
-    class UDPEndPointImplLwIP : public UDPEndPoint, public EndPointStateLwIP {
+class UDPEndPointImplLwIP : public UDPEndPoint, public EndPointStateLwIP
+{
 #if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
-        friend class DeferredUdpSendQueueLwIP;
+    friend class DeferredUdpSendQueueLwIP;
 #endif
 
-    public:
-        UDPEndPointImplLwIP(EndPointManager<UDPEndPoint> & endPointManager)
-            : UDPEndPoint(endPointManager)
-            , mUDP(nullptr)
-        {
-        }
+public:
+    UDPEndPointImplLwIP(EndPointManager<UDPEndPoint> & endPointManager) : UDPEndPoint(endPointManager), mUDP(nullptr) {}
 
-        // UDPEndPoint overrides.
-        CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback) override;
-        InterfaceId GetBoundInterface() const override;
-        uint16_t GetBoundPort() const override;
+    // UDPEndPoint overrides.
+    CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback) override;
+    InterfaceId GetBoundInterface() const override;
+    uint16_t GetBoundPort() const override;
 
-        /**
-         * @brief Set the queue filter for all UDP endpoints
-         *
-         * Responsibility is on the caller to avoid changing the filter while packets are being
-         * processed. Setting the queue filter to `nullptr` disables the filtering.
-         *
-         * NOTE: There is only one EndpointQueueFilter instance settable. However it's possible
-         *       to create an instance of EndpointQueueFilter that combines several other
-         *       EndpointQueueFilter by composition to achieve the effect of multiple filters.
-         *
-         * @param queueFilter - queue filter instance to set, owned by caller
-         */
-        static void SetQueueFilter(EndpointQueueFilter * queueFilter) { sQueueFilter = queueFilter; }
+    /**
+     * @brief Set the queue filter for all UDP endpoints
+     *
+     * Responsibility is on the caller to avoid changing the filter while packets are being
+     * processed. Setting the queue filter to `nullptr` disables the filtering.
+     *
+     * NOTE: There is only one EndpointQueueFilter instance settable. However it's possible
+     *       to create an instance of EndpointQueueFilter that combines several other
+     *       EndpointQueueFilter by composition to achieve the effect of multiple filters.
+     *
+     * @param queueFilter - queue filter instance to set, owned by caller
+     */
+    static void SetQueueFilter(EndpointQueueFilter * queueFilter) { sQueueFilter = queueFilter; }
 
-        /**
-         * Drain outbound UDP datagrams deferred while no operational LwIP netif was available.
-         * Must be called on the Matter chip thread. Safe to call when deferral is disabled (no-op).
-         */
-        static void FlushDeferredSendQueue();
+    /**
+     * Drain outbound UDP datagrams deferred while no operational LwIP netif was available.
+     * Must be called on the Matter chip thread. Safe to call when deferral is disabled (no-op).
+     */
+    static void FlushDeferredSendQueue();
 
-    private:
-        // UDPEndPoint overrides.
+private:
+    // UDPEndPoint overrides.
 #if INET_CONFIG_ENABLE_IPV4
-        CHIP_ERROR IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
+    CHIP_ERROR IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
 #endif // INET_CONFIG_ENABLE_IPV4
-        CHIP_ERROR IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
-        CHIP_ERROR BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port, InterfaceId interfaceId) override;
-        CHIP_ERROR BindInterfaceImpl(IPAddressType addressType, InterfaceId interfaceId) override;
-        CHIP_ERROR ListenImpl() override;
-        CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg) override;
-        void CloseImpl() override;
+    CHIP_ERROR IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
+    CHIP_ERROR BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port, InterfaceId interfaceId) override;
+    CHIP_ERROR BindInterfaceImpl(IPAddressType addressType, InterfaceId interfaceId) override;
+    CHIP_ERROR ListenImpl() override;
+    CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg) override;
+    void CloseImpl() override;
 
-        CHIP_ERROR PerformLwIPUdpSend(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
+    CHIP_ERROR PerformLwIPUdpSend(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
 #if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
-        CHIP_ERROR FlushOneDeferred(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
+    CHIP_ERROR FlushOneDeferred(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
 #endif
 
-        static struct netif * FindNetifFromInterfaceId(InterfaceId aInterfaceId);
-        static CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId);
+    static struct netif * FindNetifFromInterfaceId(InterfaceId aInterfaceId);
+    static CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId);
 
-        void HandleDataReceived(System::PacketBufferHandle && msg, IPPacketInfo * pktInfo);
+    void HandleDataReceived(System::PacketBufferHandle && msg, IPPacketInfo * pktInfo);
 
-        CHIP_ERROR GetPCB(IPAddressType addrType4);
-        static void LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, const ip_addr_t * addr, u16_t port);
+    CHIP_ERROR GetPCB(IPAddressType addrType4);
+    static void LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, const ip_addr_t * addr, u16_t port);
 
-        udp_pcb * mUDP; // LwIP User datagram protocol (UDP) control block.
-        std::atomic_int mDelayReleaseCount { 0 };
+    udp_pcb * mUDP; // LwIP User datagram protocol (UDP) control block.
+    std::atomic_int mDelayReleaseCount{ 0 };
 
-        static EndpointQueueFilter * sQueueFilter;
-    };
+    static EndpointQueueFilter * sQueueFilter;
+};
 
-    using UDPEndPointImpl = UDPEndPointImplLwIP;
+using UDPEndPointImpl = UDPEndPointImplLwIP;
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/inet.gni
+++ b/src/inet/inet.gni
@@ -25,10 +25,10 @@ declare_args() {
   chip_inet_config_enable_udp_endpoint = true
 
   # [SL-ONLY]: defer outbound UDP until a netif is link-up (DeferredUdpSendQueueLwIP).
-  silabs_inet_config_udp_lwip_queue_until_netif_ready = false
+  sl_inet_config_udp_lwip_queue_until_netif_ready = false
 
   # [SL-ONLY]: queue size for the UDP DeferredUdpSendQueueLwIP
-  silabs_inet_config_udp_lwip_deferred_send_queue_size = 0
+  sl_inet_config_udp_lwip_deferred_send_queue_size = 0
 
   # Enable TCP endpoint.
   chip_inet_config_enable_tcp_endpoint = true

--- a/src/inet/inet.gni
+++ b/src/inet/inet.gni
@@ -24,6 +24,12 @@ declare_args() {
   # Enable UDP endpoint.
   chip_inet_config_enable_udp_endpoint = true
 
+  # [SL-ONLY]: defer outbound UDP until a netif is link-up (DeferredUdpSendQueueLwIP).
+  silabs_inet_config_udp_lwip_queue_until_netif_ready = false
+
+  # [SL-ONLY]: queue size for the UDP DeferredUdpSendQueueLwIP
+  silabs_inet_config_udp_lwip_deferred_send_queue_size = 0
+
   # Enable TCP endpoint.
   chip_inet_config_enable_tcp_endpoint = true
 

--- a/src/inet/tests/BUILD.gn
+++ b/src/inet/tests/BUILD.gn
@@ -76,6 +76,7 @@ if (chip_build_tests) {
     ]
     test_sources = [
       "TestBasicPacketFilters.cpp",
+      "TestDeferredUdpSendRing.cpp",
       "TestInetAddress.cpp",
       "TestInetErrorStr.cpp",
     ]

--- a/src/inet/tests/TestDeferredUdpSendRing.cpp
+++ b/src/inet/tests/TestDeferredUdpSendRing.cpp
@@ -1,0 +1,138 @@
+/*
+ *
+ *    Copyright (c) 2020-2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * Unit tests for @ref chip::Inet::DeferredUdpSendRing, the FIFO backing
+ * DeferredUdpSendQueueLwIP. LwIP-specific ProbeDefer/Flush behavior is not
+ * covered here.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <inet/DeferredUdpSendRing.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Inet;
+
+struct IntSlot
+{
+    int value = -1;
+    IntSlot() = default;
+    explicit IntSlot(int v) : value(v) {}
+};
+
+using Ring3 = DeferredUdpSendRing<IntSlot, 3>;
+
+TEST(DeferredUdpSendRingTest, StartsEmpty)
+{
+    Ring3 r;
+    EXPECT_TRUE(r.Empty());
+    EXPECT_EQ(r.ActiveCount(), 0u);
+    EXPECT_FALSE(r.IsFull());
+}
+
+TEST(DeferredUdpSendRingTest, PushPopSingle)
+{
+    Ring3 r;
+    r.PushBack(IntSlot{ 42 });
+    EXPECT_FALSE(r.Empty());
+    EXPECT_EQ(r.ActiveCount(), 1u);
+    IntSlot out = r.PopFront();
+    EXPECT_EQ(out.value, 42);
+    EXPECT_TRUE(r.Empty());
+}
+
+TEST(DeferredUdpSendRingTest, FifoOrderUpToCapacity)
+{
+    Ring3 r;
+    r.PushBack(IntSlot{ 1 });
+    r.PushBack(IntSlot{ 2 });
+    r.PushBack(IntSlot{ 3 });
+    EXPECT_TRUE(r.IsFull());
+    EXPECT_EQ(r.ActiveCount(), 3u);
+    EXPECT_EQ(r.PopFront().value, 1);
+    EXPECT_EQ(r.PopFront().value, 2);
+    EXPECT_EQ(r.PopFront().value, 3);
+    EXPECT_TRUE(r.Empty());
+}
+
+TEST(DeferredUdpSendRingTest, OverflowDropsOldest)
+{
+    Ring3 r;
+    r.PushBack(IntSlot{ 1 });
+    r.PushBack(IntSlot{ 2 });
+    r.PushBack(IntSlot{ 3 });
+    r.PushBack(IntSlot{ 4 });
+    EXPECT_TRUE(r.IsFull());
+    EXPECT_EQ(r.ActiveCount(), 3u);
+    EXPECT_EQ(r.PopFront().value, 2);
+    EXPECT_EQ(r.PopFront().value, 3);
+    EXPECT_EQ(r.PopFront().value, 4);
+    EXPECT_TRUE(r.Empty());
+}
+
+TEST(DeferredUdpSendRingTest, RepeatedOverflowKeepsFifo)
+{
+    Ring3 r;
+    for (int i = 0; i < 10; ++i)
+    {
+        r.PushBack(IntSlot{ i });
+    }
+    EXPECT_EQ(r.ActiveCount(), 3u);
+    EXPECT_EQ(r.PopFront().value, 7);
+    EXPECT_EQ(r.PopFront().value, 8);
+    EXPECT_EQ(r.PopFront().value, 9);
+}
+
+TEST(DeferredUdpSendRingTest, SwapExchangesRings)
+{
+    Ring3 a;
+    Ring3 b;
+    a.PushBack(IntSlot{ 1 });
+    a.PushBack(IntSlot{ 2 });
+    b.PushBack(IntSlot{ 9 });
+
+    SwapDeferredUdpSendRings(a, b);
+
+    EXPECT_EQ(a.ActiveCount(), 1u);
+    EXPECT_EQ(b.ActiveCount(), 2u);
+    EXPECT_EQ(a.PopFront().value, 9);
+    EXPECT_EQ(b.PopFront().value, 1);
+    EXPECT_EQ(b.PopFront().value, 2);
+}
+
+TEST(DeferredUdpSendRingTest, SwapEmptyWithFull)
+{
+    Ring3 a;
+    Ring3 b;
+    b.PushBack(IntSlot{ 10 });
+    b.PushBack(IntSlot{ 11 });
+    b.PushBack(IntSlot{ 12 });
+
+    SwapDeferredUdpSendRings(a, b);
+
+    EXPECT_TRUE(b.Empty());
+    EXPECT_EQ(a.ActiveCount(), 3u);
+    EXPECT_EQ(a.PopFront().value, 10);
+    EXPECT_EQ(a.PopFront().value, 11);
+    EXPECT_EQ(a.PopFront().value, 12);
+    EXPECT_TRUE(a.Empty());
+}
+
+} // namespace

--- a/src/inet/tests/TestDeferredUdpSendRing.cpp
+++ b/src/inet/tests/TestDeferredUdpSendRing.cpp
@@ -58,6 +58,19 @@ TEST(DeferredUdpSendRingTest, PushPopSingle)
     EXPECT_TRUE(r.Empty());
 }
 
+// PopFront returns a by-value Slot owned by the caller, not a view into ring
+// storage; it must remain valid after later ring operations.
+TEST(DeferredUdpSendRingTest, PopFrontReturnSurvivesLaterRingUse)
+{
+    Ring3 r;
+    r.PushBack(IntSlot{ 5 });
+    IntSlot first = r.PopFront();
+    r.PushBack(IntSlot{ 6 });
+    EXPECT_EQ(first.value, 5);
+    EXPECT_EQ(r.PopFront().value, 6);
+    EXPECT_TRUE(r.Empty());
+}
+
 TEST(DeferredUdpSendRingTest, FifoOrderUpToCapacity)
 {
     Ring3 r;


### PR DESCRIPTION
#### Summary
For the LIT device we are trying to disconnect from the AP and reconnect when we want to send any attribute update or while reporting data of subscription.
For the reporting data, that will be on the idle mode duration we can connect a bit early i.e., a part of different PR. but while posting attribute change the matter stack sends the packet unaware about the low layer transport is offline. 

To fix this, we are buffering the packets on the LwIP layer and flushing them once we are reconnected.
This have CSA code modification of the UDPEndpointLwIPImpl.cpp and .h files but it won't affect/conflicts in the future since the changes are moved a different file all together.

Unit test is added for the Queue impl to ensure we don't see any issues

#### Related issues
NA

#### Testing
Tested with 917SoC
