### PR TITLE
[SL-UP] MATTER-6705: Fix CMP Sequential chipDie

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -350,8 +350,10 @@ CHIP_ERROR BaseApplication::Init()
     if (nbOfMatterFabric != 0)
     {
         Zigbee::RequestLeave();
+        PlatformMgr().LockChipStack();
         RETURN_SAFELY_IGNORED DeviceLayer::SystemLayer().StartTimer(
             kZbLeaveAnnouceDelay, [](System::Layer *, void *) { Zigbee::ZLLNotFactoryNew(); }, nullptr);
+        PlatformMgr().UnlockChipStack();
     }
     else
 #endif // SL_MATTER_ZIGBEE_SEQUENTIAL


### PR DESCRIPTION
### Summary
In https://github.com/SiliconLabsSoftware/matter_sdk/pull/1015, we introduce some changes to add delay to ZLLNotFactoryNewCall through StartTimer() in BaseApplication::Init() that runs without locking chip stack, which causes chipDie on assertion on app boot. 

Wrap the StartTimer() call in LockChipStack()/UnlockChipStack() 

### Related issues
MATTER-6705

### Testing
Build locally with lock, commission, reboot, verify no chipDie
