### PR TITLE
[SL-ONLY] Fix build errors seen with Code-driven migration of mode-base cluster

### DIFF
--- a/examples/oven-app/oven-app-common/include/OvenEndpoint.h
+++ b/examples/oven-app/oven-app-common/include/OvenEndpoint.h
@@ -105,6 +105,13 @@ public:
      */
     OvenModeDelegate & GetOvenModeDelegate() { return mOvenModeDelegate; }
 
+    /**
+     * @brief Get the oven mode cluster instance.
+     *
+     * @return Reference to the oven mode cluster instance.
+     */
+    ModeBase::Instance & GetOvenModeInstance() { return mOvenModeInstance; }
+
 private:
     EndpointId mEndpointId = kInvalidEndpointId;
     OvenModeDelegate mOvenModeDelegate;

--- a/examples/oven-app/oven-app-common/src/OvenEndpoint.cpp
+++ b/examples/oven-app/oven-app-common/src/OvenEndpoint.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "OvenEndpoint.h"
-#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
 
 #include "OvenManager.h"
@@ -101,43 +100,12 @@ void OvenModeDelegate::HandleChangeToMode(uint8_t NewMode, ModeBase::Commands::C
         }
     };
 
-    // Verify newMode is among supported modes
-    if (!IsSupportedMode(NewMode))
-    {
-        setResponse(ModeBase::StatusCode::kUnsupportedMode);
-        return;
-    }
-
-    // Read Current Oven Mode
-    uint8_t currentMode;
-    Status attrStatus = OvenMode::Attributes::CurrentMode::Get(mEndpointId, &currentMode);
-    if (attrStatus != Status::Success)
-    {
-        ChipLogError(AppServer, "OvenManager: Failed to read CurrentMode");
-        setResponse(ModeBase::StatusCode::kGenericFailure, "Read CurrentMode failed");
-        return;
-    }
-
-    // No action needed if current mode is the same as new mode
-    if (currentMode == NewMode)
-    {
-        setResponse(ModeBase::StatusCode::kSuccess);
-        return;
-    }
+    const uint8_t currentMode = GetInstance()->GetCurrentMode();
 
     if (OvenManager::GetInstance().IsTransitionBlocked(currentMode, NewMode))
     {
         ChipLogProgress(AppServer, "OvenManager: Blocked transition %u -> %u", currentMode, NewMode);
         setResponse(ModeBase::StatusCode::kGenericFailure, "Transition blocked");
-        return;
-    }
-
-    // Write new mode
-    Status writeStatus = OvenMode::Attributes::CurrentMode::Set(mEndpointId, NewMode);
-    if (writeStatus != Status::Success)
-    {
-        ChipLogError(AppServer, "OvenManager: Failed to write CurrentMode");
-        setResponse(ModeBase::StatusCode::kGenericFailure, "Write CurrentMode failed");
         return;
     }
 

--- a/examples/oven-app/oven-app-common/src/OvenEndpoint.cpp
+++ b/examples/oven-app/oven-app-common/src/OvenEndpoint.cpp
@@ -100,6 +100,8 @@ void OvenModeDelegate::HandleChangeToMode(uint8_t NewMode, ModeBase::Commands::C
         }
     };
 
+    VerifyOrReturn(GetInstance() != nullptr, ChipLogError(AppServer, "Delegate not initialized"));
+
     const uint8_t currentMode = GetInstance()->GetCurrentMode();
 
     if (OvenManager::GetInstance().IsTransitionBlocked(currentMode, NewMode))

--- a/examples/oven-app/silabs/include/OvenManager.h
+++ b/examples/oven-app/silabs/include/OvenManager.h
@@ -34,16 +34,20 @@
 #include "AppEvent.h"
 
 #include <app-common/zap-generated/ids/Attributes.h>
+#include <app/data-model-provider/AttributeChangeListener.h>
 #include <app/clusters/mode-base-server/mode-base-cluster-objects.h>
 #include <app/clusters/on-off-server/on-off-server.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/TypeTraits.h>
 #include <platform/CHIPDeviceLayer.h>
 
