### PR TITLE
[SL-UP] MATTER-6655: Add briefs to refactored AppTask methods

### DIFF
--- a/examples/air-quality-sensor-app/silabs/include/AppTask.h
+++ b/examples/air-quality-sensor-app/silabs/include/AppTask.h
@@ -59,6 +59,7 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -68,6 +69,7 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**
@@ -90,6 +92,7 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
+    /** @brief Data model hook invoked when a cluster attribute changes */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
@@ -102,13 +105,13 @@ public:
      */
     CHIP_ERROR GetAirQualityValue(int32_t & air_quality);
 
-    // Reads new generated sensor value, stores it, and updates local Air Quality attribute
+    /** @brief Reads new generated sensor value, stores it, and updates local Air Quality attribute */
     static void SensorTimerEventHandler(void * arg);
 
 protected:
-    /** Override of `BaseApplication::AppInit()`. */
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
-    /** Bring up the air quality sensor app: Matter manager, sensor timer, sensor driver, first reading. */
+    /** @brief Bring up the air quality sensor app: Matter manager, sensor timer, sensor driver, first reading. */
     CHIP_ERROR InitAirQualitySensor();
 };

--- a/examples/base-platform-app/silabs/include/AppTask.h
+++ b/examples/base-platform-app/silabs/include/AppTask.h
@@ -51,6 +51,7 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -60,6 +61,7 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**

--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -104,34 +104,60 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
+    /**
+     * @brief AppTask task main loop function
+     *
+     * @param pvParameter FreeRTOS task parameter
+     */
     static void AppTaskMain(void * pvParameter);
+
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
+    /**
+     * @brief Event handler when a button is pressed
+     *
+     * @param button    APP_FUNCTION_BUTTON or the action button
+     * @param btnAction SL_SIMPLE_BUTTON_PRESSED, SL_SIMPLE_BUTTON_RELEASED or SL_SIMPLE_BUTTON_DISABLED
+     */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
+
+    /** @brief AppTask thread event handler for queued button events */
     static void AppEventHandler(AppEvent * aEvent);
 
+    /** @brief Matter-thread work item: notifies the binding manager that a bound cluster changed to drive the outgoing switch command */
     static void SwitchWorkerFunction(intptr_t context);
+
+    /** @brief Matter-thread work item: emits a Generic Switch cluster event for the queued switch action */
     static void GenericSwitchWorkerFunction(intptr_t context);
 
+    /** @brief Sends an OnOff cluster command to the bound peer device for the given binding entry */
     static void ProcessOnOffBindingCommand(chip::CommandId commandId, const chip::app::Clusters::Binding::TableEntry & binding,
                                            chip::OperationalDeviceProxy * peer_device);
 
+    /** @brief Sends a LevelControl cluster command to the bound peer device for the given binding entry */
     static void ProcessLevelControlBindingCommand(BindingCommandData * data,
                                                   const chip::app::Clusters::Binding::TableEntry & binding,
                                                   chip::OperationalDeviceProxy * peer_device);
 
+    /** @brief Data model hook invoked when a cluster attribute changes */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
+    /** @brief Binding manager callback invoked per bound device to send a switch command to the target light */
     static void LightSwitchChangedHandler(const chip::app::Clusters::Binding::TableEntry & binding,
                                           chip::OperationalDeviceProxy * peer_device, void * context);
 
 protected:
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
+    /** @brief Light switch specific initialization */
     CHIP_ERROR InitLightSwitch(chip::EndpointId lightSwitchEndpoint, chip::EndpointId genericSwitchEndpoint);
 
+    /** @brief Handler scheduled on the Matter thread to set up the binding table */
     static void InitBindingHandler(intptr_t arg);
 };

--- a/examples/lighting-app/silabs/include/AppTask.h
+++ b/examples/lighting-app/silabs/include/AppTask.h
@@ -46,6 +46,7 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -55,6 +56,7 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**
@@ -65,23 +67,32 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
+    /** @brief OnOff cluster callback for the off with effect command */
     static void OnTriggerOffWithEffect(OnOffEffect * effect);
 
