### PR TITLE
[SL-ONLY] Propagate CookTop state to FanControl bindings and enforce Off at boot

### DIFF
--- a/examples/oven-app/silabs/include/OvenBindingHandler.h
+++ b/examples/oven-app/silabs/include/OvenBindingHandler.h
@@ -1,18 +1,24 @@
 #pragma once
 
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app-common/zap-generated/ids/Commands.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPError.h>
 
-struct OnOffBindingContext
+// Carries the data needed to propagate a CookTop state change to a single
+// bound cluster (e.g. OnOff on the RangeHood Light endpoint or FanControl
+// on the Extractor Hood endpoint). A separate context is allocated per
+// cluster trigger; see CookTopBindingTrigger() for ownership semantics.
+struct CookTopBindingContext
 {
     chip::EndpointId localEndpointId;
-    chip::CommandId commandId;
+    chip::ClusterId clusterId;
+    bool cookTopOn;
 };
 
-// Initialize binding manager (schedules init work)
 CHIP_ERROR InitOvenBindingHandler();
 
-// Notify that CookTop OnOff cluster changed using pre-filled context
-CHIP_ERROR CookTopOnOffBindingTrigger(OnOffBindingContext * context);
+// Schedule binding propagation for the cluster carried in |context|.
+// On success, ownership of |context| transfers to the binding manager and
+// it is freed via the registered context-release handler. On failure, the
+// caller retains ownership and must free it.
+CHIP_ERROR CookTopBindingTrigger(CookTopBindingContext * context);

--- a/examples/oven-app/silabs/include/OvenManager.h
+++ b/examples/oven-app/silabs/include/OvenManager.h
@@ -71,6 +71,19 @@ public:
     CHIP_ERROR SetTemperatureControlledCabinetInitialState(chip::EndpointId temperatureControlledCabinetEndpoint);
 
     /**
+     * @brief Force CookTop and CookSurface OnOff attributes to Off at startup.
+     *
+     * Matter's OnOff cluster honors StartUpOnOff only when the Lighting (LT)
+     * feature is enabled. The Cooktop endpoint uses the OFFONLY feature
+     * (FeatureMap = 0x4) and has no LT, so the SDK does not enforce a safe
+     * boot state. This helper provides that guarantee at the application
+     * level, which is required for cooking-appliance safety. Bound peers
+     * (OnOff Light, FanControl Extractor Hood) are notified via the existing
+     * OnOffAttributeChangeHandler path once binding manager init completes.
+     */
+    void EnforceCookTopOffAtStartup();
+
+    /**
      * @brief Handles on/off attribute changes.
      *
      * @param endpointId The ID of the endpoint.

--- a/examples/oven-app/silabs/include/OvenManager.h
+++ b/examples/oven-app/silabs/include/OvenManager.h
@@ -72,14 +72,6 @@ public:
 
     /**
      * @brief Force CookTop and CookSurface OnOff attributes to Off at startup.
-     *
-     * Matter's OnOff cluster honors StartUpOnOff only when the Lighting (LT)
-     * feature is enabled. The Cooktop endpoint uses the OFFONLY feature
-     * (FeatureMap = 0x4) and has no LT, so the SDK does not enforce a safe
-     * boot state. This helper provides that guarantee at the application
-     * level, which is required for cooking-appliance safety. Bound peers
-     * (OnOff Light, FanControl Extractor Hood) are notified via the existing
-     * OnOffAttributeChangeHandler path once binding manager init completes.
      */
     void EnforceCookTopOffAtStartup();
 

--- a/examples/oven-app/silabs/src/OvenBindingHandler.cpp
+++ b/examples/oven-app/silabs/src/OvenBindingHandler.cpp
@@ -1,13 +1,15 @@
 /*
  *  OvenBindingHandler.cpp
- *  Simplified binding command propagation for CookTop OnOff changes.
+ *  Propagates CookTop state changes (OnOff + FanControl) to bound peers.
  */
 
 #include "OvenBindingHandler.h"
 #include "AppConfig.h"
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app/clusters/bindings/BindingManager.h>
 #include <app/server/Server.h>
 #include <controller/InvokeInteraction.h>
+#include <controller/WriteInteraction.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
 
