### PR TITLE
[SL-UP] Updated virtual function SleepButtonActionHandler to non-virtual

### DIFF
--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -55,7 +55,7 @@ public:
     static SilabsButtonCb mButtonCallback;
     uint8_t GetButtonState(uint8_t button) override;
 #if defined(SL_ICD_ENABLED) && SL_ICD_ENABLED == 1
-    void SleepButtonActionHandler(void) override;
+    void SleepButtonActionHandler(void);
 #endif // defined(SL_ICD_ENABLED) && SL_ICD_ENABLED == 1
 #endif // defined(SL_CATALOG_SIMPLE_BUTTON_PRESENT)
 

--- a/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
@@ -47,7 +47,6 @@ public:
     typedef void (*SilabsButtonCb)(uint8_t, uint8_t);
     virtual void SetButtonsCb(SilabsButtonCb callback) {}
     virtual uint8_t GetButtonState(uint8_t button) { return 0; }
-    virtual void SleepButtonActionHandler(void){};
 
     // LEDS
     virtual void InitLed(void) {}


### PR DESCRIPTION
### Summary
Made SleepButtonActionHandler a non-virtual function as the virtual API is causing the device to get stuck during OTA after soft reset. Similar to https://github.com/SiliconLabsSoftware/matter_sdk/pull/819

### Related issues
[MATTER-6373](https://jira.silabs.com/browse/MATTER-6373)

### Testing
- Tested OTA for ~10 times, the issue was not seen.
- Tested BTN0 functionality.
