### PR TITLE
[SL-TEMP]Add to the Matter BLE advertissement handle in the ble info …

### DIFF
--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -198,7 +198,8 @@ uint16_t BLEManagerImpl::_NumConnections(void)
 
 CHIP_ERROR BLEManagerImpl::PrintBLEInfo() const
 {
-    ChipLogProgress(DeviceLayer, "BLE Info:");
+    ChipLogProgress(DeviceLayer, "Matter BLE Info:");
+    ChipLogProgress(DeviceLayer, "  Handle: %d", mAdvertisingSetHandle);
     ChipLogProgress(DeviceLayer, "  Service Mode: %d", mServiceMode);
     ChipLogProgress(DeviceLayer, "  Device Name: %s", mDeviceName);
     ChipLogProgress(DeviceLayer, "  Random Static Address: %02X:%02X:%02X:%02X:%02X:%02X", randomizedAddr.addr[5],


### PR DESCRIPTION
This PR is a cherry-pick of a SL-TEMP from 2.8.1 to fix
[MATTER-6342](https://jira.silabs.com/browse/MATTER-6342)

Zigbee team didn't yet implement a way for SQA to retrieve their BLE adv handles, so we re-apply our temp fix to allow SQA to determine the handle to use by reciprocality from ours.

#### Summary
`sl_bt_advertiser_create_set` provides an handle value incrementally for every Advertisement set created.
plugin cli command used during SQA test rely on the Adv handle to reconfigure or test some BLE functionality.

In the case of our Matter Zigbee CMP ble dmp test, multiple ble advertisement are created in the zigbee stack.
There is some init sequence non-deterministic) timing when logging is enabled that can influence the order in of the advertisement set creation and thus their handle value.

To facilitate SQA debug with cli command. add a line in the ble-side info command print that indicates the Matter BLE adv handle value.

#### Related issues
[MATTER-6135](https://jira.silabs.com/browse/MATTER-6135)

#### Testing
manually tested the CLI command 
When Matter BLE Advertissement set is created first.
```
matterCli> ble-side info
[00:00:44.176][info  ][DL] Matter BLE Info:
[00:00:44.176][info  ][DL]   Handle: 0
[00:00:44.176][info  ][DL]   Service Mode: 1
[00:00:44.176][info  ][DL]   Device Name: SL-CMP-Light-Conc
[00:00:44.177][info  ][DL]   Random Static Address: C2:89:A5:A3:A8:11
Done
```

With multiple ADV set created before the Matter BLE
```
[00:00:09.852][info  ][DL] Matter BLE Info:
[00:00:09.852][info  ][DL]   Handle: 3
[00:00:09.852][info  ][DL]   Service Mode: 1
[00:00:09.852][info  ][DL]   Device Name: SL-CMP-Light-Conc
[00:00:09.853][info  ][DL]   Random Static Address: CD:75:90:5D:D3:0A
```