### PR TITLE
[SL-UP] MATTER-6652: Add docs to AppTaskImpl.h files

### DIFF
--- a/examples/air-quality-sensor-app/silabs/include/AppTaskImpl.h
+++ b/examples/air-quality-sensor-app/silabs/include/AppTaskImpl.h
@@ -35,25 +35,32 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
+    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
+    // Air quality sensor specific initialization
     CHIP_ERROR InitAirQualitySensor() { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, InitAirQualitySensorImpl); }
 
+    // Reads the current air quality measurement from the sensor
+    // Override to get value from custom hardware
     CHIP_ERROR GetAirQualityValue(int32_t & air_quality)
     {
         CRTP_OPTIONAL_DISPATCH_ARGS(AppTaskImpl, Derived, GetAirQualityValueImpl, air_quality);
     }
 
+    // Handle button press
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
+    // Timer expiry callback that periodically samples the sensor
     static void SensorTimerEventHandler(void * arg)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, SensorTimerEventHandlerImpl, arg);
     }
 
+    // Data model hook invoked when a cluster attribute changes
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {
@@ -62,6 +69,9 @@ public:
 
 private:
     friend Derived;
+
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
 
     CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
 

--- a/examples/base-platform-app/silabs/include/AppTaskImpl.h
+++ b/examples/base-platform-app/silabs/include/AppTaskImpl.h
@@ -38,19 +38,24 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
+    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
+    // Handle button press
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
+    // AppTask thread event handler
     static void ApplicationEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ApplicationEventHandlerImpl, aEvent);
     }
 
 #if defined(CHIP_CONFIG_ENABLE_ICD_SERVER) && CHIP_CONFIG_ENABLE_ICD_SERVER
+    // ICD lifecycle hooks invoked by the ICD manager
+    // Override to react to power mode transitions
     void OnEnterActiveMode() override
     {
         CRTP_OPTIONAL_VOID_DISPATCH(AppTaskImpl, Derived, OnEnterActiveModeImpl);
@@ -66,6 +71,9 @@ public:
 private:
     friend Derived;
 
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
+
     CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
 
     void ButtonEventHandlerImpl(uint8_t button, uint8_t btnAction) { AppTask::ButtonEventHandler(button, btnAction); }
@@ -73,6 +81,7 @@ private:
     void ApplicationEventHandlerImpl(AppEvent * aEvent) { AppTask::ApplicationEventHandler(aEvent); }
 
 #if defined(CHIP_CONFIG_ENABLE_ICD_SERVER) && CHIP_CONFIG_ENABLE_ICD_SERVER
+    // Default ICD power mode hooks: forward to the AppTask::*Default() behavior
     void OnEnterActiveModeImpl() { AppTask::OnEnterActiveModeDefault(); }
 
     void OnEnterIdleModeImpl() { AppTask::OnEnterIdleModeDefault(); }

--- a/examples/light-switch-app/silabs/include/AppTaskImpl.h
+++ b/examples/light-switch-app/silabs/include/AppTaskImpl.h
@@ -39,34 +39,41 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
+    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
+    // Light switch specific initialization
     CHIP_ERROR InitLightSwitch(chip::EndpointId lightSwitchEndpoint, chip::EndpointId genericSwitchEndpoint)
     {
         CRTP_OPTIONAL_DISPATCH_ARGS(AppTaskImpl, Derived, InitLightSwitchImpl, lightSwitchEndpoint, genericSwitchEndpoint);
     }
 
+    // Handle button press
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
+    // AppTask thread event handler
     static void AppEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, AppEventHandlerImpl, aEvent);
     }
 
+    // Handler scheduled on the Matter thread to set up the binding table
     static void InitBindingHandler(intptr_t arg)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, InitBindingHandlerImpl, arg);
     }
 
+    // Binding manager callback invoked per bound device to send switch command to the target light
     static void LightSwitchChangedHandler(const chip::app::Clusters::Binding::TableEntry & binding,
                                           chip::OperationalDeviceProxy * peer_device, void * context)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, LightSwitchChangedHandlerImpl, binding, peer_device, context);
     }
 
+    // Data model hook invoked when a cluster attribute changes
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {
@@ -75,6 +82,9 @@ public:
 
 private:
     friend Derived;
+
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
 
     CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
 

--- a/examples/lighting-app/silabs/include/AppTaskImpl.h
+++ b/examples/lighting-app/silabs/include/AppTaskImpl.h
@@ -39,41 +39,45 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
-    // Initialization hooks.
+    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
+    // Light specific initialization
     CHIP_ERROR InitLight() { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, InitLightImpl); }
 