+    /** @brief Data model hook invoked when a cluster attribute changes */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
+    /** @brief AppTask thread event handler that applies a light action */
     static void LightActionEventHandler(AppEvent * aEvent);
 
+    /** @brief Timer expiry callback driving timed light transitions */
     static void LightTimerEventHandler(void * timerCbArg);
 
 #if (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
+    /** @brief AppTask thread event handler for RGB LED control */
     static void LightControlEventHandler(AppEvent * aEvent);
 #endif
 
 protected:
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
+
+    /** @brief Light specific initialization */
     CHIP_ERROR InitLight();
 
+    /** @brief Chip-thread work item: push the OnOff cluster state through `OnOffServer::setOnOffValue` */
     static void UpdateOnOffClusterState(intptr_t context);
     chip::app::DeferredAttributePersistenceProvider * pDeferredAttributePersister = nullptr;
 };

--- a/examples/onoff-plug-app/silabs/include/AppTask.h
+++ b/examples/onoff-plug-app/silabs/include/AppTask.h
@@ -35,6 +35,7 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -44,6 +45,7 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**
@@ -54,14 +56,20 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
+    /** @brief Data model hook invoked when a cluster attribute changes */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
+    /** @brief AppTask thread event handler that applies an OnOff action */
     static void OnOffActionEventHandler(AppEvent * aEvent);
 
 protected:
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
+
+    /** @brief Plug specific initialization */
     CHIP_ERROR InitPlug();
 
+    /** @brief Chip-thread work item: push the OnOff cluster state via `OnOffServer::setOnOffValue` */
     static void UpdateOnOffClusterState(intptr_t context);
 };

--- a/examples/rangehood-app/silabs/include/AppTask.h
+++ b/examples/rangehood-app/silabs/include/AppTask.h
@@ -42,10 +42,17 @@ public:
 
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
+    /**
+     * @brief AppTask task main loop function
+     *
+     * @param pvParameter FreeRTOS task parameter
+     */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /** @brief Platform button callback; posts fan-control or base application events. */
@@ -67,6 +74,9 @@ public:
     static LightEndpoint & GetLightEndpoint();
 
 protected:
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
+
+    /** @brief Rangehood specific initialization */
     CHIP_ERROR InitRangeHood();
 };

--- a/examples/thermostat/silabs/include/AppTask.h
+++ b/examples/thermostat/silabs/include/AppTask.h
@@ -33,6 +33,7 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -42,8 +43,10 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
+    /** @brief Requests a refresh of the thermostat LCD UI */
     static void UpdateThermoStatUI();
 
     /**
@@ -97,7 +100,7 @@ public:
     CHIP_ERROR GetTemperature(int16_t & temperature);
 
 protected:
-    /** Override of `BaseApplication::AppInit()`. */
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
     /** Bring up the thermostat app: sensor timer, sensor driver, first UI paint. */


### PR DESCRIPTION
#### Summary
Late in cycle point was made to add doxygen style briefs to all AppTask methods in AppTask.h. Some apps/methods have this, but there are some gaps. 

Add doxygen style briefs to refactored app APIs where they are missing 

#### Related issues
MATTER-6655

#### Testing
n/a comment only 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only edits to example app headers with no functional or security impact.
> 
> **Overview**
> Adds **Doxygen `@brief` comments** to `AppTask` APIs in Silabs example `AppTask.h` headers where documentation was missing or inconsistent after the refactored `BaseApplication` / `AppTask` split.
> 
> Coverage spans **air-quality-sensor**, **base-platform**, **light-switch** (largest expansion: binding workers, switch handlers, init hooks), **lighting**, **onoff-plug**, **rangehood** (including `AppTaskMain` / `StartAppTask` blocks), and **thermostat**. Common additions include `GetAppTask`, `StartAppTask`, `DMPostAttributeChangeCallback`, protected `AppInit()` overrides, and app-specific init helpers; some **plain comments** were converted to `@brief` form (e.g. sensor timer, thermostat UI).
> 
> **No runtime or API behavior changes**—header comments only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84ef938596525aaa58859e7b5e68903e2c52ee32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->