-class OvenManager
+class OvenManager : public chip::app::DataModel::AttributeChangeListener
 {
 
 public:
+    void OnAttributeChanged(const chip::app::ConcreteAttributePath & path,
+                            chip::app::DataModel::AttributeChangeType type) override;
+
     enum Action_t
     {
         COOK_TOP_ON_ACTION = 0,
@@ -86,16 +90,6 @@ public:
     void OnOffAttributeChangeHandler(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value, uint16_t size);
 
     /**
-     * @brief Handles oven mode attribute changes.
-     *
-     * @param endpointId The ID of the endpoint.
-     * @param attributeId The ID of the attribute.
-     * @param value Pointer to the new value.
-     * @param size Size of the new value.
-     */
-    void OvenModeAttributeChangeHandler(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value, uint16_t size);
-
-    /**
      * @brief Checks if a transition between two oven modes is blocked.
      *
      * @param fromMode The current mode.
@@ -122,6 +116,9 @@ public:
     static constexpr chip::EndpointId GetCookTopEndpoint() { return kCookTopEndpoint; }
 
 private:
+    void HandleOvenModeChanged(uint8_t newMode);
+
+    bool mAttributeListenerRegistered = false;
     static constexpr uint8_t kBlockedTransitionCount = 3; // Number of blocked transitions
     struct BlockedTransition
     {

--- a/examples/oven-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/oven-app/silabs/src/DataModelCallbacks.cpp
@@ -31,6 +31,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/util/generic-callbacks.h>
 
 using namespace ::chip;
 using namespace ::chip::app;
@@ -55,12 +56,11 @@ void MatterPostAttributeChangeCallback(const ConcreteAttributePath & attributePa
         ChipLogDetail(Zcl, "TemperatureControl cluster ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u",
                       ChipLogValueMEI(attributeId), type, *value, size);
         break;
-    case Clusters::OvenMode::Id:
-        ChipLogDetail(Zcl, "OvenMode cluster ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u", ChipLogValueMEI(attributeId),
-                      type, *value, size);
-        OvenManager::GetInstance().OvenModeAttributeChangeHandler(attributePath.mEndpointId, attributeId, value, size);
-        break;
     default:
         break;
     }
 }
+
+void MatterOvenModeClusterInitCallback(EndpointId endpointId) {}
+
+void MatterOvenModeClusterShutdownCallback(EndpointId endpointId, MatterClusterShutdownType) {}

--- a/examples/oven-app/silabs/src/OvenManager.cpp
+++ b/examples/oven-app/silabs/src/OvenManager.cpp
@@ -22,6 +22,7 @@
 #include "OvenEndpoint.h"
 
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/InteractionModelEngine.h>
 #include <app/clusters/mode-base-server/mode-base-cluster-objects.h>
 #include <app/clusters/temperature-control-server/CodegenIntegration.h>
 #include <app/clusters/temperature-measurement-server/CodegenIntegration.h>
@@ -40,6 +41,15 @@ OvenManager OvenManager::sOvenMgr;
 
 void OvenManager::Init()
 {
+    DataModel::Provider * provider = InteractionModelEngine::GetInstance()->GetDataModelProvider();
+    VerifyOrReturn(provider != nullptr, ChipLogError(AppServer, "DataModel provider not available"));
+
+    if (!mAttributeListenerRegistered)
+    {
+        provider->RegisterAttributeChangeListener(*this);
+        mAttributeListenerRegistered = true;
+    }
+
     // Endpoint initializations
 
     CHIP_ERROR initErr = mTemperatureControlledCabinetEndpoint.Init();
@@ -90,6 +100,33 @@ void OvenManager::Init()
                    ChipLogError(AppServer, "Getting CookSurfaceEndpoint2 OnOff state failed"));
 
     mCurrentOvenMode = mTemperatureControlledCabinetEndpoint.GetOvenModeInstance().GetCurrentMode();
+}
+
+void OvenManager::OnAttributeChanged(const ConcreteAttributePath & path, DataModel::AttributeChangeType type)
+{
+    if (path.mEndpointId != kTemperatureControlledCabinetEndpoint || path.mClusterId != OvenMode::Id ||
+        path.mAttributeId != OvenMode::Attributes::CurrentMode::Id)
+    {
+        return;
+    }
+
+    HandleOvenModeChanged(mTemperatureControlledCabinetEndpoint.GetOvenModeInstance().GetCurrentMode());
+}
+
+void OvenManager::HandleOvenModeChanged(uint8_t newMode)
+{
+    if (mCurrentOvenMode == newMode)
+    {
+        return;
+    }
+
+    mCurrentOvenMode = newMode;
+
+    AppEvent event         = {};
+    event.Type             = AppEvent::kEventType_Oven;
+    event.OvenEvent.Action = OVEN_MODE_UPDATE_ACTION;
+    event.Handler          = AppTask::OvenActionHandler;
+    AppTask::GetAppTask().PostEvent(&event);
 }
 
 CHIP_ERROR OvenManager::SetCookSurfaceInitialState(EndpointId cookSurfaceEndpoint)
@@ -183,19 +220,6 @@ void OvenManager::OnOffAttributeChangeHandler(EndpointId endpointId, AttributeId
         event.Handler          = AppTask::OvenActionHandler;
         AppTask::GetAppTask().PostEvent(&event);
     }
-}
-
-void OvenManager::OvenModeAttributeChangeHandler(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value,
-                                                 uint16_t size)
-{
-    VerifyOrReturn(value != nullptr, ChipLogError(AppServer, "OvenModeAttributeChangeHandler: value pointer is null"));
-
-    mCurrentOvenMode       = *value;
-    AppEvent event         = {};
-    event.Type             = AppEvent::kEventType_Oven;
-    event.OvenEvent.Action = OVEN_MODE_UPDATE_ACTION;
-    event.Handler          = AppTask::OvenActionHandler;
-    AppTask::GetAppTask().PostEvent(&event);
 }
 
 bool OvenManager::IsTransitionBlocked(uint8_t fromMode, uint8_t toMode)

--- a/examples/oven-app/silabs/src/OvenManager.cpp
+++ b/examples/oven-app/silabs/src/OvenManager.cpp
@@ -21,7 +21,6 @@
 #include "OvenBindingHandler.h"
 #include "OvenEndpoint.h"
 
-#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/clusters/mode-base-server/mode-base-cluster-objects.h>
 #include <app/clusters/temperature-control-server/CodegenIntegration.h>
@@ -90,10 +89,7 @@ void OvenManager::Init()
     VerifyOrReturn(OnOffServer::Instance().getOnOffValue(kCookSurfaceEndpoint2, &mIsCookSurface2On) == Status::Success,
                    ChipLogError(AppServer, "Getting CookSurfaceEndpoint2 OnOff state failed"));
 
-    // Get current oven mode
-    VerifyOrReturn(OvenMode::Attributes::CurrentMode::Get(kTemperatureControlledCabinetEndpoint, &mCurrentOvenMode) ==
-                       Status::Success,
-                   ChipLogError(AppServer, "Getting CurrentOvenMode failed"));
+    mCurrentOvenMode = mTemperatureControlledCabinetEndpoint.GetOvenModeInstance().GetCurrentMode();
 }
 
 CHIP_ERROR OvenManager::SetCookSurfaceInitialState(EndpointId cookSurfaceEndpoint)

--- a/examples/oven-app/silabs/src/OvenManager.cpp
+++ b/examples/oven-app/silabs/src/OvenManager.cpp
@@ -104,21 +104,16 @@ void OvenManager::Init()
 
 void OvenManager::OnAttributeChanged(const ConcreteAttributePath & path, DataModel::AttributeChangeType type)
 {
-    if (path.mEndpointId != kTemperatureControlledCabinetEndpoint || path.mClusterId != OvenMode::Id ||
-        path.mAttributeId != OvenMode::Attributes::CurrentMode::Id)
-    {
-        return;
-    }
+    VerifyOrReturn(path.mEndpointId == kTemperatureControlledCabinetEndpoint, ChipLogError(AppServer, "OnAttributeChanged: path.mEndpointId is invalid"));
+    VerifyOrReturn(path.mClusterId == OvenMode::Id, ChipLogError(AppServer, "OnAttributeChanged: path.mClusterId is invalid"));
+    VerifyOrReturn(path.mAttributeId == OvenMode::Attributes::CurrentMode::Id, ChipLogError(AppServer, "OnAttributeChanged: path.mAttributeId is invalid"));
 
     HandleOvenModeChanged(mTemperatureControlledCabinetEndpoint.GetOvenModeInstance().GetCurrentMode());
 }
 
 void OvenManager::HandleOvenModeChanged(uint8_t newMode)
 {
-    if (mCurrentOvenMode == newMode)
-    {
-        return;
-    }
+    VerifyOrReturn(mCurrentOvenMode != newMode, ChipLogProgress(AppServer, "OvenManager: newMode is the same as current mode"));
 
     mCurrentOvenMode = newMode;
 


### PR DESCRIPTION
### Summary
Mode-Base cluster has been moved to Code-driven approach. Due to this, build failures are seen in oven-app.
This PR fixes the failures seen by pushing required changes.


### Related issues

[MATTER-6783](https://jira.silabs.com/browse/MATTER-6783)

### Testing
CI build of oven-app
