### PR TITLE
[SL-ONLY] Add missing attribute write for zigbee

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -332,7 +332,6 @@ CHIP_ERROR BaseApplication::Init()
         return err;
     }
 
-    GetPlatform().WatchdogInit();
 #ifdef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
 #ifdef SL_CATALOG_MULTIPROTOCOL_ZIGBEE_MATTER_COMMON_PRESENT
     if (PlatformMgr().ScheduleWork([](intptr_t) { MultiProtocolDataModel::Initialize(); }) != CHIP_NO_ERROR)
@@ -1022,7 +1021,11 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
     case DeviceEventType::kThreadConnectivityChange:
     case DeviceEventType::kInternetConnectivityChange: {
 #ifdef SL_MATTER_ENABLE_AWS
-        if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
+    if (event->ThreadConnectivityChange.Result == kConnectivity_Established
+#if defined(SL_MATTER_ENABLE_DUAL_STACK) && SL_MATTER_ENABLE_DUAL_STACK
+        || (event->InternetConnectivityChange.IPv6 == kConnectivity_Established)
+#endif
+        )
         {
             if (MATTER_AWS_OK != MatterAwsInit(matterAws::control::subscribeCB))
             {

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -331,7 +331,6 @@ CHIP_ERROR BaseApplication::Init()
         appError(err);
         return err;
     }
-
 #ifdef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
 #ifdef SL_CATALOG_MULTIPROTOCOL_ZIGBEE_MATTER_COMMON_PRESENT
     if (PlatformMgr().ScheduleWork([](intptr_t) { MultiProtocolDataModel::Initialize(); }) != CHIP_NO_ERROR)

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -97,6 +97,10 @@
 #include <app-common/zap-generated/callback.h>
 #endif
 
+#ifdef CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
+#include "CustomerAppTask.h"
+#endif // CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
+
 // SL-Only
 #include "sl_component_catalog.h"
 #ifdef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
@@ -107,10 +111,6 @@
 #include <MultiProtocolDataModelHelper.h>
 #endif // SL_CATALOG_MULTIPROTOCOL_ZIGBEE_MATTER_COMMON_PRESENT
 #endif // SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
-
-#ifdef CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
-#include "CustomerAppTask.h"
-#endif // CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
 
 // Tracing
 #include <platform/silabs/tracing/SilabsTracingMacros.h>

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -1134,10 +1134,6 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     EndpointId endpointId   = attributePath.mEndpointId;
     ClusterId clusterId     = attributePath.mClusterId;
     AttributeId attributeId = attributePath.mAttributeId;
-    if (clusterId == app::Clusters::ClosureControl::Id && attributeId == app::Clusters::ClosureControl::Attributes::CurrentPosition::Id)
-    {
-        CustomerClosureManager::GetInstance().OnCurrentPositionChange(endpointId, value);
-    }
     MultiProtocolDataModel::WriteMatterAttributeValueToZigbee(endpointId, clusterId, attributeId, value, type);
 #endif // SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
 }

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -97,9 +97,6 @@
 #include <app-common/zap-generated/callback.h>
 #endif
 
-#ifdef CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
-#include "CustomerAppTask.h"
-#endif // CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
 // SL-Only
 #include "sl_component_catalog.h"
 #ifdef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
@@ -111,11 +108,19 @@
 #endif // SL_CATALOG_MULTIPROTOCOL_ZIGBEE_MATTER_COMMON_PRESENT
 #endif // SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 
+#ifdef CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
+#include "CustomerAppTask.h"
+#endif // CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
+
 // Tracing
 #include <platform/silabs/tracing/SilabsTracingMacros.h>
 #if MATTER_TRACING_ENABLED && defined(ENABLE_CHIP_SHELL)
 #include <TracingShellCommands.h>
 #endif // MATTER_TRACING_ENABLED
+
+#ifdef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
+#include <MultiProtocolDataModelHelper.h>
+#endif // SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
 
 // sl-only
 #if defined(SL_MATTER_ENABLE_APP_SLEEP_MANAGER) && SL_MATTER_ENABLE_APP_SLEEP_MANAGER
@@ -326,6 +331,8 @@ CHIP_ERROR BaseApplication::Init()
         appError(err);
         return err;
     }
+
+    GetPlatform().WatchdogInit();
 #ifdef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
 #ifdef SL_CATALOG_MULTIPROTOCOL_ZIGBEE_MATTER_COMMON_PRESENT
     if (PlatformMgr().ScheduleWork([](intptr_t) { MultiProtocolDataModel::Initialize(); }) != CHIP_NO_ERROR)
