### PR TITLE
[SL-ONLY]  Cherry-pick llvm build release (#956)

### DIFF
--- a/examples/closure-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/closure-app/silabs/src/DataModelCallbacks.cpp
@@ -34,14 +34,15 @@
 #include <app/clusters/closure-control-server/CodegenIntegration.h>
 
 using namespace ::chip;
+using namespace ::chip::app;
 using namespace ::chip::app::Clusters::ClosureControl;
 
-void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
+void MatterPostAttributeChangeCallback(const ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
     switch (attributePath.mClusterId)
     {
-    case app::Clusters::Identify::Id:
+    case Clusters::Identify::Id:
         ChipLogProgress(Zcl, "Identify cluster ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u",
                         ChipLogValueMEI(attributePath.mAttributeId), type, *value, size);
         break;
@@ -51,11 +52,11 @@ void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attrib
 }
 
 /* Forwards all attributes changes */
-void MatterClosureControlClusterServerAttributeChangedCallback(const app::ConcreteAttributePath & attributePath)
+void MatterClosureControlClusterServerAttributeChangedCallback(const ConcreteAttributePath & attributePath)
 {
     ChipLogProgress(Zcl, "Closure Control cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(attributePath.mAttributeId));
 #ifdef DISPLAY_ENABLED
-    using namespace chip::app::Clusters::ClosureControl::Attributes;
+    using namespace Clusters::ClosureControl::Attributes;
 
     switch (attributePath.mAttributeId)
     {
@@ -73,7 +74,7 @@ void MatterClosureControlClusterServerAttributeChangedCallback(const app::Concre
 #endif // DISPLAY_ENABLED
 }
 
-void MatterClosureDimensionClusterServerAttributeChangedCallback(const app::ConcreteAttributePath & attributePath)
+void MatterClosureDimensionClusterServerAttributeChangedCallback(const ConcreteAttributePath & attributePath)
 {
     ChipLogProgress(Zcl, "Closure Dimension cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(attributePath.mAttributeId));
 }

--- a/examples/fan-control-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/fan-control-app/silabs/src/DataModelCallbacks.cpp
@@ -31,9 +31,10 @@
 // TODO: Add support for DIC
 
 using namespace ::chip;
+using namespace ::chip::app;
 using namespace ::chip::app::Clusters;
 
-void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
+void MatterPostAttributeChangeCallback(const ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
     ClusterId clusterId     = attributePath.mClusterId;
@@ -45,7 +46,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     case FanControl::Id:
         FanControlMgr().HandleFanControlAttributeChange(attributeId, type, size, value);
         break;
-    case Identify::Id:
+    case Clusters::Identify::Id:
         ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u",
                         ChipLogValueMEI(attributeId), type, *value, size);
         break;

--- a/examples/multi-sensor-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/multi-sensor-app/silabs/src/DataModelCallbacks.cpp
@@ -29,9 +29,10 @@
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;
+using namespace ::chip::app;
 using namespace ::chip::app::Clusters;
 
-void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
+void MatterPostAttributeChangeCallback(const ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
     ClusterId clusterId     = attributePath.mClusterId;
@@ -40,7 +41,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 
     switch (clusterId)
     {
-    case Identify::Id:
+    case Clusters::Identify::Id:
         ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u",
                         ChipLogValueMEI(attributeId), type, *value, size);
         break;

--- a/examples/oven-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/oven-app/silabs/src/DataModelCallbacks.cpp
@@ -33,28 +33,29 @@
 #include <app/ConcreteCommandPath.h>
 
 using namespace ::chip;
+using namespace ::chip::app;
 
-void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
+void MatterPostAttributeChangeCallback(const ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
     ClusterId clusterId     = attributePath.mClusterId;
     AttributeId attributeId = attributePath.mAttributeId;
     switch (clusterId)
     {
-    case app::Clusters::Identify::Id:
+    case Clusters::Identify::Id:
         ChipLogDetail(Zcl, "Identify cluster ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u", ChipLogValueMEI(attributeId),
                       type, *value, size);
         break;
-    case app::Clusters::OnOff::Id:
+    case Clusters::OnOff::Id:
         ChipLogDetail(Zcl, "OnOff cluster ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u", ChipLogValueMEI(attributeId),
                       type, *value, size);
         OvenManager::GetInstance().OnOffAttributeChangeHandler(attributePath.mEndpointId, attributeId, value, size);
         break;
-    case app::Clusters::TemperatureControl::Id:
+    case Clusters::TemperatureControl::Id:
         ChipLogDetail(Zcl, "TemperatureControl cluster ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u",
                       ChipLogValueMEI(attributeId), type, *value, size);
         break;
-    case app::Clusters::OvenMode::Id:
+    case Clusters::OvenMode::Id:
         ChipLogDetail(Zcl, "OvenMode cluster ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u", ChipLogValueMEI(attributeId),
                       type, *value, size);
         OvenManager::GetInstance().OvenModeAttributeChangeHandler(attributePath.mEndpointId, attributeId, value, size);

--- a/examples/rangehood-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/rangehood-app/silabs/src/DataModelCallbacks.cpp
@@ -34,9 +34,10 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 
 using namespace ::chip;
+using namespace ::chip::app;
 using namespace ::chip::app::Clusters;
 
-void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
+void MatterPostAttributeChangeCallback(const ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
     ClusterId clusterId     = attributePath.mClusterId;
@@ -61,7 +62,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
         RangeHoodManager::GetInstance().OnOffAttributeChangeHandler(endpointId, attributeId, value, size);
         break;
 
-    case Identify::Id:
+    case Clusters::Identify::Id:
         ChipLogDetail(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u on endpoint %u",
                       ChipLogValueMEI(attributeId), type, *value, size, endpointId);
         break;

--- a/examples/refrigerator-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/refrigerator-app/silabs/src/DataModelCallbacks.cpp
@@ -32,9 +32,10 @@
 #endif // SL_MATTER_ENABLE_AWS
 
 using namespace ::chip;
+using namespace ::chip::app;
 using namespace ::chip::app::Clusters;
 
-void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
+void MatterPostAttributeChangeCallback(const ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
     ClusterId clusterId     = attributePath.mClusterId;
@@ -43,17 +44,17 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 
     switch (clusterId)
     {
-    case app::Clusters::Identify::Id:
+    case Clusters::Identify::Id:
         ChipLogProgress(Zcl, "Identify cluster ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u",
                         ChipLogValueMEI(attributePath.mAttributeId), type, *value, size);
         break;
-    case app::Clusters::RefrigeratorAlarm::Id:
+    case Clusters::RefrigeratorAlarm::Id:
         RefrigeratorMgr().RefAlarmAttributeChangeHandler(attributePath.mEndpointId, attributeId, value, size);
 #ifdef SL_MATTER_ENABLE_AWS
         matterAws::control::AttributeHandler(attributePath.mEndpointId, attributeId);
 #endif // SL_MATTER_ENABLE_AWS
         break;
-    case app::Clusters::TemperatureControl::Id:
+    case Clusters::TemperatureControl::Id:
         RefrigeratorMgr().TempCtrlAttributeChangeHandler(attributePath.mEndpointId, attributeId, value, size);
 #ifdef SL_MATTER_ENABLE_AWS
         matterAws::control::AttributeHandler(attributePath.mEndpointId, attributeId);

--- a/examples/window-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/window-app/silabs/src/DataModelCallbacks.cpp
@@ -34,14 +34,15 @@
 #include <app/clusters/window-covering-server/window-covering-server.h>
 
 using namespace ::chip;
+using namespace ::chip::app;
 using namespace ::chip::app::Clusters::WindowCovering;
 
-void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
+void MatterPostAttributeChangeCallback(const ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
     switch (attributePath.mClusterId)
     {
-    case app::Clusters::Identify::Id:
+    case Clusters::Identify::Id:
         ChipLogProgress(Zcl, "Identify cluster ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u",
                         ChipLogValueMEI(attributePath.mAttributeId), type, *value, size);
         break;
@@ -51,7 +52,7 @@ void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attrib
 }
 
 /* Forwards all attributes changes */
-void MatterWindowCoveringClusterServerAttributeChangedCallback(const app::ConcreteAttributePath & attributePath)
+void MatterWindowCoveringClusterServerAttributeChangedCallback(const ConcreteAttributePath & attributePath)
 {
     WindowManager::Instance().PostAttributeChange(attributePath.mEndpointId, attributePath.mAttributeId);
 }


### PR DESCRIPTION
* Fixed ambiguous calls to 'Identify'

* standardized the namespace usage in DataModelCallbacks

### Summary

Changes to allow a build using LLVM from matter extension main.

### Related issues

n/a

### Testing

Cherry-pick, this already was tested during release.
