### PR TITLE
[SL-UP] Register ThermostatDelegate on Silabs thermostat cluster init

### DIFF
--- a/examples/thermostat/silabs/include/AppTask.h
+++ b/examples/thermostat/silabs/include/AppTask.h
@@ -24,6 +24,7 @@
 #include <app/ConcreteAttributePath.h>
 #include <cstdint>
 #include <lib/core/CHIPError.h>
+#include <lib/core/DataModelTypes.h>
 
 struct AppEvent;
 
@@ -70,6 +71,11 @@ public:
      */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
+
+    /**
+     * @brief Thermostat cluster init hook. Registers ThermostatDelegate for preset-related attributes.
+     */
+    void DMThermostatClusterInit(chip::EndpointId endpoint);
 
     /**
      * @brief Initialize the temperature sensor backing this thermostat.

--- a/examples/thermostat/silabs/include/AppTaskImpl.h
+++ b/examples/thermostat/silabs/include/AppTaskImpl.h
@@ -68,6 +68,11 @@ public:
         CRTP_OPTIONAL_VOID_DISPATCH(AppTaskImpl, Derived, DMPostAttributeChangeCallbackImpl, attributePath, type, size, value);
     }
 
+    void DMThermostatClusterInit(chip::EndpointId endpoint)
+    {
+        CRTP_OPTIONAL_VOID_DISPATCH(AppTaskImpl, Derived, DMThermostatClusterInitImpl, endpoint);
+    }
+
 private:
     friend Derived;
 
@@ -92,4 +97,6 @@ private:
     {
         AppTask::DMPostAttributeChangeCallback(attributePath, type, size, value);
     }
+
+    void DMThermostatClusterInitImpl(chip::EndpointId endpoint) { AppTask::DMThermostatClusterInit(endpoint); }
 };

--- a/examples/thermostat/silabs/src/AppTask.cpp
+++ b/examples/thermostat/silabs/src/AppTask.cpp
@@ -29,6 +29,7 @@
 #endif // DISPLAY_ENABLED
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
@@ -352,9 +353,15 @@ void AppTask::DMPostAttributeChangeCallback(const ConcreteAttributePath & attrib
 #endif // SL_MATTER_ENABLE_AWS
 }
 
-void emberAfThermostatClusterInitCallback(chip::EndpointId endpoint)
+void AppTask::DMThermostatClusterInit(chip::EndpointId endpoint)
 {
     using namespace chip::app::Clusters::Thermostat;
     auto & delegate = ThermostatDelegate::GetInstance();
     SetDefaultDelegate(endpoint, &delegate);
+}
+
+// emberAfThermostatClusterInitCallback — weak ZAP entry point. CRTP forwarder into AppTask.
+void emberAfThermostatClusterInitCallback(EndpointId endpoint)
+{
+    CustomerAppTask::GetAppTask().DMThermostatClusterInit(endpoint);
 }

--- a/examples/thermostat/silabs/src/AppTask.cpp
+++ b/examples/thermostat/silabs/src/AppTask.cpp
@@ -34,6 +34,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/clusters/thermostat-server/ThermostatCluster.h>
 #include <app/server/Server.h>
+#include <thermostat-delegate-impl.h>
 #include <app/util/attribute-storage.h>
 #include <cmsis_os2.h>
 #include <lib/support/CodeUtils.h>
@@ -349,4 +350,11 @@ void AppTask::DMPostAttributeChangeCallback(const ConcreteAttributePath & attrib
 #ifdef SL_MATTER_ENABLE_AWS
     matterAws::control::AttributeHandler(attributePath.mEndpointId, attributeId);
 #endif // SL_MATTER_ENABLE_AWS
+}
+
+void emberAfThermostatClusterInitCallback(chip::EndpointId endpoint)
+{
+    using namespace chip::app::Clusters::Thermostat;
+    auto & delegate = ThermostatDelegate::GetInstance();
+    SetDefaultDelegate(endpoint, &delegate);
 }


### PR DESCRIPTION
#### Summary

Register ThermostatDelegate when the Thermostat cluster initializes on the Silicon Labs thermostat example, so preset-related attributes can be read instead of returning IM Failure. Addresses TC_IDM_10_1 failures  where those attributes appeared in AttributeList but wildcard reads failed.

Problem : The Silabs thermostat enables Thermostat PRES and preset attributes in ZAP. The code-driven cluster serves them through ThermostatDelegate. The app already links thermostat-delegate-impl.cpp, but only the autogen weak emberAfThermostatClusterInitCallback ran (no-op). With no delegate registered, preset reads failed and certification reported ValueDecodeFailure for attributes listed as supported.

Fix : Implement emberAfThermostatClusterInitCallback in examples/thermostat/silabs/src/AppTask.cpp: call ThermostatDelegate::GetInstance() and SetDefaultDelegate().

#### Related issues
[MATTER-6409](https://jira.silabs.com/browse/MATTER-6409)
<!--
    This section will help the reviewer easily navigate to the GitHub issues related to this PR change.
    Please mention all the related issues in this section.

    Tip: use the syntax of Fixes #.... to mark issues completed on PR merge or use #... to reference issues that are addressed.

    Examples:
        Fixes: #12345
        #12345
        N/A (not preferable)

    Please replace this HTML comment with the actual information about related issues.
-->

#### Testing
Built thermostat for BRD4338a, commissioned, executed the test_TC_IDM_10_1 testcase and verified that the failure is not seen.

Also, verified the build of thermostat CMP app in matter_extension with the below command: 

./slc/build.sh slc/apps/thermostat/thread/matter_thread_soc_thermostat_series_2_freertos.slcw brd4187c --output_suffix cmp-concurrent --with_app matter_zigbee_concurrent,matter_zigbee_multiprotocol_common

<!--
    This section will help the reviewer understand how this PR change was tested.
    As a general rule, a proposed PR change must not break the existing code and must be well-tested.
    Please include information about testing.

    See testing guidelines: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#testing

    Examples:
        added unit tests
        verified by YAML test: TC_ABC.yaml
        added Python test: TC_DEF.py
        manually tested (mention steps to reproduce)

    Please replace this HTML comment with the actual information about how the testing was done.
 -->

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
