### PR TITLE
[SL-UP] Fix build failure when Si0721 sensor is enabled on non-ICD apps.

### DIFF
--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -70,8 +70,8 @@ uint8_t ledPinArray[SL_LED_COUNT] = { SL_LED_LED0_PIN, SL_LED_LED1_PIN };
 #endif // (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED)
 #endif // ENABLE_WSTK_LEDS
 
-#if SL_ICD_ENABLED
 #include "sl_si91x_driver_gpio.h"
+#if SL_ICD_ENABLED
 #include "sl_si91x_power_manager.h"
 #endif // SL_ICD_ENABLED
 }


### PR DESCRIPTION
#### Summary

Build failure is seen with thermostat app with Si70xx sensor support enabled. This issue is seen because the sl_si91x_driver_gpio.h header file is included only for ICD apps. Si70xx Sensor calls GPIO APIs declared in this header. But, this header is not being included for EVSE app builds as the ICD component is missing

#### Related issues

N/A

#### Testing

Tested thermostat app build in matter_extension and matter_sdk with si70xx sensor support added. Verified that the build error is resolved.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
