### PR TITLE
[SL-UP] : Fix light switch app compile issues

### DIFF
--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -435,7 +435,8 @@ void AppTask::ProcessOnOffBindingCommand(CommandId commandId, const Binding::Tab
     {
         VerifyOrDie(peer_device->ConnectionReady());
         Messaging::ExchangeManager * exchangeMgr = peer_device->GetExchangeManager();
-        const SessionHandle & sessionHandle      = peer_device->GetSecureSession().Value();
+        auto optionalSession                     = peer_device->GetSecureSession();
+        const SessionHandle & sessionHandle      = optionalSession.Value();
 
         switch (commandId)
         {


### PR DESCRIPTION
#### Summary

Problem:
peer_device->GetSecureSession() returns an Optional<SessionHandle> by value. Calling .Value() on that rvalue gives a reference into the temporary optional. Storing that in const SessionHandle & sessionHandle leaves a reference to storage that is gone after the initializer, which triggers -Wdangling-reference / -Wdangling-pointer with -Werror

Failure ref; https://github.com/SiliconLabsSoftware/matter_sdk/pull/965#issue-4483331281 

Somehow only fails on release branch and not on the main branch, need to investigate

Solution
Hold the optional in a local so the SessionHandle stays valid for the whole block:


#### Related issues



#### Testing

Compilation locally


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