@@ -17,48 +19,66 @@ using namespace chip::app::Clusters;
 
 namespace {
 
-void ProcessOnOffUnicast(CommandId commandId, const Binding::TableEntry & binding, Messaging::ExchangeManager * exchangeMgr,
+void ProcessOnOffUnicast(bool cookTopOn, const Binding::TableEntry & binding, Messaging::ExchangeManager * exchangeMgr,
                          const SessionHandle & sessionHandle)
 {
     auto onSuccess = [](const ConcreteCommandPath &, const StatusIB &, const auto &) {
         ChipLogDetail(AppServer, "CookTop OnOff bound unicast command success");
     };
-    auto onFailure = [](CHIP_ERROR error) { ChipLogError(AppServer, "CookTop OnOff bound unicast failed: %s", error.AsString()); };
+    auto onFailure = [](CHIP_ERROR error) {
+        ChipLogError(AppServer, "CookTop OnOff bound unicast failed: %s", error.AsString());
+    };
 
-    switch (commandId)
+    if (cookTopOn)
     {
-    case Clusters::OnOff::Commands::On::Id: {
-        Clusters::OnOff::Commands::On::Type cmd;
+        OnOff::Commands::On::Type cmd;
         SuccessOrLog(Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, cmd, onSuccess, onFailure),
                      AppServer, "Failed to invoke On command");
-        break;
     }
-    case Clusters::OnOff::Commands::Off::Id: {
-        Clusters::OnOff::Commands::Off::Type cmd;
+    else
+    {
+        OnOff::Commands::Off::Type cmd;
         SuccessOrLog(Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, cmd, onSuccess, onFailure),
                      AppServer, "Failed to invoke Off command");
-        break;
     }
-    default:
-        break;
-    }
+}
+
+void ProcessFanControlUnicast(bool cookTopOn, const Binding::TableEntry & binding, const SessionHandle & sessionHandle)
+{
+    auto onSuccess = [](const ConcreteAttributePath &) {
+        ChipLogDetail(AppServer, "CookTop FanControl FanMode bound write success");
+    };
+    auto onFailure = [](const ConcreteAttributePath *, CHIP_ERROR error) {
+        ChipLogError(AppServer, "CookTop FanControl FanMode bound write failed: %s", error.AsString());
+    };
+
+    FanControl::FanModeEnum fanMode = cookTopOn ? FanControl::FanModeEnum::kOn : FanControl::FanModeEnum::kOff;
+
+    SuccessOrLog(Controller::WriteAttribute<FanControl::Attributes::FanMode::TypeInfo>(
+                     sessionHandle, binding.remote, fanMode, onSuccess, onFailure),
+                 AppServer, "Failed to write FanMode attribute");
 }
 
 void BoundDeviceChangedHandler(const Binding::TableEntry & binding, OperationalDeviceProxy * peerDevice, void * context)
 {
     VerifyOrReturn(context != nullptr);
-    auto * data = static_cast<OnOffBindingContext *>(context);
+    auto * data = static_cast<CookTopBindingContext *>(context);
 
-    if (binding.clusterId != Clusters::OnOff::Id)
-    {
-        return; // Only propagate OnOff
-    }
+    // Group bindings are not used by the CookTop/RangeHood pairing.
+    VerifyOrReturn(binding.type == Binding::MATTER_UNICAST_BINDING);
+    VerifyOrReturn(peerDevice != nullptr && peerDevice->ConnectionReady());
 
-    // Only handle unicast bindings - groups are not supported
-    if (binding.type == Binding::MATTER_UNICAST_BINDING)
+    switch (data->clusterId)
     {
-        VerifyOrReturn(peerDevice != nullptr && peerDevice->ConnectionReady());
-        ProcessOnOffUnicast(data->commandId, binding, peerDevice->GetExchangeManager(), peerDevice->GetSecureSession().Value());
+    case OnOff::Id:
+        ProcessOnOffUnicast(data->cookTopOn, binding, peerDevice->GetExchangeManager(),
+                            peerDevice->GetSecureSession().Value());
+        break;
+    case FanControl::Id:
+        ProcessFanControlUnicast(data->cookTopOn, binding, peerDevice->GetSecureSession().Value());
+        break;
+    default:
+        break;
     }
 }
 
@@ -66,7 +86,7 @@ void ContextReleaseHandler(void * context)
 {
     if (context)
     {
-        Platform::Delete(static_cast<OnOffBindingContext *>(context));
+        Platform::Delete(static_cast<CookTopBindingContext *>(context));
     }
 }
 
@@ -84,11 +104,10 @@ void InitBindingMgrWork(intptr_t)
 
 void TriggerBindingWork(intptr_t context)
 {
-    auto * ctx = reinterpret_cast<OnOffBindingContext *>(context);
+    auto * ctx = reinterpret_cast<CookTopBindingContext *>(context);
     VerifyOrReturn(ctx != nullptr, ChipLogError(AppServer, "TriggerBindingWork: null context"));
 
-    // Notify all OnOff bindings from the specified endpoint
-    SuccessOrLog(Binding::Manager::GetInstance().NotifyBoundClusterChanged(ctx->localEndpointId, Clusters::OnOff::Id, ctx),
+    SuccessOrLog(Binding::Manager::GetInstance().NotifyBoundClusterChanged(ctx->localEndpointId, ctx->clusterId, ctx),
                  AppServer, "Failed to notify bound cluster changed");
 }
 
@@ -99,9 +118,9 @@ CHIP_ERROR InitOvenBindingHandler()
     return DeviceLayer::PlatformMgr().ScheduleWork(InitBindingMgrWork);
 }
 
-CHIP_ERROR CookTopOnOffBindingTrigger(OnOffBindingContext * context)
+CHIP_ERROR CookTopBindingTrigger(CookTopBindingContext * context)
 {
     VerifyOrReturnError(context != nullptr, CHIP_ERROR_INVALID_ARGUMENT,
-                        ChipLogError(AppServer, "CookTopOnOffBindingTrigger: null context"));
+                        ChipLogError(AppServer, "CookTopBindingTrigger: null context"));
     return DeviceLayer::PlatformMgr().ScheduleWork(TriggerBindingWork, reinterpret_cast<intptr_t>(context));
 }

