### PR TITLE
[SL-UP] Bugfix: Group iterator release.

### DIFF
--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -525,7 +525,11 @@ Status GroupcastCluster::LeaveGroup(const Groupcast::Commands::LeaveGroup::Decod
         // Apply changes to all groups
         GroupInfoIterator * iter = groups.IterateGroupInfo(fabricIndex);
         VerifyOrReturnError(nullptr != iter, Status::ResourceExhausted);
-        VerifyOrReturnError(iter->Count() > 0, Status::NotFound);
+        if (iter->Count() == 0)
+        {
+            iter->Release();
+            return Status::NotFound;
+        }
 
         GroupInfo info;
         while (iter->Next(info) && (Status::Success == err))

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -44,6 +44,7 @@
 #include <crypto/PersistentStorageOperationalKeystore.h>
 #include <inet/InetConfig.h>
 #include <lib/core/CHIPConfig.h>
+#include <lib/support/AutoRelease.h>
 #include <lib/support/SafeInt.h>
 #include <messaging/ExchangeMgr.h>
 #include <platform/DefaultTimerDelegate.h>
@@ -590,15 +591,11 @@ private:
                     Credentials::GroupDataProvider::GroupInfo group;
                     for (const FabricInfo & fabric : mServer->GetFabricTable())
                     {
-                        auto * iter = provider->IterateGroupInfo(fabric.GetFabricIndex());
-                        if (iter)
+                        chip::AutoRelease iter(provider->IterateGroupInfo(fabric.GetFabricIndex()));
+                        while (!iter.IsNull() && iter->Next(group) && !in_use)
                         {
-                            while (iter->Next(group) && !in_use)
-                            {
-                                in_use = !group.UsePerGroupAddress();
-                            }
+                            in_use = !group.UsePerGroupAddress();
                         }
-                        iter->Release();
                         if (in_use)
                             break;
                     }


### PR DESCRIPTION
#### Summary

The group iterator if not released when iter->Count() > 0, causing a resource depletion, which in turn manifests as an invalid call of a null pointer as `iter->Release()`.

Duplicates [CSA PR#71918](https://github.com/project-chip/connectedhomeip/pull/71918).

#### Related issues

Fixes [MATTER-6270](https://jira.silabs.com/browse/MATTER-6270).

#### Testing

* TestGroupcastCluster
* TestGroupDataProvider
* TestGroupKeyManagementCluster
* TestGroupMessageCounter
* TestGroupOperationalCredentials
* TestGroupsCluster

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
