### PR TITLE
[SL-UP] Light switch duplication cleanup 

### DIFF
--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -383,38 +383,32 @@ void AppTask::GenericSwitchWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "GenericSwitchWorkerFunction - Invalid work"));
 
     GenericSwitchEventData * data = reinterpret_cast<GenericSwitchEventData *>(context);
+    auto switchCluster              = Clusters::Switch::FindClusterOnEndpoint(data->endpoint);
 
-    switch (data->event)
+    if (switchCluster != nullptr)
     {
-    case Switch::Events::InitialPress::Id: {
-        uint8_t currentPosition = 1;
-
-        auto switchCluster = Clusters::Switch::FindClusterOnEndpoint(data->endpoint);
-        if (switchCluster != nullptr)
+        switch (data->event)
         {
+        case Switch::Events::InitialPress::Id: {
+            const uint8_t currentPosition = 1;
             if (switchCluster->SetCurrentPosition(currentPosition) == CHIP_NO_ERROR)
             {
                 RETURN_SAFELY_IGNORED switchCluster->OnInitialPress(currentPosition);
             }
+            break;
         }
-        break;
-    }
-    case Switch::Events::ShortRelease::Id: {
-        uint8_t previousPosition = 1;
-        uint8_t currentPosition  = 0;
-
-        auto switchCluster = Clusters::Switch::FindClusterOnEndpoint(data->endpoint);
-        if (switchCluster != nullptr)
-        {
+        case Switch::Events::ShortRelease::Id: {
+            const uint8_t previousPosition = 1;
+            const uint8_t currentPosition  = 0;
             if (switchCluster->SetCurrentPosition(currentPosition) == CHIP_NO_ERROR)
             {
                 RETURN_SAFELY_IGNORED switchCluster->OnShortRelease(previousPosition);
             }
+            break;
         }
-        break;
-    }
-    default:
-        break;
+        default:
+            break;
+        }
     }
 
     Platform::Delete(data);


### PR DESCRIPTION
#### Summary
follow-up PR to address this comment: https://github.com/project-chip/connectedhomeip/pull/72073#discussion_r3269401418

assign switchCluster and check against nullptr before the switch, avoids duplication handling this inside of each case 

#### Related issues
follow up to https://github.com/project-chip/connectedhomeip/pull/72073

#### Testing
ci

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only restructures `GenericSwitchWorkerFunction` to reuse a single `Switch` cluster lookup and guard the event handling on `nullptr`.
> 
> **Overview**
> Refactors `AppTask::GenericSwitchWorkerFunction` in the Silabs light-switch example to **remove duplicated `Clusters::Switch::FindClusterOnEndpoint`/`nullptr` checks** by doing the lookup once and guarding the `switch` on a non-null cluster.
> 
> Behavior is intended to remain the same for `InitialPress` and `ShortRelease` events, with only small readability/const-correctness tweaks (e.g., `const` positions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dd6e9c1e1cc763f4bbc515d5714f0da72d296bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->