-    // External callbacks invoked outside the AppTask thread (e.g. button ISR, OnOff cluster).
-    // Implementations typically post an event to the AppTask queue.
+    // Handle button press
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
+    // OnOff cluster callback for the off with effect command
     static void OnTriggerOffWithEffect(OnOffEffect * effect)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, OnTriggerOffWithEffectImpl, effect);
     }
 
-    // Handlers invoked from AppTask, timer, or stack threads — see each method for the exact context.
+    // AppTask thread event handler that applies a light action
     static void LightActionEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, LightActionEventHandlerImpl, aEvent);
     }
 
+    // Timer expiry callback driving timed light transitions
     static void LightTimerEventHandler(void * timerCbArg)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, LightTimerEventHandlerImpl, timerCbArg);
     }
 
 #if (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
+    // AppTask thread event handler for RGB LED control
     static void LightControlEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, LightControlEventHandlerImpl, aEvent);
     }
 #endif
 
+    // Data model hook invoked when a cluster attribute changes
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {
@@ -83,19 +87,17 @@ public:
 private:
     friend Derived;
 
-    /** Default implementations — override in Derived to customize. */
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
 
-    // Initialization hooks (*Impl)
     CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
 
     CHIP_ERROR InitLightImpl() { return AppTask::InitLight(); }
 
-    // External callbacks (*Impl)
     void ButtonEventHandlerImpl(uint8_t button, uint8_t btnAction) { AppTask::ButtonEventHandler(button, btnAction); }
 
     void OnTriggerOffWithEffectImpl(OnOffEffect * effect) { AppTask::OnTriggerOffWithEffect(effect); }
 
-    // Event / timer / data-model handlers (*Impl)
     void LightActionEventHandlerImpl(AppEvent * aEvent) { AppTask::LightActionEventHandler(aEvent); }
 
     void LightTimerEventHandlerImpl(void * timerCbArg) { AppTask::LightTimerEventHandler(timerCbArg); }

--- a/examples/lock-app/silabs/include/AppTaskImpl.h
+++ b/examples/lock-app/silabs/include/AppTaskImpl.h
@@ -35,57 +35,61 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
-    // External triggers — entry points that pass context into AppTask (e.g. PostEvent).
-    // Optional override: *Impl().
+    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
+    // Lock specific initialization
     CHIP_ERROR InitLock() { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, InitLockImpl); }
 
+    // Handle button press
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
-    // AppTask-thread event handler (queued event). Optional override: *Impl().
+    // AppTask thread event handler
     static void LockButtonActionHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, LockButtonActionHandlerImpl, aEvent);
     }
 
-    // CMSIS osTimer expiry callback (unlatch timer). Optional override: *Impl().
+    // Timer expiry callback
     static void UnlatchCallback(void * argument)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, UnlatchCallbackImpl, argument);
     }
 
-    // AppTask-thread event handler (queued actuator-movement timer event). Optional override: *Impl().
+    // AppTask thread event handler
     static void ActuatorMovementEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ActuatorMovementEventHandlerImpl, aEvent);
     }
 
-    // AppTask-thread event handler (queued lock-action event posted from the Matter / DoorLock
-    // cluster-callback thread or from the FreeRTOS unlatch-timer trampoline). Optional override: *Impl().
+    // AppTask thread event handler for a queued lock action event
     static void LockActionEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, LockActionEventHandlerImpl, aEvent);
     }
 
+    // AppTask thread event handler for a queued lock/unlock request
     static void LockRequestEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, LockRequestEventHandlerImpl, aEvent);
     }
 
+    // Processes a lock request on the AppTask thread
     void HandleLockRequestOnAppTask(const AppTask::LockRequest & request)
     {
         CRTP_OPTIONAL_VOID_DISPATCH(AppTaskImpl, Derived, HandleLockRequestOnAppTaskImpl, request);
     }
 
+    // Completes an unlock once the unlatch sequence has finished
     static void UnlockAfterUnlatch(intptr_t context)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, UnlockAfterUnlatchImpl, context);
     }
 
