### PR TITLE
[SL-UP] [MATTER-6696] : fix Dor Lock macro assignments

### DIFF
--- a/examples/lock-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/lock-app/silabs/include/CHIPProjectConfig.h
@@ -130,13 +130,13 @@ static constexpr uint8_t kNumCredentialTypes         = 6;
  * A size, in bytes, of an individual credential.
  */
 
-#define DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH SilabsDoorLockConfig::ResourceRanges::kMaxCredentialsPerUser
+#define DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH SilabsDoorLockConfig::ResourceRanges::kMaxCredentialSize
 /**
- * DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH
+ * DOOR_LOCK_USER_CREDENTIALS_BUFFER_LENGTH
  *
  * Number of CredentialStructs attached to a user.
  */
-#define DOOR_LOCK_USER_CREDENTIALS_BUFFER_LENGTH SilabsDoorLockConfig::ResourceRanges::kMaxCredentialSize
+#define DOOR_LOCK_USER_CREDENTIALS_BUFFER_LENGTH SilabsDoorLockConfig::ResourceRanges::kMaxCredentialsPerUser
 
 // Enable `Extension` attribute of ACL Cluster as required by door locks
 #ifndef CHIP_CONFIG_ENABLE_ACL_EXTENSIONS


### PR DESCRIPTION
### Summary
Mix-up in the assignments of the macros,
DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH and DOOR_LOCK_USER_CREDENTIALS_BUFFER_LENGTH had opposite values assigned.

Fixed the value assignments and also fixed the comment. 
DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH (20)

DOOR_LOCK_USER_CREDENTIALS_BUFFER_LENGTH (10)

### Related issues
[MATTER-6696](https://jira.silabs.com/browse/MATTER-6696)

### Testing
CI