### PR TITLE
[SL-UP] Updated GetMotionLockStatus Logic

### DIFF
--- a/src/app/clusters/window-covering-server/WindowCoveringCluster.cpp
+++ b/src/app/clusters/window-covering-server/WindowCoveringCluster.cpp
@@ -588,19 +588,15 @@ Status GetMotionLockStatus(chip::EndpointId endpoint)
     BitMask<ConfigStatus> configStatus = ConfigStatusGet(endpoint);
 
     // Is the device locked?
-    if (!configStatus.Has(ConfigStatus::kOperational))
+    if (mode.Has(Mode::kMaintenanceMode))
     {
-        if (mode.Has(Mode::kMaintenanceMode))
-        {
-            // Mainterance Mode
-            return Status::Busy;
-        }
-
-        if (mode.Has(Mode::kCalibrationMode))
-        {
-            // Calibration Mode
-            return Status::Failure;
-        }
+        // Mainterance Mode
+        return Status::Busy;
+    }
+    if (mode.Has(Mode::kCalibrationMode))
+    {
+        // Calibration Mode
+        return Status::Failure;
     }
 
     return Status::Success;

--- a/src/app/clusters/window-covering-server/WindowCoveringCluster.cpp
+++ b/src/app/clusters/window-covering-server/WindowCoveringCluster.cpp
@@ -585,7 +585,6 @@ void PostAttributeChange(chip::EndpointId endpoint, chip::AttributeId attributeI
 Status GetMotionLockStatus(chip::EndpointId endpoint)
 {
     BitMask<Mode> mode                 = ModeGet(endpoint);
-    BitMask<ConfigStatus> configStatus = ConfigStatusGet(endpoint);
 
     // Is the device locked?
     if (mode.Has(Mode::kMaintenanceMode))


### PR DESCRIPTION
#### Summary
*This PR is only created for internal review*
The current logic for GetMotionLockStatus first checks the kOperational in ConfigStatus first and then checks the Mode. Following the Matter Specs -
> While in maintenance mode, all commands (e.g: UpOrOpen, DownOrClose, GoTos) or local inputs that can result in movement, must be ignored and respond with a BUSY status. Additionally, the Operational bit of the ConfigStatus attribute should be set to its not operational value.

We're making sure that the ModeSet internally calls the ConfigStatusSet
```cpp
    if (oldMode != newMode)
        Attributes::Mode::Set(endpoint, newMode);

    if (oldStatus != newStatus)
        ConfigStatusSet(endpoint, newStatus);
```

So it's not necessary to check the kOperational in ConfigStatus first in GetMotionLockStatus.

#### Related issues
N/A

#### Testing
- Tested locally with CSA test scripts. The test cases were passing.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