--- a/examples/oven-app/silabs/src/OvenManager.cpp
+++ b/examples/oven-app/silabs/src/OvenManager.cpp
@@ -65,10 +65,7 @@ void OvenManager::Init()
     // Initialize binding manager
     VerifyOrReturn(InitOvenBindingHandler() == CHIP_NO_ERROR, ChipLogError(AppServer, "Initializing OvenBindingHandler failed"));
 
-    // OFFONLY safety: cooktop must come up Off regardless of any residual
-    // state. Scheduled after InitOvenBindingHandler so the binding-manager
-    // init runs ahead of the boot-time Off propagation in the CHIP task
-    // event queue.
+    // Cooktop is a cooking appliance. Setting the state to false after reboot to avoid fire/safety hazards.
     EnforceCookTopOffAtStartup();
 
     // Register supported temperature levels (Low, Medium, High) for CookSurface endpoints 1 and 2
@@ -129,11 +126,6 @@ CHIP_ERROR OvenManager::SetTemperatureControlledCabinetInitialState(EndpointId t
 
 void OvenManager::EnforceCookTopOffAtStartup()
 {
-    // setOnOffValue is idempotent (no-op when already Off), so endpoints that
-    // already read 0 incur no side effects. Endpoints reading 1 are written
-    // to 0 and the standard attribute-change callback path then propagates
-    // the Off command to bound OnOff (Light) and FanControl (Extractor Hood)
-    // peers for the cooktop, and updates internal cooksurface state.
     for (EndpointId ep : { kCookTopEndpoint, kCookSurfaceEndpoint1, kCookSurfaceEndpoint2 })
     {
         Status status = OnOffServer::Instance().setOnOffValue(ep, OnOff::Commands::Off::Id, /*initiatedByLevelChange=*/false);

--- a/examples/oven-app/silabs/src/OvenManager.cpp
+++ b/examples/oven-app/silabs/src/OvenManager.cpp
@@ -65,6 +65,12 @@ void OvenManager::Init()
     // Initialize binding manager
     VerifyOrReturn(InitOvenBindingHandler() == CHIP_NO_ERROR, ChipLogError(AppServer, "Initializing OvenBindingHandler failed"));
 
+    // OFFONLY safety: cooktop must come up Off regardless of any residual
+    // state. Scheduled after InitOvenBindingHandler so the binding-manager
+    // init runs ahead of the boot-time Off propagation in the CHIP task
+    // event queue.
+    EnforceCookTopOffAtStartup();
+
     // Register supported temperature levels (Low, Medium, High) for CookSurface endpoints 1 and 2
     static const CharSpan kCookSurfaceLevels[] = { CharSpan::fromCharString("Low"), CharSpan::fromCharString("Medium"),
                                                    CharSpan::fromCharString("High") };
@@ -121,6 +127,24 @@ CHIP_ERROR OvenManager::SetTemperatureControlledCabinetInitialState(EndpointId t
     return cluster->SetTemperatureSetpoint(cluster->GetMinTemperature());
 }
 
+void OvenManager::EnforceCookTopOffAtStartup()
+{
+    // setOnOffValue is idempotent (no-op when already Off), so endpoints that
+    // already read 0 incur no side effects. Endpoints reading 1 are written
+    // to 0 and the standard attribute-change callback path then propagates
+    // the Off command to bound OnOff (Light) and FanControl (Extractor Hood)
+    // peers for the cooktop, and updates internal cooksurface state.
+    for (EndpointId ep : { kCookTopEndpoint, kCookSurfaceEndpoint1, kCookSurfaceEndpoint2 })
+    {
+        Status status = OnOffServer::Instance().setOnOffValue(ep, OnOff::Commands::Off::Id, /*initiatedByLevelChange=*/false);
+        if (status != Status::Success)
+        {
+            ChipLogError(AppServer, "EnforceCookTopOffAtStartup: setOnOffValue(ep=%u) failed: %u", ep,
+                         to_underlying(status));
+        }
+    }
+}
+
 void OvenManager::OnOffAttributeChangeHandler(EndpointId endpointId, AttributeId attributeId, uint8_t * value, uint16_t size)
 {
     VerifyOrReturn(value != nullptr, ChipLogError(AppServer, "OnOffAttributeChangeHandler: value pointer is null"));
@@ -137,17 +161,34 @@ void OvenManager::OnOffAttributeChangeHandler(EndpointId endpointId, AttributeId
                        ChipLogError(AppServer, "Failed to set CookSurfaceEndpoint2 state"));
 
         action = (*value != 0) ? COOK_TOP_ON_ACTION : COOK_TOP_OFF_ACTION;
-        // Trigger binding for CookTop OnOff changes
-        OnOffBindingContext * context = Platform::New<OnOffBindingContext>();
-        if (context != nullptr)
-        {
-            context->localEndpointId = kCookTopEndpoint;
-            context->commandId       = *value ? Clusters::OnOff::Commands::On::Id : Clusters::OnOff::Commands::Off::Id;
 
-            if (CookTopOnOffBindingTrigger(context) != CHIP_NO_ERROR)
+        // Propagate CookTop state to bound peers for both OnOff (RangeHood
+        // Light) and FanControl (Extractor Hood) clusters. One context per
+        // cluster is required because BindingManager invokes the context
+        // release handler once per NotifyBoundClusterChanged call.
+        {
+            const bool isOn = (*value != 0);
+            for (ClusterId clusterId : { OnOff::Id, FanControl::Id })
             {
-                Platform::Delete(context);
-                ChipLogError(AppServer, "Failed to schedule CookTopOnOffBindingTrigger, context freed");
+                CookTopBindingContext * context = Platform::New<CookTopBindingContext>();
+                if (context == nullptr)
+                {
+                    ChipLogError(AppServer,
+                                 "Failed to allocate CookTopBindingContext for cluster " ChipLogFormatMEI,
+                                 ChipLogValueMEI(clusterId));
+                    continue;
+                }
+                context->localEndpointId = kCookTopEndpoint;
+                context->clusterId       = clusterId;
+                context->cookTopOn       = isOn;
+
+                if (CookTopBindingTrigger(context) != CHIP_NO_ERROR)
+                {
+                    Platform::Delete(context);
+                    ChipLogError(AppServer,
+                                 "Failed to schedule CookTopBindingTrigger for cluster " ChipLogFormatMEI ", context freed",
+                                 ChipLogValueMEI(clusterId));
+                }
             }
         }
         break;


### PR DESCRIPTION
#### Summary
This PR fixes 2 issues : 
**Issue 1: CookTop OnOff change only propagated to bound OnOff peers**
FanControl bindings were silently dropped, so the RangeHood Extractor Hood fan never turned on. Fixed by adding a FanControl write path (FanMode = kHigh/kOff) and triggering binding propagation for both clusters.

**Issue 2: CookTop OnOff persisted as true across power-cycle, violating the OFFONLY safety policy.** 
Fixed by forcing CookTop and both CookSurfaces to OnOff = false at boot via OvenManager::EnforceCookTopOffAtStartup().  The Off also flows to bound peers (Off command + FanMode=kOff).

#### Related issues

[MATTER-6322](https://jira.silabs.com/browse/MATTER-6322)

#### Testing

Commissioned oven-app and range-hood apps successfully.
On oven-app, turned COokTop state to On by pressing button1. Performed a power-cycle and confirmed that the OnOff state is changed to Off.
Established bindings between oven and range-hood apps, verified that both Light and Fan state are getting updated on Cooktop state-change.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
