### PR TITLE
[SL-TEMP]Add to the Matter BLE advertissement handle in the ble info

### DIFF
--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -196,7 +196,8 @@ uint16_t BLEManagerImpl::_NumConnections(void)
 
 CHIP_ERROR BLEManagerImpl::PrintBLEInfo() const
 {
-    ChipLogProgress(DeviceLayer, "BLE Info:");
+    ChipLogProgress(DeviceLayer, "Matter BLE Info:");
+    ChipLogProgress(DeviceLayer, "  Handle: %d", mAdvertisingSetHandle);
     ChipLogProgress(DeviceLayer, "  Service Mode: %d", mServiceMode);
     ChipLogProgress(DeviceLayer, "  Device Name: %s", mDeviceName);
     ChipLogProgress(DeviceLayer, "  Random Static Address: %02X:%02X:%02X:%02X:%02X:%02X", randomizedAddr.addr[5],


### PR DESCRIPTION
### Summary

Cherry-pick of #952 onto `main`.

Refer to the original PR #952 for the full description and rationale.

### Testing

Cherry-pick only. No functional changes relative to #952; testing is covered by the original PR.