### PR TITLE
[SL-UP] MATTER-6405: Mutlipan commissioning bugfix 

### DIFF
--- a/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
@@ -172,6 +172,11 @@ extern "C" otInstance * otGetInstance(void)
     return sOTInstance;
 }
 
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+static otNetifAddress sOtIp6UnicastPool[4];
+static otNetifMulticastAddress sOtIp6MulticastPool[4];
+#endif
+
 extern "C" void sl_ot_create_instance(void)
 {
     SuccessOrDie(chip::Platform::MemoryInit());
@@ -185,6 +190,13 @@ extern "C" void sl_ot_create_instance(void)
     sOTInstance = otInstanceInitSingle();
 #endif // SL_OPENTHREAD_MULTI_PAN_ENABLE
 }
+
+VerifyOrDie(sOTInstance != nullptr);
+
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    // Required before otIp6SetEnabled() when cert prebuilt libs use runtime IPv6 address pools
+    VerifyOrDie(otIp6Init(sOTInstance, sOtIp6UnicastPool, 4, sOtIp6MulticastPool, 4) == OT_ERROR_NONE);
+#endif
 
 extern "C" void sl_ot_cli_init(void)
 {

--- a/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
@@ -172,7 +172,8 @@ extern "C" otInstance * otGetInstance(void)
     return sOTInstance;
 }
 
-#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+#if defined(OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE) && OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+
 static otNetifAddress sOtIp6UnicastPool[4];
 static otNetifMulticastAddress sOtIp6MulticastPool[4];
 #endif
@@ -192,7 +193,8 @@ extern "C" void sl_ot_create_instance(void)
 
 VerifyOrDie(sOTInstance != nullptr);
 
-#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+#if defined(OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE) && OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+
     // Required before otIp6SetEnabled() when cert prebuilt libs use runtime IPv6 address pools
     VerifyOrDie(otIp6Init(sOTInstance, sOtIp6UnicastPool, 4, sOtIp6MulticastPool, 4) == OT_ERROR_NONE);
 #endif

--- a/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
@@ -189,7 +189,6 @@ extern "C" void sl_ot_create_instance(void)
     // Standard single instance initialization
     sOTInstance = otInstanceInitSingle();
 #endif // SL_OPENTHREAD_MULTI_PAN_ENABLE
-}
 
 VerifyOrDie(sOTInstance != nullptr);
 
@@ -197,6 +196,7 @@ VerifyOrDie(sOTInstance != nullptr);
     // Required before otIp6SetEnabled() when cert prebuilt libs use runtime IPv6 address pools
     VerifyOrDie(otIp6Init(sOTInstance, sOtIp6UnicastPool, 4, sOtIp6MulticastPool, 4) == OT_ERROR_NONE);
 #endif
+}
 
 extern "C" void sl_ot_cli_init(void)
 {

--- a/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
@@ -172,12 +172,6 @@ extern "C" otInstance * otGetInstance(void)
     return sOTInstance;
 }
 
-#if defined(OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE) && OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
-
-static otNetifAddress sOtIp6UnicastPool[4];
-static otNetifMulticastAddress sOtIp6MulticastPool[4];
-#endif
-
 extern "C" void sl_ot_create_instance(void)
 {
     SuccessOrDie(chip::Platform::MemoryInit());
@@ -191,12 +185,15 @@ extern "C" void sl_ot_create_instance(void)
     sOTInstance = otInstanceInitSingle();
 #endif // SL_OPENTHREAD_MULTI_PAN_ENABLE
 
-VerifyOrDie(sOTInstance != nullptr);
+    VerifyOrDie(sOTInstance != nullptr);
 
 #if defined(OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE) && OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    static otNetifAddress sOtIp6UnicastPool[OPENTHREAD_CONFIG_IP6_MAX_EXT_UCAST_ADDRS];
+    static otNetifMulticastAddress sOtIp6MulticastPool[OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS];
 
     // Required before otIp6SetEnabled() when cert prebuilt libs use runtime IPv6 address pools
-    VerifyOrDie(otIp6Init(sOTInstance, sOtIp6UnicastPool, 4, sOtIp6MulticastPool, 4) == OT_ERROR_NONE);
+    VerifyOrDie(otIp6Init(sOTInstance, sOtIp6UnicastPool, OPENTHREAD_CONFIG_IP6_MAX_EXT_UCAST_ADDRS, sOtIp6MulticastPool,
+                          OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS) == OT_ERROR_NONE);
 #endif
 }
 


### PR DESCRIPTION
#### Summary
Lighting app multipan is failing to commission as openthread multi instance cert lib updates introduced in sisdk build 584 enforce a new rule that `otIp6Init()` must be called before `otIp6SetEnabled()` since `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` is enabled by default for certification builds. This causes IPv6 enablement to fail with `InvalidState`

In thread stack manager:
- allocate thread stack default amount of slots in memory per pool for unicast and multicast (set of IPv6 addresses) 
- within `sl_ot_create_instance`, call `otIp6Init()` when `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` enabled 
   - runs at boot when instance 0 created 

#### Related issues
MATTER-6405

#### Testing
Build locally with multipan enable and successfully commission

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches early Thread/IPv6 initialization on Silicon Labs platforms; impact is limited to builds with external IPv6 pool enabled, but failures are fatal via VerifyOrDie.
> 
> **Overview**
> Fixes **Multi-PAN** commissioning failures on EFR32 when certification OpenThread builds require external IPv6 address pools.
> 
> In `sl_ot_create_instance` (after single or multi-instance init), the stack now **asserts** the OpenThread instance was created successfully. When `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` is set, it also provisions static unicast/multicast pools sized from `OPENTHREAD_CONFIG_IP6_MAX_EXT_*` and calls **`otIp6Init()`** on instance 0 at boot so IPv6 can be enabled later without `InvalidState`.
> 
> The new path is gated on the same config flag and only runs at instance creation time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6447996eaa9fe04404231ce843690b6dac9700f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->