### PR TITLE
[SL-ONLY] : Update silabs-zap-failure-regen.yaml for release sync branches

### DIFF
--- a/.github/workflows/silabs-zap-failure-regen.yaml
+++ b/.github/workflows/silabs-zap-failure-regen.yaml
@@ -14,12 +14,12 @@ jobs:
             cancel-in-progress: true
 
         if:
-            ${{ github.event.workflow_run.conclusion == 'failure' &&
-            github.event.workflow_run.head_branch == 'automation/update_main' }}
+            ${{ github.event.workflow_run.conclusion == 'failure' && (
+            github.event.workflow_run.head_branch == 'automation/update_main' || startsWith(github.event.workflow_run.head_branch, 'automation/update_release_')) }}
 
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/project-chip/chip-build:129
+            image: ghcr.io/project-chip/chip-build:200
 
         steps:
             - name: Generate token for the workflow

--- a/.github/workflows/silabs-zap-failure-regen.yaml
+++ b/.github/workflows/silabs-zap-failure-regen.yaml
@@ -35,9 +35,22 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  ref: automation/update_main
+                  ref: ${{ github.event.workflow_run.head_branch }}
                   fetch-depth: 0
                   token: ${{ steps.generate_token.outputs.token }}
+
+            - name: Determine target and base branches
+              id: branch_info
+              run: |
+                  target_branch="${{ github.event.workflow_run.head_branch }}"
+                  if [[ "${target_branch}" == "automation/update_main" ]]; then
+                      base_branch="main"
+                  else
+                      base_branch="${target_branch#automation/update_}"
+                  fi
+
+                  echo "target_branch=${target_branch}" >> "${GITHUB_OUTPUT}"
+                  echo "base_branch=${base_branch}" >> "${GITHUB_OUTPUT}"
 
             - name: Checkout submodules & Bootstrap
               uses: ./.github/actions/checkout-submodules-and-bootstrap
@@ -45,17 +58,17 @@ jobs:
                   platform: linux
                   bootstrap-log-name: bootstrap-logs-zap-failure-regen
 
-            - name: Merge Fetch main branch
+            - name: Fetch base branch
               run: |
-                  git fetch --no-recurse-submodules origin main
+                  git fetch --no-recurse-submodules origin "${{ steps.branch_info.outputs.base_branch }}"
 
             - name: Set committer to GitHub App
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-            - name: Merge main branch into automation/update_main
-              run: git merge --no-edit origin/main
+            - name: Merge base branch into automation branch
+              run: git merge --no-edit "origin/${{ steps.branch_info.outputs.base_branch }}"
 
             - name: Generate Silabs examples zap files
               run: |
@@ -82,4 +95,4 @@ jobs:
               run: |
                   git add -A
                   git commit -m "[SL-ONLY] Regenerate ZAP files for Silabs apps"
-                  git push origin automation/update_main
+                  git push origin "${{ steps.branch_info.outputs.target_branch }}"

--- a/.github/workflows/silabs-zap-failure-regen.yaml
+++ b/.github/workflows/silabs-zap-failure-regen.yaml
@@ -33,7 +33,7 @@ jobs:
               run: echo "::add-mask::${{ steps.generate_token.outputs.token }}"
 
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   ref: ${{ github.event.workflow_run.head_branch }}
                   fetch-depth: 0


### PR DESCRIPTION
### Summary
Release sync branches do not get zap updates.
Root cause is that release branch is filtered in zap-regen workflow. 

### Related issues


### Testing

<!--
    Describe how you tested this change.

    Examples:
        - Added unit tests
        - Verified by YAML test: TC_ABC.yaml
        - Added Python test: TC_DEF.py
        - Manually tested (describe steps)

    Please replace this HTML comment with the actual testing details.
-->
