### PR TITLE
[SL-UP] Correcting the include file for the application_properties.h

### DIFF
--- a/examples/platform/silabs/OTAConfig.cpp
+++ b/examples/platform/silabs/OTAConfig.cpp
@@ -22,7 +22,7 @@
 
 #ifndef SLI_SI91X_MCU_INTERFACE
 
-#include "application_properties.h"
+#include "api/application_properties.h"
 
 #if defined(SL_COMPONENT_CATALOG_PRESENT)
 #include "sl_component_catalog.h"


### PR DESCRIPTION
#### Summary
In OTAConfig.cpp, the include file is for the application_properties.h which is in the folder bootloader/platform/bootloader/api/application_properties.h

The component which is used to include this is https://github.com/SiliconLabsSoftware/sisdk-prerelease/blob/sisdk-2026.6/bootloader/platform/bootloader/component/bootloader_application_properties_header.slcc
Earlier it was working since the path for include was coming via some other components, but with the build 543 for series 3 it is not building anymore. 
Correcting the path so that it utilizes the correct include path for both Series 2 and Series 3

#### Related issues
NA

#### Testing
Local build test and CI