+    // Data model hook invoked when a cluster attribute changes
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {
@@ -98,6 +102,7 @@ public:
     // behavior.
     // ---------------------------------------------------------------------
 
+    // Lock command: validate the credential and drive the lock actuator, return true on success
     bool DMDoorLockOnDoorLockCommand(chip::EndpointId endpointId,
                                      const chip::app::DataModel::Nullable<chip::FabricIndex> & fabricIdx,
                                      const chip::app::DataModel::Nullable<chip::NodeId> & nodeId,
@@ -108,6 +113,7 @@ public:
                                     err);
     }
 
+    // Unlock command: validate the credential and drive the lock actuator, return true on success
     bool DMDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId,
                                        const chip::app::DataModel::Nullable<chip::FabricIndex> & fabricIdx,
                                        const chip::app::DataModel::Nullable<chip::NodeId> & nodeId,
@@ -118,6 +124,7 @@ public:
                                     err);
     }
 
+    // Unbolt command: validate the credential and retract the bolt, return true on success
     bool DMDoorLockOnDoorUnboltCommand(chip::EndpointId endpointId,
                                        const chip::app::DataModel::Nullable<chip::FabricIndex> & fabricIdx,
                                        const chip::app::DataModel::Nullable<chip::NodeId> & nodeId,
@@ -128,6 +135,7 @@ public:
                                     err);
     }
 
+    // Credential storage accessors, override to back credentials with custom storage
     bool DMDoorLockGetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, CredentialTypeEnum credentialType,
                                  EmberAfPluginDoorLockCredentialInfo & credential)
     {
@@ -143,6 +151,7 @@ public:
                                     modifier, credentialStatus, credentialType, credentialData);
     }
 
+    // User storage accessors, override to back the user database with custom storage
     bool DMDoorLockGetUser(chip::EndpointId endpointId, uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user)
     {
         CRTP_OPTIONAL_DISPATCH_ARGS(AppTaskImpl, Derived, DMDoorLockGetUserImpl, endpointId, userIndex, user);
@@ -156,6 +165,7 @@ public:
                                     uniqueId, userStatus, usertype, credentialRule, credentials, totalCredentials);
     }
 
+    // Schedule storage accessors, override to back schedules with custom storage
     DlStatus DMDoorLockGetWeekDaySchedule(chip::EndpointId endpointId, uint8_t weekdayIndex, uint16_t userIndex,
                                           EmberAfPluginDoorLockWeekDaySchedule & schedule)
     {
@@ -199,6 +209,7 @@ public:
                                     localStartTime, localEndTime, operatingMode);
     }
 
+    // Auto relock timer expiry: relock the door after the configured relock interval
     void DMDoorLockOnAutoRelock(chip::EndpointId endpointId)
     {
         CRTP_OPTIONAL_VOID_DISPATCH(AppTaskImpl, Derived, DMDoorLockOnAutoRelockImpl, endpointId);
@@ -207,7 +218,8 @@ public:
 private:
     friend Derived;
 
-    /** Default implementations — override in Derived to customize. */
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
 
     CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
 
@@ -235,7 +247,8 @@ private:
         AppTask::DMPostAttributeChangeCallback(attributePath, type, size, value);
     }
 
-    // DoorLock cluster DM defaults — forward to AppTask::DM*.
+    // DoorLock cluster DM defaults, each forwards to the matching AppTask::DM* method
+
     bool DMDoorLockOnDoorLockCommandImpl(chip::EndpointId endpointId,
                                          const chip::app::DataModel::Nullable<chip::FabricIndex> & fabricIdx,
                                          const chip::app::DataModel::Nullable<chip::NodeId> & nodeId,

--- a/examples/onoff-plug-app/silabs/include/AppTaskImpl.h
+++ b/examples/onoff-plug-app/silabs/include/AppTaskImpl.h
@@ -39,20 +39,25 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
+    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
+    // Plug specific initialization
     CHIP_ERROR InitPlug() { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, InitPlugImpl); }
 
+    // Handle button press
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
+    // AppTask thread event handler that applies an OnOff action
     static void OnOffActionEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, OnOffActionEventHandlerImpl, aEvent);
     }
 