@@ -1015,11 +1022,7 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
     case DeviceEventType::kThreadConnectivityChange:
     case DeviceEventType::kInternetConnectivityChange: {
 #ifdef SL_MATTER_ENABLE_AWS
-        if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established
-#if defined(SL_MATTER_ENABLE_DUAL_STACK) && SL_MATTER_ENABLE_DUAL_STACK
-            || event->InternetConnectivityChange.IPv6 == kConnectivity_Established
-#endif
-        )
+        if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
         {
             if (MATTER_AWS_OK != MatterAwsInit(matterAws::control::subscribeCB))
             {
@@ -1124,7 +1127,13 @@ bool BaseApplication::GetProvisionStatus()
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
+    [[maybe_unused]] EndpointId endpointId   = attributePath.mEndpointId;
+    [[maybe_unused]] ClusterId clusterId     = attributePath.mClusterId;
+    [[maybe_unused]] AttributeId attributeId = attributePath.mAttributeId;
     // Route through CustomerAppTask / AppTaskImpl (CRTP) so overrides use DMPostAttributeChangeCallbackImpl.
     CustomerAppTask::GetAppTask().DMPostAttributeChangeCallback(attributePath, type, size, value);
+#ifdef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
+    MultiProtocolDataModel::WriteMatterAttributeValueToZigbee(endpointId, clusterId, attributeId, value, type);
+#endif // SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
 }
 #endif // CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -100,7 +100,6 @@
 #ifdef CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
 #include "CustomerAppTask.h"
 #endif // CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
-
 // SL-Only
 #include "sl_component_catalog.h"
 #ifdef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -1128,12 +1128,16 @@ bool BaseApplication::GetProvisionStatus()
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
-    [[maybe_unused]] EndpointId endpointId   = attributePath.mEndpointId;
-    [[maybe_unused]] ClusterId clusterId     = attributePath.mClusterId;
-    [[maybe_unused]] AttributeId attributeId = attributePath.mAttributeId;
     // Route through CustomerAppTask / AppTaskImpl (CRTP) so overrides use DMPostAttributeChangeCallbackImpl.
     CustomerAppTask::GetAppTask().DMPostAttributeChangeCallback(attributePath, type, size, value);
 #ifdef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
+    EndpointId endpointId   = attributePath.mEndpointId;
+    ClusterId clusterId     = attributePath.mClusterId;
+    AttributeId attributeId = attributePath.mAttributeId;
+    if (clusterId == app::Clusters::ClosureControl::Id && attributeId == app::Clusters::ClosureControl::Attributes::CurrentPosition::Id)
+    {
+        CustomerClosureManager::GetInstance().OnCurrentPositionChange(endpointId, value);
+    }
     MultiProtocolDataModel::WriteMatterAttributeValueToZigbee(endpointId, clusterId, attributeId, value, type);
 #endif // SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
 }

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -1021,9 +1021,9 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
     case DeviceEventType::kThreadConnectivityChange:
     case DeviceEventType::kInternetConnectivityChange: {
 #ifdef SL_MATTER_ENABLE_AWS
-    if (event->ThreadConnectivityChange.Result == kConnectivity_Established
+        if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established
 #if defined(SL_MATTER_ENABLE_DUAL_STACK) && SL_MATTER_ENABLE_DUAL_STACK
-        || (event->InternetConnectivityChange.IPv6 == kConnectivity_Established)
+            || event->InternetConnectivityChange.IPv6 == kConnectivity_Established
 #endif
         )
         {


### PR DESCRIPTION
#### Summary

Missed during refactor, 
Need to support datamodel updates for zigbe for CMP apps

#### Related issues
[MATTER-6363](https://jira.silabs.com/browse/MATTER-6363)

#### Testing

CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds cross-protocol attribute propagation from Matter to Zigbee on attribute-change callbacks, which could affect multiprotocol runtime behavior and attribute consistency on Zigbee-enabled builds.
> 
> **Overview**
> Restores Zigbee datamodel synchronization for Silabs CMP apps by **writing Matter attribute updates through to Zigbee** in `MatterPostAttributeChangeCallback` when `SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT` is enabled.
> 
> Also updates `BaseApplication.cpp` includes to pull in `MultiProtocolDataModelHelper.h` under the Zigbee ZCL framework catalog guard so the new propagation call is available only on Zigbee-capable builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97905bd14ccba864af5633cf6564c03b0ddef323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->