### PR TITLE
[SL-TEMP]Remove sli_zigbee_af_print_internal_var_arg until sisdk 2026.6 is pickup

### DIFF
--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -323,6 +323,7 @@ extern "C" void LwIPLog(const char * aFormat, ...)
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
+#if 0 // [SL-TEMP] sli_zigbee_af_print_internal_var_arg requires sisdk 2026.6 or later.
 #if defined(SL_COMPONENT_CATALOG_PRESENT) &&                                                                                       \
     (defined(SL_CATALOG_ZIGBEE_ZCL_CLI_PRESENT) || defined(SL_CATALOG_ZIGBEE_DEBUG_PRINT_PRESENT))
 #include "zcl-debug-print.h"
@@ -378,6 +379,7 @@ extern "C" void sli_zigbee_af_print_internal_var_arg(uint16_t area, uint32_t log
 }
 #endif // defined(SL_COMPONENT_CATALOG_PRESENT) && (defined(SL_CATALOG_ZIGBEE_ZCL_CLI_PRESENT) ||
        // defined(SL_CATALOG_ZIGBEE_DEBUG_PRINT_PRESENT))
+#endif // 0 - [SL-TEMP] sli_zigbee_af_print_internal_var_arg requires sisdk 2026.6 or later.
 
 /**
  * Platform logging function for OpenThread


### PR DESCRIPTION
### Summary
The printing weak function`sli_zigbee_af_print_internal_var_arg` has been added in sisdk-2026.6
It was implemented in our common logging code for the release.
Matter_extension main as not been updated yet thus we remove the function implementation until it is available.

### Testing
build CMP app with matter_extension main
