### PR TITLE
[SL-ONLY] Set ZLL not factory new for both Sequential and Concurrent CMP after matter commissioning completes

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -175,6 +175,8 @@ bool sHaveBLEConnections = false;
 
 constexpr uint32_t kLightTimerPeriod = static_cast<uint32_t>(pdMS_TO_TICKS(10));
 
+constexpr System::Clock::Milliseconds32 kZbLeaveAnnouceDelay = System::Clock::Milliseconds32(1000);
+
 uint8_t sAppEventQueueBuffer[APP_EVENT_QUEUE_SIZE * sizeof(AppEvent)];
 osMessageQueue_t sAppEventQueueStruct;
 constexpr osMessageQueueAttr_t appEventQueueAttr = { .cb_mem  = &sAppEventQueueStruct,
@@ -348,6 +350,8 @@ CHIP_ERROR BaseApplication::Init()
     if (nbOfMatterFabric != 0)
     {
         Zigbee::RequestLeave();
+        RETURN_SAFELY_IGNORED DeviceLayer::SystemLayer().StartTimer(
+            kZbLeaveAnnouceDelay, [](System::Layer *, void *) { Zigbee::ZLLNotFactoryNew(); }, nullptr);
     }
     else
 #endif // SL_MATTER_ZIGBEE_SEQUENTIAL
@@ -1111,7 +1115,6 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 #ifdef SL_MATTER_ZIGBEE_SEQUENTIAL // Matter Zigbee sequential
         Zigbee::RequestLeave();
 #endif // SL_MATTER_ZIGBEE_SEQUENTIAL
-        constexpr System::Clock::Milliseconds32 kZbLeaveAnnouceDelay = System::Clock::Milliseconds32(1000);
         RETURN_SAFELY_IGNORED DeviceLayer::SystemLayer().StartTimer(
             kZbLeaveAnnouceDelay, [](System::Layer *, void *) { Zigbee::ZLLNotFactoryNew(); }, nullptr);
 #endif // SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -357,7 +357,10 @@ CHIP_ERROR BaseApplication::Init()
 #endif // SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
     SILABS_TRACE_END_ERROR(TimeTraceOperation::kAppInit, err);
     SILABS_TRACE_END_ERROR(TimeTraceOperation::kBootup, err);
-    if (err == CHIP_NO_ERROR) { mIsApplicationInitialized = true; }
+    if (err == CHIP_NO_ERROR)
+    {
+        mIsApplicationInitialized = true;
+    }
     return err;
 }
 
@@ -1107,8 +1110,10 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 #ifdef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 #ifdef SL_MATTER_ZIGBEE_SEQUENTIAL // Matter Zigbee sequential
         Zigbee::RequestLeave();
-        Zigbee::ZLLNotFactoryNew();
 #endif // SL_MATTER_ZIGBEE_SEQUENTIAL
+        constexpr System::Clock::Milliseconds32 kZbLeaveAnnouceDelay = System::Clock::Milliseconds32(1000);
+        RETURN_SAFELY_IGNORED DeviceLayer::SystemLayer().StartTimer(
+            kZbLeaveAnnouceDelay, [](System::Layer *, void *) { Zigbee::ZLLNotFactoryNew(); }, nullptr);
 #endif // SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
     }
     break;


### PR DESCRIPTION
### Summary
SQA reported instances failure to rejoin Thread/Matter network after a powercycle.
Log show that ZLL Init/Touchlink are active at boot even when we are part of a Matter network. This should not be the case after [#255](https://github.com/SiliconLabsSoftware/matter_sdk/pull/255) from previous releases addressing exactly this.

ZB Touchlink announcement have been proven in the pass to affect Thread attachment and SRP registration at bootup.

After investigation, we found that the Zigbee stack’s leave-network sequence clears our Not FactoryNew setting. On a Leave Network request, the stack runs a Leave Announcement period before the device actually leaves. If the device leaves without communicating with another device during that period, the stack resets the FactoryNew token and overwrites our setting.

The following changes ensure that this sequence do not impact our desired setting anymore.
- Add a Delay to our ZLLNotFactoryNew call: 
- Clear the ZB FactoryNew state for both Sequential and Concurrent.

### Related issues
https://jira.silabs.com/browse/MATTER-6389

### Testing
Commission CMP sequential app on Matter but not on Zigbee. Reboot the device. 
 - Validate that ZLL Init/touchlink is not done at bootup.