+    // Data model hook invoked when a cluster attribute changes
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {
@@ -62,7 +67,8 @@ public:
 private:
     friend Derived;
 
-    /** Default implementations - override in Derived to customize. **/
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
 
     CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
 

--- a/examples/rangehood-app/silabs/include/AppTaskImpl.h
+++ b/examples/rangehood-app/silabs/include/AppTaskImpl.h
@@ -21,29 +21,48 @@
 #include "AppTask.h"
 #include "CRTPHelpers.h"
 
+/**
+ * @brief CRTP override layer for `AppTask`.
+ *
+ * Each public entry point dispatches to a corresponding `Derived::*Impl()` hook.
+ * The default `*Impl()` (declared private below) forwards to `AppTask`, so
+ * `Derived` only needs to override the hooks whose behavior it wants to
+ * customize.
+ *
+ * Customer code overrides these hooks in `CustomerAppTask`; see the app README
+ * ("How to Override APIs").
+ *
+ * @tparam Derived The CRTP derived class (`CustomerAppTask`).
+ */
 template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
+    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
+    // Rangehood specific initialization
     CHIP_ERROR InitRangeHood() { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, InitRangeHoodImpl); }
 
+    // Handle button press
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
+    // AppTask thread event handler for a queued rangehood action event
     static void ActionTriggerHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ActionTriggerHandlerImpl, aEvent);
     }
 
+    // AppTask thread event handler that drives the FanControl cluster from a button press
     static void FanControlButtonHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, FanControlButtonHandlerImpl, aEvent);
     }
 
+    // Data model hook invoked when a cluster attribute changes
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {
@@ -52,6 +71,9 @@ public:
 
 private:
     friend Derived;
+
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
 
     CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
 

--- a/examples/thermostat/silabs/include/AppTaskImpl.h
+++ b/examples/thermostat/silabs/include/AppTaskImpl.h
@@ -35,39 +35,47 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
-    // External triggers — entry points that pass context into AppTask. Optional override: *Impl().
+    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
+    // Thermostat specific initialization
     CHIP_ERROR InitThermostat() { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, InitThermostatImpl); }
 
+    // Initializes the temperature sensor driver and its sampling timer
     CHIP_ERROR InitSensor() { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, InitSensorImpl); }
+
+    // Reads the current temperature from the sensor, override to get value from custom hardware
     CHIP_ERROR GetTemperature(int16_t & temperature)
     {
         CRTP_OPTIONAL_DISPATCH_ARGS(AppTaskImpl, Derived, GetTemperatureImpl, temperature);
     }
 
+    // Handle button press
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
-    // AppTask-thread event handlers (queued events, timers, data model). Optional override: *Impl().
+    // Timer expiry callback that periodically samples the temperature sensor
     static void SensorTimerEventHandler(void * arg)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, SensorTimerEventHandlerImpl, arg);
     }
 
+    // AppTask thread event handler that pushes a new temperature reading into the Matter cluster
     static void TemperatureUpdateEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, TemperatureUpdateEventHandlerImpl, aEvent);
     }
 
+    // Data model hook invoked when a cluster attribute changes
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {
         CRTP_OPTIONAL_VOID_DISPATCH(AppTaskImpl, Derived, DMPostAttributeChangeCallbackImpl, attributePath, type, size, value);
     }
 
+    // Data model hook to initialize the Thermostat cluster on the given endpoint
     void DMThermostatClusterInit(chip::EndpointId endpoint)
     {
         CRTP_OPTIONAL_VOID_DISPATCH(AppTaskImpl, Derived, DMThermostatClusterInitImpl, endpoint);
@@ -76,7 +84,8 @@ public:
 private:
     friend Derived;
 
-    /** Default implementations — override in Derived to customize. */
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
 
     CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
 


### PR DESCRIPTION
#### Summary
In customer documentation in app README files, we point user to AppTaskImpl.h to see declarations of every overridable method. However, these files are lacking proper documentation to explain to users what each method actually does and is responsible for. 

For each refactored app, add some descriptions to each method in corresponding AppTaskImpl.h file to give user high level idea of the Silabs implemented methods 

#### Related issues
MATTER-6652

#### Testing
n/a comment only

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only documentation in example headers; no executable logic or API changes.
> 
> **Overview**
> Adds **inline comments** to each Silabs example’s `AppTaskImpl.h` so customers can see what each overridable hook does without reading `AppTask.cpp`. READMEs already point integrators at these headers for the full `*Impl()` list; the diff only improves that reference material.
> 
> Across **air-quality, base-platform, light-switch, lighting, lock, onoff-plug, rangehood, and thermostat** apps, public CRTP entry points get short labels (init, buttons, timers, AppTask events, data-model callbacks, and app-specific APIs such as DoorLock DM hooks on lock). Private default `*Impl()` sections are documented as forwarding to `AppTask` and as the hooks to override in `CustomerAppTask`. **Range hood** also gains a class-level `@brief` block aligned with the other examples. No dispatch logic or signatures change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db4cabac2dd362a39814059698572c996fbda002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->