### PR TITLE
[SL-ONLY] Delayed start of AWS Task

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -1016,16 +1016,10 @@ void InitMatterAwsHandler(System::Layer * systemLayer, void * appState)
 {
     sMatterAwsInitScheduled = false;
 
-    if (sMatterAwsInitDone)
-    {
-        return;
-    }
+    VerifyOrReturn(!sMatterAwsInitDone);
 
-    if (MATTER_AWS_OK != MatterAwsInit(matterAws::control::subscribeCB))
-    {
-        ChipLogError(AppServer, "MatterAwsInit failed");
-        return;
-    }
+    VerifyOrReturn(MATTER_AWS_OK == MatterAwsInit(matterAws::control::subscribeCB),
+                   ChipLogError(AppServer, "MatterAwsInit failed"));
 
     sMatterAwsInitDone = true;
 }
@@ -1051,11 +1045,10 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 #endif
         )
         {
-            ChipLogError(AppServer, "Scheduling Matter AWS starting");
             if (!sMatterAwsInitDone && !sMatterAwsInitScheduled)
             {
                 sMatterAwsInitScheduled = true;
-                ChipLogError(AppServer, "Scheduling Matter AWS initialization");
+                ChipLogProgress(AppServer, "Scheduling Matter AWS initialization");
                 TEMPORARY_RETURN_IGNORED chip::DeviceLayer::SystemLayer().StartTimer(
                     chip::System::Clock::Seconds32(MATTER_AWS_INIT_DELAY_SEC), InitMatterAwsHandler, nullptr);
             }

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -1007,6 +1007,31 @@ void BaseApplication::InitOTARequestorHandler(System::Layer * systemLayer, void 
 }
 #endif // defined(SILABS_OTA_ENABLED) && SILABS_OTA_ENABLED
 
+#ifdef SL_MATTER_ENABLE_AWS
+namespace {
+bool sMatterAwsInitScheduled = false;
+bool sMatterAwsInitDone      = false;
+
+void InitMatterAwsHandler(System::Layer * systemLayer, void * appState)
+{
+    sMatterAwsInitScheduled = false;
+
+    if (sMatterAwsInitDone)
+    {
+        return;
+    }
+
+    if (MATTER_AWS_OK != MatterAwsInit(matterAws::control::subscribeCB))
+    {
+        ChipLogError(AppServer, "MatterAwsInit failed");
+        return;
+    }
+
+    sMatterAwsInitDone = true;
+}
+} // namespace
+#endif // SL_MATTER_ENABLE_AWS
+
 void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 {
     switch (event->Type)
@@ -1026,9 +1051,13 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 #endif
         )
         {
-            if (MATTER_AWS_OK != MatterAwsInit(matterAws::control::subscribeCB))
+            ChipLogError(AppServer, "Scheduling Matter AWS starting");
+            if (!sMatterAwsInitDone && !sMatterAwsInitScheduled)
             {
-                ChipLogError(AppServer, "MatterAwsInit failed");
+                sMatterAwsInitScheduled = true;
+                ChipLogError(AppServer, "Scheduling Matter AWS initialization");
+                TEMPORARY_RETURN_IGNORED chip::DeviceLayer::SystemLayer().StartTimer(
+                    chip::System::Clock::Seconds32(MATTER_AWS_INIT_DELAY_SEC), InitMatterAwsHandler, nullptr);
             }
         }
 #endif // SL_MATTER_ENABLE_AWS

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -1049,7 +1049,7 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
             {
                 sMatterAwsInitScheduled = true;
                 ChipLogProgress(AppServer, "Scheduling Matter AWS initialization");
-                TEMPORARY_RETURN_IGNORED chip::DeviceLayer::SystemLayer().StartTimer(
+                RETURN_SAFELY_IGNORED chip::DeviceLayer::SystemLayer().StartTimer(
                     chip::System::Clock::Seconds32(MATTER_AWS_INIT_DELAY_SEC), InitMatterAwsHandler, nullptr);
             }
         }

--- a/examples/platform/silabs/matter_aws/matter_aws_interface/include/MatterAwsConfig.h
+++ b/examples/platform/silabs/matter_aws/matter_aws_interface/include/MatterAwsConfig.h
@@ -34,6 +34,8 @@
 #define MATTER_AWS_TASK_STACK_SIZE (2 * 1024) // 2k
 #define MATTER_AWS_TASK_PRIORITY (osPriorityAboveNormal)
 
+/* Delay before MatterAwsInit() when SL_MATTER_ENABLE_AWS is enabled and internet
+ * connectivity (IPv4, or IPv6 if dual-stack) is first reported as established. */
 #ifndef MATTER_AWS_INIT_DELAY_SEC
 #define MATTER_AWS_INIT_DELAY_SEC (5)
 #endif

--- a/examples/platform/silabs/matter_aws/matter_aws_interface/include/MatterAwsConfig.h
+++ b/examples/platform/silabs/matter_aws/matter_aws_interface/include/MatterAwsConfig.h
@@ -34,6 +34,10 @@
 #define MATTER_AWS_TASK_STACK_SIZE (2 * 1024) // 2k
 #define MATTER_AWS_TASK_PRIORITY (osPriorityAboveNormal)
 
+#ifndef MATTER_AWS_INIT_DELAY_SEC
+#define MATTER_AWS_INIT_DELAY_SEC (5)
+#endif
+
 /* Network Configuration */
 #define MATTER_AWS_SERVER_HOST ""
 #define MATTER_AWS_SERVER_PORT (8883)
@@ -59,6 +63,5 @@
 #define AWS_OTA_TASK_STACK_SIZE (1024)
 #define AWS_OTA_TASK_PRIORITY (1)
 #endif // SL_MATTER_ENABLE_AWS_OTA_FEAT
-
 
 #endif // __MATTER_AWS_CONFIG_H


### PR DESCRIPTION
#### Summary

Matter AWS task TLS connection fails due to to timeout randomly during commissioning. this is due to Matter AWS task competing for resources during commission.

Fix: 
As Matter AWS task ideally shoould start after commissioning, but trugger is based on ipv4 or ipv6 connectivity, so we are delaying the AWS task for 5 sec, to avoid conflcit for resources.
Matter AWS is POC at present, and this will be redesigned for GA .

#### Related issues



#### Testing
Previously failure seen - 3/10 times, after fix we saw 10/10 success.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
