### PR TITLE
[SL-UP]Add an API to check the Initialize state of AppTask

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -354,7 +354,7 @@ CHIP_ERROR BaseApplication::Init()
 #endif // SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
     SILABS_TRACE_END_ERROR(TimeTraceOperation::kAppInit, err);
     SILABS_TRACE_END_ERROR(TimeTraceOperation::kBootup, err);
-    mIsApplicationInitialized = true;
+    if (err == CHIP_NO_ERROR) { mIsApplicationInitialized = true };
     return err;
 }
 

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -354,6 +354,7 @@ CHIP_ERROR BaseApplication::Init()
 #endif // SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
     SILABS_TRACE_END_ERROR(TimeTraceOperation::kAppInit, err);
     SILABS_TRACE_END_ERROR(TimeTraceOperation::kBootup, err);
+    mIsApplicationInitialized = true;
     return err;
 }
 
@@ -1128,13 +1129,16 @@ bool BaseApplication::GetProvisionStatus()
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
-    // Route through CustomerAppTask / AppTaskImpl (CRTP) so overrides use DMPostAttributeChangeCallbackImpl.
-    CustomerAppTask::GetAppTask().DMPostAttributeChangeCallback(attributePath, type, size, value);
 #ifdef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
     EndpointId endpointId   = attributePath.mEndpointId;
     ClusterId clusterId     = attributePath.mClusterId;
     AttributeId attributeId = attributePath.mAttributeId;
     MultiProtocolDataModel::WriteMatterAttributeValueToZigbee(endpointId, clusterId, attributeId, value, type);
 #endif // SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
+
+    // Verify that the App layer is initialized before propagating attribute changes callback to it.
+    VerifyOrReturn(CustomerAppTask::GetAppTask().IsApplicationInitialized());
+    // Route through CustomerAppTask / AppTaskImpl (CRTP) so overrides use DMPostAttributeChangeCallbackImpl.
+    CustomerAppTask::GetAppTask().DMPostAttributeChangeCallback(attributePath, type, size, value);
 }
 #endif // defined(CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK) && !defined(CHIP_SILABS_APP_NO_DM_IMPLEMENTATION)

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -354,7 +354,7 @@ CHIP_ERROR BaseApplication::Init()
 #endif // SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
     SILABS_TRACE_END_ERROR(TimeTraceOperation::kAppInit, err);
     SILABS_TRACE_END_ERROR(TimeTraceOperation::kBootup, err);
-    if (err == CHIP_NO_ERROR) { mIsApplicationInitialized = true };
+    if (err == CHIP_NO_ERROR) { mIsApplicationInitialized = true; }
     return err;
 }
 

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -119,6 +119,13 @@ public:
     void UnlinkAppLed() { sAppActionLed = nullptr; }
 
     /**
+     * @brief Check if the application is initialized
+     *
+     * @return Set to true when Init() was called successfully
+     */
+    bool IsApplicationInitialized() { return mIsApplicationInitialized; }
+
+    /**
      * @brief PostEvent function that add event to AppTask queue for processing
      *
      * @param event AppEvent to post
@@ -293,5 +300,6 @@ protected:
     bool mSyncClusterToButtonAction;
 
 private:
+    bool mIsApplicationInitialized = false;
     static void InitOTARequestorHandler(chip::System::Layer * systemLayer, void * appState);
 };


### PR DESCRIPTION
#### Summary
Slight change in some refactor app lead cases where `MatterPostChangeAttributeCallback` was propagated in the AppTask before it is initialized leading to a crash.

For example setting StartUpOnOff attribute to any value could,(would in the case of Toggle) trigger a early OnOff state change.

Fix:
-Add a Boolean/Api to our BaseApplication, usable by the inheriting `AppTaskImpl`, to indicate that the AppTask is fully initialized.
- Set the bool, mIsApplicationInitialized, at the end of `BaseApplication::Init()` once `BaseInit()` and `AppInit()` are successfully called.
- Check IsApplicationInitialized() before propagating the MatterPostChangeAttributeCallback to te `AppTaskImpl`
 

#### Related issues
fixes https://jira.silabs.com/browse/MATTER-6412 and https://jira.silabs.com/browse/MATTER-6361

#### Testing
- Commission the cmp lighting-app.
- Set StartUpOnOff attribute to Toggle(2) : `mattertool onoff write start-up-on-off 2 $NODE_ID 1`
- Reboot the device, Led state Toggles every reboot, app doesn't crash anymore.
- run Test_TC_OO_2_4.yaml