### PR TITLE
[SL-ONLY] Set ZLL not factory new for both Sequential and Concurrent CMP after matter commissioning completes

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -171,6 +171,8 @@ bool sHaveBLEConnections = false;
 
 constexpr uint32_t kLightTimerPeriod = static_cast<uint32_t>(pdMS_TO_TICKS(10));
 
+constexpr System::Clock::Milliseconds32 kZbLeaveAnnouceDelay = System::Clock::Milliseconds32(1000);
+
 uint8_t sAppEventQueueBuffer[APP_EVENT_QUEUE_SIZE * sizeof(AppEvent)];
 osMessageQueue_t sAppEventQueueStruct;
 constexpr osMessageQueueAttr_t appEventQueueAttr = { .cb_mem  = &sAppEventQueueStruct,
@@ -341,6 +343,8 @@ CHIP_ERROR BaseApplication::Init()
     if (nbOfMatterFabric != 0)
     {
         Zigbee::RequestLeave();
+        RETURN_SAFELY_IGNORED DeviceLayer::SystemLayer().StartTimer(
+            kZbLeaveAnnouceDelay, [](System::Layer *, void *) { Zigbee::ZLLNotFactoryNew(); }, nullptr);
     }
     else
 #endif // SL_MATTER_ZIGBEE_SEQUENTIAL
@@ -1073,8 +1077,9 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 #ifdef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 #ifdef SL_MATTER_ZIGBEE_SEQUENTIAL // Matter Zigbee sequential
         Zigbee::RequestLeave();
-        Zigbee::ZLLNotFactoryNew();
 #endif // SL_MATTER_ZIGBEE_SEQUENTIAL
+        RETURN_SAFELY_IGNORED DeviceLayer::SystemLayer().StartTimer(
+            kZbLeaveAnnouceDelay, [](System::Layer *, void *) { Zigbee::ZLLNotFactoryNew(); }, nullptr);
 #endif // SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
     }
     break;


### PR DESCRIPTION
### Summary

Cherry-pick of #1015 onto `main`.

Refer to the original PR #1015 for the full description and rationale.

A merge conflict in `examples/platform/silabs/BaseApplication.cpp` was resolved by dropping an incidental reformatting hunk for `mIsApplicationInitialized`, which does not exist on `main`. The functional ZLL timer changes were applied unchanged.

### Testing

Cherry-pick only. No functional changes relative to #1015; testing is covered by the original PR.