### PR TITLE
[SL-TEMP] Cherry-pick (#1000) Increased the Identify cluster pool to include client serve…

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -201,7 +201,10 @@ SilabsLCD slLCD;
 #ifdef MATTER_DM_PLUGIN_IDENTIFY_SERVER
 Clusters::Identify::EffectIdentifierEnum sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
 
-ObjectPool<Identify, MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT> IdentifyPool;
+ObjectPool<Identify,
+           MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT + MATTER_DM_IDENTIFY_CLUSTER_CLIENT_ENDPOINT_COUNT +
+               CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT>
+    IdentifyPool;
 
 #endif // MATTER_DM_PLUGIN_IDENTIFY_SERVER
 


### PR DESCRIPTION
### Summary

Cherry-pick
Increased the Identify cluster pool to include client servers

Why still needed:
See slack thread [here](https://csa-matter.slack.com/archives/C08MX3VB7N0/p1780669248249889)

I haven't seen a PR in code driven letting me believe this was addressed in CSA, so we should keep the fix.

### Related issues

n/a

### Testing

Cherry-pick, this was tested in the release branch.
