### PR TITLE
[SL-ONLY] MATTER-6156 MATTER-6350: Fix multiple definition errors when MATTER AWS and ALTCP are enabled

### DIFF
--- a/src/platform/silabs/mqtt/mqtt_transport_interface/include/MQTT_transport.h
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/include/MQTT_transport.h
@@ -49,6 +49,6 @@ err_t MQTT_Transport_SSLConfigure(MQTT_Transport_t * transP, const u8_t * ca, si
                                   size_t privkey_len, const u8_t * privkey_pass, size_t privkey_pass_len, const u8_t * cert,
                                   size_t cert_len);
 err_t MQTT_Transport_Connect(MQTT_Transport_t * client, const char * host, size_t hostLen, u16_t port,
-                             matter_aws_connect_cb matterAws_con_cb);
+                             matter_aws_connect_cb connect_cb);
 
 #endif // MQTT_TRANSPORT_H

--- a/src/platform/silabs/mqtt/mqtt_transport_interface/include/altcp.h
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/include/altcp.h
@@ -128,49 +128,49 @@ void silabsLog(const char * aFormat, ...);
         }                                                                                                                          \
     } while (0)
 
-struct altcp_pcb * altcp_new(altcp_allocator_t * allocator);
-struct altcp_pcb * altcp_new_ip6(altcp_allocator_t * allocator);
-struct altcp_pcb * altcp_new_ip_type(altcp_allocator_t * allocator, u8_t ip_type);
+struct altcp_pcb * matter_aws_altcp_new(altcp_allocator_t * allocator);
+struct altcp_pcb * matter_aws_altcp_new_ip6(altcp_allocator_t * allocator);
+struct altcp_pcb * matter_aws_altcp_new_ip_type(altcp_allocator_t * allocator, u8_t ip_type);
 
-void altcp_arg(struct altcp_pcb * conn, void * arg);
-void altcp_accept(struct altcp_pcb * conn, altcp_accept_fn accept);
-void altcp_recv(struct altcp_pcb * conn, altcp_recv_fn recv);
-void altcp_sent(struct altcp_pcb * conn, altcp_sent_fn sent);
-void altcp_poll(struct altcp_pcb * conn, altcp_poll_fn poll, u8_t interval);
-void altcp_err(struct altcp_pcb * conn, altcp_err_fn err);
+void matter_aws_altcp_arg(struct altcp_pcb * conn, void * arg);
+void matter_aws_altcp_accept(struct altcp_pcb * conn, altcp_accept_fn accept);
+void matter_aws_altcp_recv(struct altcp_pcb * conn, altcp_recv_fn recv);
+void matter_aws_altcp_sent(struct altcp_pcb * conn, altcp_sent_fn sent);
+void matter_aws_altcp_poll(struct altcp_pcb * conn, altcp_poll_fn poll, u8_t interval);
+void matter_aws_altcp_err(struct altcp_pcb * conn, altcp_err_fn err);
 
-void altcp_recved(struct altcp_pcb * conn, u16_t len);
-err_t altcp_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port);
-err_t altcp_connect(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port, altcp_connected_fn connected);
+void matter_aws_altcp_recved(struct altcp_pcb * conn, u16_t len);
+err_t matter_aws_altcp_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port);
+err_t matter_aws_altcp_connect(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port, altcp_connected_fn connected);
 
 /* return conn for source code compatibility to tcp callback API only */
-struct altcp_pcb * altcp_listen_with_backlog_and_err(struct altcp_pcb * conn, u8_t backlog, err_t * err);
-#define altcp_listen_with_backlog(conn, backlog) altcp_listen_with_backlog_and_err(conn, backlog, NULL)
+struct altcp_pcb * matter_aws_altcp_listen_with_backlog_and_err(struct altcp_pcb * conn, u8_t backlog, err_t * err);
+#define altcp_listen_with_backlog(conn, backlog) matter_aws_altcp_listen_with_backlog_and_err(conn, backlog, NULL)
 /** @ingroup altcp */
-#define altcp_listen(conn) altcp_listen_with_backlog_and_err(conn, TCP_DEFAULT_LISTEN_BACKLOG, NULL)
+#define altcp_listen(conn) matter_aws_altcp_listen_with_backlog_and_err(conn, TCP_DEFAULT_LISTEN_BACKLOG, NULL)
 
-void altcp_abort(struct altcp_pcb * conn);
-err_t altcp_close(struct altcp_pcb * conn);
-err_t altcp_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx);
+void matter_aws_altcp_abort(struct altcp_pcb * conn);
+err_t matter_aws_altcp_close(struct altcp_pcb * conn);
+err_t matter_aws_altcp_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx);
 
-err_t altcp_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags);
-err_t altcp_output(struct altcp_pcb * conn);
+err_t matter_aws_altcp_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags);
+err_t matter_aws_altcp_output(struct altcp_pcb * conn);
 
-u16_t altcp_mss(struct altcp_pcb * conn);
-u16_t altcp_sndbuf(struct altcp_pcb * conn);
-u16_t altcp_sndqueuelen(struct altcp_pcb * conn);
-void altcp_nagle_disable(struct altcp_pcb * conn);
-void altcp_nagle_enable(struct altcp_pcb * conn);
-int altcp_nagle_disabled(struct altcp_pcb * conn);
+u16_t matter_aws_altcp_mss(struct altcp_pcb * conn);
+u16_t matter_aws_altcp_sndbuf(struct altcp_pcb * conn);
+u16_t matter_aws_altcp_sndqueuelen(struct altcp_pcb * conn);
+void matter_aws_altcp_nagle_disable(struct altcp_pcb * conn);
+void matter_aws_altcp_nagle_enable(struct altcp_pcb * conn);
+int matter_aws_altcp_nagle_disabled(struct altcp_pcb * conn);
 
-void altcp_setprio(struct altcp_pcb * conn, u8_t prio);
+void matter_aws_altcp_setprio(struct altcp_pcb * conn, u8_t prio);
 
-err_t altcp_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_addr_t * addr, u16_t * port);
-ip_addr_t * altcp_get_ip(struct altcp_pcb * conn, int local);
-u16_t altcp_get_port(struct altcp_pcb * conn, int local);
+err_t matter_aws_altcp_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_addr_t * addr, u16_t * port);
+ip_addr_t * matter_aws_altcp_get_ip(struct altcp_pcb * conn, int local);
+u16_t matter_aws_altcp_get_port(struct altcp_pcb * conn, int local);
 
 #ifdef ALTCP_DEBUG
-enum tcp_state altcp_dbg_get_tcp_state(struct altcp_pcb * conn);
+enum tcp_state matter_aws_altcp_dbg_get_tcp_state(struct altcp_pcb * conn);
 #endif
 
 #else /* TRANSPORT_ALTCP */
@@ -187,49 +187,49 @@ enum tcp_state altcp_dbg_get_tcp_state(struct altcp_pcb * conn);
 #define altcp_err_fn tcp_err_fn
 
 #define altcp_pcb tcp_pcb
-#define altcp_tcp_new_ip_type tcp_new_ip_type
+#define matter_aws_altcp_tcp_new_ip_type tcp_new_ip_type
 #define altcp_tcp_new tcp_new
 #define altcp_tcp_new_ip6 tcp_new_ip6
 
-#define altcp_new(allocator) tcp_new()
-#define altcp_new_ip6(allocator) tcp_new_ip6()
-#define altcp_new_ip_type(allocator, ip_type) tcp_new_ip_type(ip_type)
+#define matter_aws_altcp_new(allocator) tcp_new()
+#define matter_aws_altcp_new_ip6(allocator) tcp_new_ip6()
+#define matter_aws_altcp_new_ip_type(allocator, ip_type) tcp_new_ip_type(ip_type)
 
-#define altcp_arg tcp_arg
-#define altcp_accept tcp_accept
-#define altcp_recv tcp_recv
-#define altcp_sent tcp_sent
-#define altcp_poll tcp_poll
-#define altcp_err tcp_err
+#define matter_aws_altcp_arg tcp_arg
+#define matter_aws_altcp_accept tcp_accept
+#define matter_aws_altcp_recv tcp_recv
+#define matter_aws_altcp_sent tcp_sent
+#define matter_aws_altcp_poll tcp_poll
+#define matter_aws_altcp_err tcp_err
 
-#define altcp_recved tcp_recved
-#define altcp_bind tcp_bind
-#define altcp_connect tcp_connect
+#define matter_aws_altcp_recved tcp_recved
+#define matter_aws_altcp_bind tcp_bind
+#define matter_aws_altcp_connect tcp_connect
 
-#define altcp_listen_with_backlog_and_err tcp_listen_with_backlog_and_err
+#define matter_aws_altcp_listen_with_backlog_and_err tcp_listen_with_backlog_and_err
 #define altcp_listen_with_backlog tcp_listen_with_backlog
 #define altcp_listen tcp_listen
 
-#define altcp_abort tcp_abort
-#define altcp_close tcp_close
-#define altcp_shutdown tcp_shutdown
+#define matter_aws_altcp_abort tcp_abort
+#define matter_aws_altcp_close tcp_close
+#define matter_aws_altcp_shutdown tcp_shutdown
 
-#define altcp_write tcp_write
-#define altcp_output tcp_output
+#define matter_aws_altcp_write tcp_write
+#define matter_aws_altcp_output tcp_output
 
-#define altcp_mss tcp_mss
-#define altcp_sndbuf tcp_sndbuf
-#define altcp_sndqueuelen tcp_sndqueuelen
-#define altcp_nagle_disable tcp_nagle_disable
-#define altcp_nagle_enable tcp_nagle_enable
-#define altcp_nagle_disabled tcp_nagle_disabled
-#define altcp_setprio tcp_setprio
+#define matter_aws_altcp_mss tcp_mss
+#define matter_aws_altcp_sndbuf tcp_sndbuf
+#define matter_aws_altcp_sndqueuelen tcp_sndqueuelen
+#define matter_aws_altcp_nagle_disable tcp_nagle_disable
+#define matter_aws_altcp_nagle_enable tcp_nagle_enable
+#define matter_aws_altcp_nagle_disabled tcp_nagle_disabled
+#define matter_aws_altcp_setprio tcp_setprio
 
-#define altcp_get_tcp_addrinfo tcp_get_tcp_addrinfo
-#define altcp_get_ip(pcb, local) ((local) ? (&(pcb)->local_ip) : (&(pcb)->remote_ip))
+#define matter_aws_altcp_get_tcp_addrinfo tcp_get_tcp_addrinfo
+#define matter_aws_altcp_get_ip(pcb, local) ((local) ? (&(pcb)->local_ip) : (&(pcb)->remote_ip))
 
 #ifdef ALTCP_DEBUG
-#define altcp_dbg_get_tcp_state tcp_dbg_get_tcp_state
+#define matter_aws_altcp_dbg_get_tcp_state tcp_dbg_get_tcp_state
 #endif
 
 #endif /* TRANSPORT_ALTCP */

--- a/src/platform/silabs/mqtt/mqtt_transport_interface/include/altcp_priv.h
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/include/altcp_priv.h
@@ -52,8 +52,8 @@
 extern "C" {
 #endif
 
-struct altcp_pcb * altcp_alloc(void);
-void altcp_free(struct altcp_pcb * conn);
+struct altcp_pcb * matter_aws_altcp_alloc(void);
+void matter_aws_altcp_free(struct altcp_pcb * conn);
 
 /* Function prototypes for application layers */
 typedef void (*altcp_set_poll_fn)(struct altcp_pcb * conn, u8_t interval);
@@ -117,25 +117,25 @@ struct altcp_functions
 #endif
 };
 
-void altcp_default_set_poll(struct altcp_pcb * conn, u8_t interval);
-void altcp_default_recved(struct altcp_pcb * conn, u16_t len);
-err_t altcp_default_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port);
-err_t altcp_default_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx);
-err_t altcp_default_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags);
-err_t altcp_default_output(struct altcp_pcb * conn);
-u16_t altcp_default_mss(struct altcp_pcb * conn);
-u16_t altcp_default_sndbuf(struct altcp_pcb * conn);
-u16_t altcp_default_sndqueuelen(struct altcp_pcb * conn);
-void altcp_default_nagle_disable(struct altcp_pcb * conn);
-void altcp_default_nagle_enable(struct altcp_pcb * conn);
-int altcp_default_nagle_disabled(struct altcp_pcb * conn);
-void altcp_default_setprio(struct altcp_pcb * conn, u8_t prio);
-void altcp_default_dealloc(struct altcp_pcb * conn);
-err_t altcp_default_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_addr_t * addr, u16_t * port);
-ip_addr_t * altcp_default_get_ip(struct altcp_pcb * conn, int local);
-u16_t altcp_default_get_port(struct altcp_pcb * conn, int local);
+void matter_aws_altcp_default_set_poll(struct altcp_pcb * conn, u8_t interval);
+void matter_aws_altcp_default_recved(struct altcp_pcb * conn, u16_t len);
+err_t matter_aws_altcp_default_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port);
+err_t matter_aws_altcp_default_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx);
+err_t matter_aws_altcp_default_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags);
+err_t matter_aws_altcp_default_output(struct altcp_pcb * conn);
+u16_t matter_aws_altcp_default_mss(struct altcp_pcb * conn);
+u16_t matter_aws_altcp_default_sndbuf(struct altcp_pcb * conn);
+u16_t matter_aws_altcp_default_sndqueuelen(struct altcp_pcb * conn);
+void matter_aws_altcp_default_nagle_disable(struct altcp_pcb * conn);
+void matter_aws_altcp_default_nagle_enable(struct altcp_pcb * conn);
+int matter_aws_altcp_default_nagle_disabled(struct altcp_pcb * conn);
+void matter_aws_altcp_default_setprio(struct altcp_pcb * conn, u8_t prio);
+void matter_aws_altcp_default_dealloc(struct altcp_pcb * conn);
+err_t matter_aws_altcp_default_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_addr_t * addr, u16_t * port);
+ip_addr_t * matter_aws_altcp_default_get_ip(struct altcp_pcb * conn, int local);
+u16_t matter_aws_altcp_default_get_port(struct altcp_pcb * conn, int local);
 #ifdef ALTCP_DEBUG
-enum tcp_state altcp_default_dbg_get_tcp_state(struct altcp_pcb * conn);
+enum tcp_state matter_aws_altcp_default_dbg_get_tcp_state(struct altcp_pcb * conn);
 #endif
 
 #ifdef __cplusplus

--- a/src/platform/silabs/mqtt/mqtt_transport_interface/include/altcp_tcp.h
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/include/altcp_tcp.h
@@ -53,15 +53,15 @@
 extern "C" {
 #endif
 
-struct altcp_pcb * altcp_tcp_new_ip_type(u8_t ip_type);
+struct altcp_pcb * matter_aws_altcp_tcp_new_ip_type(u8_t ip_type);
 
-#define altcp_tcp_new() altcp_tcp_new_ip_type(IPADDR_TYPE_V4)
-#define altcp_tcp_new_ip6() altcp_tcp_new_ip_type(IPADDR_TYPE_V6)
+#define altcp_tcp_new() matter_aws_altcp_tcp_new_ip_type(IPADDR_TYPE_V4)
+#define altcp_tcp_new_ip6() matter_aws_altcp_tcp_new_ip_type(IPADDR_TYPE_V6)
 
-struct altcp_pcb * altcp_tcp_alloc(void * arg, u8_t ip_type);
+struct altcp_pcb * matter_aws_altcp_tcp_alloc(void * arg, u8_t ip_type);
 
 struct tcp_pcb;
-struct altcp_pcb * altcp_tcp_wrap(struct tcp_pcb * tpcb);
+struct altcp_pcb * matter_aws_altcp_tcp_wrap(struct tcp_pcb * tpcb);
 
 #ifdef __cplusplus
 }

--- a/src/platform/silabs/mqtt/mqtt_transport_interface/include/altcp_tls.h
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/include/altcp_tls.h
@@ -63,49 +63,49 @@ struct altcp_tls_config;
 /** @ingroup altcp_tls
  * Create an ALTCP_TLS server configuration handle
  */
-struct altcp_tls_config * altcp_tls_create_config_server_privkey_cert(const u8_t * privkey, size_t privkey_len,
+struct altcp_tls_config * matter_aws_altcp_tls_create_config_server_privkey_cert(const u8_t * privkey, size_t privkey_len,
                                                                       const u8_t * privkey_pass, size_t privkey_pass_len,
                                                                       const u8_t * cert, size_t cert_len);
 
 /** @ingroup altcp_tls
  * Create an ALTCP_TLS client configuration handle
  */
-struct altcp_tls_config * altcp_tls_create_config_client(const u8_t * cert, size_t cert_len);
+struct altcp_tls_config * matter_aws_altcp_tls_create_config_client(const u8_t * cert, size_t cert_len);
 
 /** @ingroup altcp_tls
  * Create an ALTCP_TLS client configuration handle with two-way server/client authentication
  */
-struct altcp_tls_config * altcp_tls_create_config_client_2wayauth(const u8_t * ca, size_t ca_len, const u8_t * privkey,
+struct altcp_tls_config * matter_aws_altcp_tls_create_config_client_2wayauth(const u8_t * ca, size_t ca_len, const u8_t * privkey,
                                                                   size_t privkey_len, const u8_t * privkey_pass,
                                                                   size_t privkey_pass_len, const u8_t * cert, size_t cert_len);
 /** @ingroup altcp_tls
  * Free an ALTCP_TLS configuration handle
  */
-void altcp_tls_free_config(struct altcp_tls_config * conf);
+void matter_aws_altcp_tls_free_config(struct altcp_tls_config * conf);
 
 /** @ingroup altcp_tls
  * Create new ALTCP_TLS layer wrapping an existing pcb as inner connection (e.g. TLS over TCP)
  */
-struct altcp_pcb * altcp_tls_wrap(struct altcp_tls_config * config, struct altcp_pcb * inner_pcb);
+struct altcp_pcb * matter_aws_altcp_tls_wrap(struct altcp_tls_config * config, struct altcp_pcb * inner_pcb);
 
 /** @ingroup altcp_tls
  * Create new ALTCP_TLS pcb and its inner tcp pcb
  */
-struct altcp_pcb * altcp_tls_new(struct altcp_tls_config * config, u8_t ip_type);
+struct altcp_pcb * matter_aws_altcp_tls_new(struct altcp_tls_config * config, u8_t ip_type);
 
 /** @ingroup altcp_tls
  * Create new ALTCP_TLS layer pcb and its inner tcp pcb.
- * Same as @ref altcp_tls_new but this allocator function fits to
- * @ref altcp_allocator_t / @ref altcp_new.\n
+ * Same as @ref matter_aws_altcp_tls_new but this allocator function fits to
+ * @ref altcp_allocator_t / @ref matter_aws_altcp_new.\n
  'arg' must contain a struct altcp_tls_config *.
  */
-struct altcp_pcb * altcp_tls_alloc(void * arg, u8_t ip_type);
+struct altcp_pcb * matter_aws_altcp_tls_alloc(void * arg, u8_t ip_type);
 
 /** @ingroup altcp_tls
  * Return pointer to internal TLS context so application can tweak it.
  * Real type depends on port (e.g. mbedtls)
  */
-void * altcp_tls_context(struct altcp_pcb * conn);
+void * matter_aws_altcp_tls_context(struct altcp_pcb * conn);
 
 #ifdef __cplusplus
 }

--- a/src/platform/silabs/mqtt/mqtt_transport_interface/include/altcp_tls_mbedtls_mem.h
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/include/altcp_tls_mbedtls_mem.h
@@ -57,11 +57,11 @@
 extern "C" {
 #endif
 
-void altcp_mbedtls_mem_init(void);
-altcp_mbedtls_state_t * altcp_mbedtls_alloc(void * conf);
-void altcp_mbedtls_free(void * conf, altcp_mbedtls_state_t * state);
-void * altcp_mbedtls_alloc_config(size_t size);
-void altcp_mbedtls_free_config(void * item);
+void matter_aws_altcp_mbedtls_mem_init(void);
+altcp_mbedtls_state_t * matter_aws_altcp_mbedtls_alloc(void * conf);
+void matter_aws_altcp_mbedtls_free(void * conf, altcp_mbedtls_state_t * state);
+void * matter_aws_altcp_mbedtls_alloc_config(size_t size);
+void matter_aws_altcp_mbedtls_free_config(void * item);
 
 #ifdef __cplusplus
 }

--- a/src/platform/silabs/mqtt/mqtt_transport_interface/src/MQTT_transport.c
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/src/MQTT_transport.c
@@ -35,7 +35,7 @@ struct MQTT_Transport_t
     struct altcp_tls_config * tls_config;
     struct altcp_pcb * conn;
 
-    matter_aws_connect_cb matter_aws_conn_cb;
+    matter_aws_connect_cb connect_cb;
     ip_addr_t * ipaddr;
     /** received buffers from tcp */
     struct pbuf * pcbRxStart;
@@ -105,7 +105,7 @@ err_t MQTT_Transport_SSLConfigure(MQTT_Transport_t * transP, const u8_t * ca, si
                                   size_t cert_len)
 {
     struct altcp_tls_config * altcp_tls_config;
-    altcp_tls_config = altcp_tls_create_config_client_2wayauth(ca, ca_len, privkey, privkey_len, NULL, 0, cert, cert_len);
+    altcp_tls_config = matter_aws_altcp_tls_create_config_client_2wayauth(ca, ca_len, privkey, privkey_len, NULL, 0, cert, cert_len);
     if (NULL == altcp_tls_config)
     {
         return ERR_FAIL;
@@ -115,7 +115,7 @@ err_t MQTT_Transport_SSLConfigure(MQTT_Transport_t * transP, const u8_t * ca, si
 }
 
 err_t MQTT_Transport_Connect(MQTT_Transport_t * transP, const char * host, size_t hostLen, u16_t port,
-                             matter_aws_connect_cb matter_aws_conn_cb)
+                             matter_aws_connect_cb connect_cb)
 {
     err_t ret;
     err_t dns_ret;
@@ -165,7 +165,7 @@ err_t MQTT_Transport_Connect(MQTT_Transport_t * transP, const char * host, size_
             return dns_ret;
         }
     }
-    transP->matter_aws_conn_cb = matter_aws_conn_cb;
+    transP->connect_cb = connect_cb;
     ret                        = connection_new(transP, &ipaddr, port);
     return ret;
 }
@@ -175,7 +175,7 @@ static uint16_t transport_get_sendlen_cb(void * conn)
     MQTT_Transport_t * client = (MQTT_Transport_t *) conn;
     if (!client)
         return 0;
-    return altcp_sndbuf(client->conn);
+    return matter_aws_altcp_sndbuf(client->conn);
 }
 
 static int8_t transport_write_cb(void * conn, void * buff, uint16_t len, uint8_t flags, uint8_t isFinal)
@@ -183,10 +183,10 @@ static int8_t transport_write_cb(void * conn, void * buff, uint16_t len, uint8_t
     MQTT_Transport_t * client = (MQTT_Transport_t *) conn;
     if (!client)
         return ERR_FAIL;
-    if (ERR_OK != altcp_write(client->conn, buff, len, convert_write_flags(flags)))
+    if (ERR_OK != matter_aws_altcp_write(client->conn, buff, len, convert_write_flags(flags)))
         return ERR_FAIL;
     if (isFinal)
-        altcp_output(client->conn);
+        matter_aws_altcp_output(client->conn);
     return ERR_OK;
 }
 
@@ -236,13 +236,13 @@ static void transport_close_cb(void * arg)
     if (conn != NULL && client->conn_state == TRANSPORT_CONNECTED)
     {
         err_t res;
-        altcp_recv(conn, NULL);
-        altcp_err(conn, NULL);
-        altcp_sent(conn, NULL);
-        res = altcp_close(conn);
+        matter_aws_altcp_recv(conn, NULL);
+        matter_aws_altcp_err(conn, NULL);
+        matter_aws_altcp_sent(conn, NULL);
+        res = matter_aws_altcp_close(conn);
         if (res != ERR_OK)
         {
-            altcp_abort(conn);
+            matter_aws_altcp_abort(conn);
             TRANSPORT_DEBUGF(("transport_close_cb: Close err=%s\n", lwip_strerr(res)));
         }
         client->conn = NULL;
@@ -280,9 +280,9 @@ static void transport_err_cb(void * arg, err_t err)
     client->conn_state = TRANSPORT_NOT_CONNECTED;
 
     /* Safety check: ensure callback is not NULL before calling */
-    if (client->matter_aws_conn_cb != NULL)
+    if (client->connect_cb != NULL)
     {
-        client->matter_aws_conn_cb(err);
+        client->connect_cb(err);
     }
 }
 
@@ -308,7 +308,7 @@ static err_t transport_recv_cb(void * arg, struct altcp_pcb * pcb, struct pbuf *
 
 #if 0
     /* Tell remote that data has been received */
-    altcp_recved(pcb, p->tot_len);
+    matter_aws_altcp_recved(pcb, p->tot_len);
     res = mqtt_parse_incoming(client, p);
     pbuf_free(p);
 
@@ -398,19 +398,19 @@ static err_t transport_connect_cb(void * arg, struct altcp_pcb * tpcb, err_t err
         TRANSPORT_DEBUGF(("transport_connect_cb: TCP connect error %d\n", err));
         SILABS_LOG("TCP connect error");
         client->conn_state = TRANSPORT_NOT_CONNECTED;
-        client->matter_aws_conn_cb(err);
+        client->connect_cb(err);
         return err;
     }
     /* Setup TCP callbacks */
-    altcp_recv(tpcb, transport_recv_cb);
-    altcp_sent(tpcb, transport_sent_cb);
+    matter_aws_altcp_recv(tpcb, transport_recv_cb);
+    matter_aws_altcp_sent(tpcb, transport_sent_cb);
     // tcp_poll(tpcb, tcp_poll_cb, 2);
     TRANSPORT_DEBUGF(("transport_connect_cb: TCP connection established to server\n"));
     SILABS_LOG("tcp_cb: TCP connection established to server\n");
     client->conn_state = TRANSPORT_CONNECTED;
-    if (client->matter_aws_conn_cb != NULL)
+    if (client->connect_cb != NULL)
     {
-        client->matter_aws_conn_cb(ERR_OK);
+        client->connect_cb(ERR_OK);
     }
     return ERR_OK;
 }
@@ -420,11 +420,11 @@ void mbedtls_signal_app(void * arg)
     MQTT_Transport_t * client = (MQTT_Transport_t *) arg;
     xEventGroupSetBits(client->events, SIGNAL_TRANSINTF_MBEDTLS_RX);
 }
-extern err_t altcp_mbedtls_lower_recv_process(struct altcp_pcb * conn);
+extern err_t matter_aws_altcp_mbedtls_lower_recv_process(struct altcp_pcb * conn);
 
 void transport_process_mbedtls_rx(MQTT_Transport_t * client)
 {
-    altcp_mbedtls_lower_recv_process(client->conn);
+    matter_aws_altcp_mbedtls_lower_recv_process(client->conn);
 }
 
 static err_t connection_new(MQTT_Transport_t * client, const ip_addr_t * ipaddr, u16_t port)
@@ -445,11 +445,11 @@ static err_t connection_new(MQTT_Transport_t * client, const ip_addr_t * ipaddr,
     if (client->tls_config)
     {
         SILABS_LOG("executing tls new");
-        client->conn = altcp_tls_new(client->tls_config, IP_GET_TYPE(ipaddr));
+        client->conn = matter_aws_altcp_tls_new(client->tls_config, IP_GET_TYPE(ipaddr));
         if (client->conn != NULL && client->hostname != NULL)
         {
             /* Set hostname for TLS certificate verification */
-            mbedtls_ssl_context * ssl = (mbedtls_ssl_context *) altcp_tls_context(client->conn);
+            mbedtls_ssl_context * ssl = (mbedtls_ssl_context *) matter_aws_altcp_tls_context(client->conn);
             if (ssl != NULL)
             {
                 int ret = mbedtls_ssl_set_hostname(ssl, client->hostname);
@@ -469,16 +469,16 @@ static err_t connection_new(MQTT_Transport_t * client, const ip_addr_t * ipaddr,
 #endif
     {
         SILABS_LOG("not executing");
-        client->conn = altcp_tcp_new_ip_type(IP_GET_TYPE(ipaddr));
+        client->conn = matter_aws_altcp_tcp_new_ip_type(IP_GET_TYPE(ipaddr));
     }
     if (client->conn == NULL)
     {
         return ERR_MEM;
     }
     /* Set arg pointer for callbacks */
-    altcp_arg(client->conn, client);
+    matter_aws_altcp_arg(client->conn, client);
     /* Any local address, pick random local port number */
-    err = altcp_bind(client->conn, IP_ADDR_ANY, 0);
+    err = matter_aws_altcp_bind(client->conn, IP_ADDR_ANY, 0);
     if (err != ERR_OK)
     {
         TRANSPORT_DEBUGF(("client_connect: Error binding to local ip/port, %d\n", err));
@@ -486,20 +486,20 @@ static err_t connection_new(MQTT_Transport_t * client, const ip_addr_t * ipaddr,
     }
 
     /* Connect to server */
-    err = altcp_connect(client->conn, ipaddr, port, transport_connect_cb);
+    err = matter_aws_altcp_connect(client->conn, ipaddr, port, transport_connect_cb);
     if (err != ERR_OK)
     {
         TRANSPORT_DEBUGF(("client_connect: Error connecting to remote ip/port, %d\n", err));
         goto transport_fail;
     }
     /* Set error callback */
-    altcp_err(client->conn, transport_err_cb);
+    matter_aws_altcp_err(client->conn, transport_err_cb);
     client->conn_state = TRANSPORT_NOT_CONNECTED;
 
     return ERR_OK;
 
 transport_fail:
-    altcp_abort(client->conn);
+    matter_aws_altcp_abort(client->conn);
     client->conn = NULL;
     return err;
 }

--- a/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp.c
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp.c
@@ -40,7 +40,7 @@
  * * Replace "struct tcp_pcb" with "struct altcp_pcb"
  * * Prefix all called tcp API functions with "altcp_" instead of "tcp_" to link
  *   against the altcp functions
- * * @ref altcp_new (and @ref altcp_new_ip_type/@ref altcp_new_ip6) take
+ * * @ref matter_aws_altcp_new (and @ref matter_aws_altcp_new_ip_type/@ref matter_aws_altcp_new_ip6) take
  *   an @ref altcp_allocator_t as an argument, whereas the original tcp API
  *   functions take no arguments.
  * * An @ref altcp_allocator_t allocator is an object that holds a pointer to an
@@ -49,7 +49,7 @@
  *   even need to know if it uses TLS or pure TCP, this is handled at runtime
  *   by passing a specific allocator.
  * * An application can alternatively bind hard to the altcp_tls API by calling
- *   @ref altcp_tls_new or @ref altcp_tls_wrap.
+ *   @ref matter_aws_altcp_tls_new or @ref matter_aws_altcp_tls_wrap.
  * * The TLS layer is not directly implemented by lwIP, but a port to mbedTLS is
  *   provided.
  * * Another altcp layer is proxy-connect to use TLS behind a HTTP proxy (see
@@ -60,9 +60,9 @@
  * An altcp allocator is created by the application by combining an allocator
  * callback function and a corresponding state, e.g.:\code{.c}
  * static const unsigned char cert[] = {0x2D, ... (see mbedTLS doc for how to create this)};
- * struct altcp_tls_config * conf = altcp_tls_create_config_client(cert, sizeof(cert));
+ * struct altcp_tls_config * conf = matter_aws_altcp_tls_create_config_client(cert, sizeof(cert));
  * altcp_allocator_t tls_allocator = {
- *   altcp_tls_alloc, conf
+ *   matter_aws_altcp_tls_alloc, conf
  * };
  * \endcode
  *
@@ -74,8 +74,8 @@
  *
  * It is not defined by lwIP itself but by the TLS port (e.g. altcp_tls to mbedTLS
  * adaption). However, the parameters used to create it are defined in @ref
- * altcp_tls.h (see @ref altcp_tls_create_config_server_privkey_cert for servers
- * and @ref altcp_tls_create_config_client/@ref altcp_tls_create_config_client_2wayauth
+ * altcp_tls.h (see @ref matter_aws_altcp_tls_create_config_server_privkey_cert for servers
+ * and @ref matter_aws_altcp_tls_create_config_client/@ref matter_aws_altcp_tls_create_config_client_2wayauth
  * for clients).
  *
  * For mbedTLS, ensure that certificates can be parsed by 'mbedtls_x509_crt_parse()' and
@@ -126,13 +126,13 @@
 
 #include <string.h>
 
-extern const struct altcp_functions altcp_tcp_functions;
+extern const struct altcp_functions matter_aws_altcp_tcp_functions;
 
 /**
  * For altcp layer implementations only: allocate a new struct altcp_pcb from the pool
  * and zero the memory
  */
-struct altcp_pcb * altcp_alloc(void)
+struct altcp_pcb * matter_aws_altcp_alloc(void)
 {
     struct altcp_pcb * ret = (struct altcp_pcb *) pvPortMalloc(sizeof(struct altcp_pcb));
     if (ret != NULL)
@@ -145,7 +145,7 @@ struct altcp_pcb * altcp_alloc(void)
 /**
  * For altcp layer implementations only: return a struct altcp_pcb to the pool
  */
-void altcp_free(struct altcp_pcb * conn)
+void matter_aws_altcp_free(struct altcp_pcb * conn)
 {
     if (conn)
     {
@@ -159,38 +159,38 @@ void altcp_free(struct altcp_pcb * conn)
 
 /**
  * @ingroup altcp
- * altcp_new_ip6: @ref altcp_new for IPv6
+ * matter_aws_altcp_new_ip6: @ref matter_aws_altcp_new for IPv6
  */
-struct altcp_pcb * altcp_new_ip6(altcp_allocator_t * allocator)
+struct altcp_pcb * matter_aws_altcp_new_ip6(altcp_allocator_t * allocator)
 {
-    return altcp_new_ip_type(allocator, IPADDR_TYPE_V6);
+    return matter_aws_altcp_new_ip_type(allocator, IPADDR_TYPE_V6);
 }
 
 /**
  * @ingroup altcp
- * altcp_new: @ref altcp_new for IPv4
+ * matter_aws_altcp_new: @ref matter_aws_altcp_new for IPv4
  */
-struct altcp_pcb * altcp_new(altcp_allocator_t * allocator)
+struct altcp_pcb * matter_aws_altcp_new(altcp_allocator_t * allocator)
 {
-    return altcp_new_ip_type(allocator, IPADDR_TYPE_V4);
+    return matter_aws_altcp_new_ip_type(allocator, IPADDR_TYPE_V4);
 }
 
 /**
  * @ingroup altcp
- * altcp_new_ip_type: called by applications to allocate a new pcb with the help of an
+ * matter_aws_altcp_new_ip_type: called by applications to allocate a new pcb with the help of an
  * allocator function.
  *
  * @param allocator allocator function and argument
  * @param ip_type IP version of the pcb (@ref lwip_ip_addr_type)
  * @return a new altcp_pcb or NULL on error
  */
-struct altcp_pcb * altcp_new_ip_type(altcp_allocator_t * allocator, u8_t ip_type)
+struct altcp_pcb * matter_aws_altcp_new_ip_type(altcp_allocator_t * allocator, u8_t ip_type)
 {
     struct altcp_pcb * conn;
     if (allocator == NULL)
     {
         /* no allocator given, create a simple TCP connection */
-        return altcp_tcp_new_ip_type(ip_type);
+        return matter_aws_altcp_tcp_new_ip_type(ip_type);
     }
     if (allocator->alloc == NULL)
     {
@@ -210,7 +210,7 @@ struct altcp_pcb * altcp_new_ip_type(altcp_allocator_t * allocator, u8_t ip_type
  * @ingroup altcp
  * @see tcp_arg()
  */
-void altcp_arg(struct altcp_pcb * conn, void * arg)
+void matter_aws_altcp_arg(struct altcp_pcb * conn, void * arg)
 {
     if (conn)
     {
@@ -222,7 +222,7 @@ void altcp_arg(struct altcp_pcb * conn, void * arg)
  * @ingroup altcp
  * @see tcp_accept()
  */
-void altcp_accept(struct altcp_pcb * conn, altcp_accept_fn accept)
+void matter_aws_altcp_accept(struct altcp_pcb * conn, altcp_accept_fn accept)
 {
     if (conn != NULL)
     {
@@ -234,7 +234,7 @@ void altcp_accept(struct altcp_pcb * conn, altcp_accept_fn accept)
  * @ingroup altcp
  * @see tcp_recv()
  */
-void altcp_recv(struct altcp_pcb * conn, altcp_recv_fn recv)
+void matter_aws_altcp_recv(struct altcp_pcb * conn, altcp_recv_fn recv)
 {
     if (conn)
     {
@@ -246,7 +246,7 @@ void altcp_recv(struct altcp_pcb * conn, altcp_recv_fn recv)
  * @ingroup altcp
  * @see tcp_sent()
  */
-void altcp_sent(struct altcp_pcb * conn, altcp_sent_fn sent)
+void matter_aws_altcp_sent(struct altcp_pcb * conn, altcp_sent_fn sent)
 {
     if (conn)
     {
@@ -258,7 +258,7 @@ void altcp_sent(struct altcp_pcb * conn, altcp_sent_fn sent)
  * @ingroup altcp
  * @see tcp_poll()
  */
-void altcp_poll(struct altcp_pcb * conn, altcp_poll_fn poll, u8_t interval)
+void matter_aws_altcp_poll(struct altcp_pcb * conn, altcp_poll_fn poll, u8_t interval)
 {
     if (conn)
     {
@@ -275,7 +275,7 @@ void altcp_poll(struct altcp_pcb * conn, altcp_poll_fn poll, u8_t interval)
  * @ingroup altcp
  * @see tcp_err()
  */
-void altcp_err(struct altcp_pcb * conn, altcp_err_fn err)
+void matter_aws_altcp_err(struct altcp_pcb * conn, altcp_err_fn err)
 {
     if (conn)
     {
@@ -289,7 +289,7 @@ void altcp_err(struct altcp_pcb * conn, altcp_err_fn err)
  * @ingroup altcp
  * @see tcp_recved()
  */
-void altcp_recved(struct altcp_pcb * conn, u16_t len)
+void matter_aws_altcp_recved(struct altcp_pcb * conn, u16_t len)
 {
     if (conn && conn->fns && conn->fns->recved)
     {
@@ -301,7 +301,7 @@ void altcp_recved(struct altcp_pcb * conn, u16_t len)
  * @ingroup altcp
  * @see tcp_bind()
  */
-err_t altcp_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port)
+err_t matter_aws_altcp_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port)
 {
     if (conn && conn->fns && conn->fns->bind)
     {
@@ -314,7 +314,7 @@ err_t altcp_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port)
  * @ingroup altcp
  * @see tcp_connect()
  */
-err_t altcp_connect(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port, altcp_connected_fn connected)
+err_t matter_aws_altcp_connect(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port, altcp_connected_fn connected)
 {
     if (conn && conn->fns && conn->fns->connect)
     {
@@ -327,7 +327,7 @@ err_t altcp_connect(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t por
  * @ingroup altcp
  * @see tcp_listen_with_backlog_and_err()
  */
-struct altcp_pcb * altcp_listen_with_backlog_and_err(struct altcp_pcb * conn, u8_t backlog, err_t * err)
+struct altcp_pcb * matter_aws_altcp_listen_with_backlog_and_err(struct altcp_pcb * conn, u8_t backlog, err_t * err)
 {
     if (conn && conn->fns && conn->fns->listen)
     {
@@ -340,7 +340,7 @@ struct altcp_pcb * altcp_listen_with_backlog_and_err(struct altcp_pcb * conn, u8
  * @ingroup altcp
  * @see tcp_abort()
  */
-void altcp_abort(struct altcp_pcb * conn)
+void matter_aws_altcp_abort(struct altcp_pcb * conn)
 {
     if (conn && conn->fns && conn->fns->abort)
     {
@@ -352,7 +352,7 @@ void altcp_abort(struct altcp_pcb * conn)
  * @ingroup altcp
  * @see tcp_close()
  */
-err_t altcp_close(struct altcp_pcb * conn)
+err_t matter_aws_altcp_close(struct altcp_pcb * conn)
 {
     if (conn && conn->fns && conn->fns->close)
     {
@@ -365,7 +365,7 @@ err_t altcp_close(struct altcp_pcb * conn)
  * @ingroup altcp
  * @see tcp_shutdown()
  */
-err_t altcp_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx)
+err_t matter_aws_altcp_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx)
 {
     if (conn && conn->fns && conn->fns->shutdown)
     {
@@ -378,7 +378,7 @@ err_t altcp_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx)
  * @ingroup altcp
  * @see tcp_write()
  */
-err_t altcp_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags)
+err_t matter_aws_altcp_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags)
 {
     if (conn && conn->fns && conn->fns->write)
     {
@@ -391,7 +391,7 @@ err_t altcp_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t
  * @ingroup altcp
  * @see tcp_output()
  */
-err_t altcp_output(struct altcp_pcb * conn)
+err_t matter_aws_altcp_output(struct altcp_pcb * conn)
 {
     if (conn && conn->fns && conn->fns->output)
     {
@@ -404,7 +404,7 @@ err_t altcp_output(struct altcp_pcb * conn)
  * @ingroup altcp
  * @see tcp_mss()
  */
-u16_t altcp_mss(struct altcp_pcb * conn)
+u16_t matter_aws_altcp_mss(struct altcp_pcb * conn)
 {
     if (conn && conn->fns && conn->fns->mss)
     {
@@ -417,7 +417,7 @@ u16_t altcp_mss(struct altcp_pcb * conn)
  * @ingroup altcp
  * @see tcp_sndbuf()
  */
-u16_t altcp_sndbuf(struct altcp_pcb * conn)
+u16_t matter_aws_altcp_sndbuf(struct altcp_pcb * conn)
 {
     if (conn && conn->fns && conn->fns->sndbuf)
     {
@@ -430,7 +430,7 @@ u16_t altcp_sndbuf(struct altcp_pcb * conn)
  * @ingroup altcp
  * @see tcp_sndqueuelen()
  */
-u16_t altcp_sndqueuelen(struct altcp_pcb * conn)
+u16_t matter_aws_altcp_sndqueuelen(struct altcp_pcb * conn)
 {
     if (conn && conn->fns && conn->fns->sndqueuelen)
     {
@@ -439,7 +439,7 @@ u16_t altcp_sndqueuelen(struct altcp_pcb * conn)
     return 0;
 }
 
-void altcp_nagle_disable(struct altcp_pcb * conn)
+void matter_aws_altcp_nagle_disable(struct altcp_pcb * conn)
 {
     if (conn && conn->fns && conn->fns->nagle_disable)
     {
@@ -447,7 +447,7 @@ void altcp_nagle_disable(struct altcp_pcb * conn)
     }
 }
 
-void altcp_nagle_enable(struct altcp_pcb * conn)
+void matter_aws_altcp_nagle_enable(struct altcp_pcb * conn)
 {
     if (conn && conn->fns && conn->fns->nagle_enable)
     {
@@ -455,7 +455,7 @@ void altcp_nagle_enable(struct altcp_pcb * conn)
     }
 }
 
-int altcp_nagle_disabled(struct altcp_pcb * conn)
+int matter_aws_altcp_nagle_disabled(struct altcp_pcb * conn)
 {
     if (conn && conn->fns && conn->fns->nagle_disabled)
     {
@@ -468,7 +468,7 @@ int altcp_nagle_disabled(struct altcp_pcb * conn)
  * @ingroup altcp
  * @see tcp_setprio()
  */
-void altcp_setprio(struct altcp_pcb * conn, u8_t prio)
+void matter_aws_altcp_setprio(struct altcp_pcb * conn, u8_t prio)
 {
     if (conn && conn->fns && conn->fns->setprio)
     {
@@ -476,7 +476,7 @@ void altcp_setprio(struct altcp_pcb * conn, u8_t prio)
     }
 }
 
-err_t altcp_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_addr_t * addr, u16_t * port)
+err_t matter_aws_altcp_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_addr_t * addr, u16_t * port)
 {
     if (conn && conn->fns && conn->fns->addrinfo)
     {
@@ -485,7 +485,7 @@ err_t altcp_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_addr_t * add
     return ERR_VAL;
 }
 
-ip_addr_t * altcp_get_ip(struct altcp_pcb * conn, int local)
+ip_addr_t * matter_aws_altcp_get_ip(struct altcp_pcb * conn, int local)
 {
     if (conn && conn->fns && conn->fns->getip)
     {
@@ -494,7 +494,7 @@ ip_addr_t * altcp_get_ip(struct altcp_pcb * conn, int local)
     return NULL;
 }
 
-u16_t altcp_get_port(struct altcp_pcb * conn, int local)
+u16_t matter_aws_altcp_get_port(struct altcp_pcb * conn, int local)
 {
     if (conn && conn->fns && conn->fns->getport)
     {
@@ -504,7 +504,7 @@ u16_t altcp_get_port(struct altcp_pcb * conn, int local)
 }
 
 #ifdef ALTCP_DEBUG
-enum tcp_state altcp_dbg_get_tcp_state(struct altcp_pcb * conn)
+enum tcp_state matter_aws_altcp_dbg_get_tcp_state(struct altcp_pcb * conn)
 {
     if (conn && conn->fns && conn->fns->dbg_get_tcp_state)
     {
@@ -516,32 +516,32 @@ enum tcp_state altcp_dbg_get_tcp_state(struct altcp_pcb * conn)
 
 /* Default implementations for the "virtual" functions */
 
-void altcp_default_set_poll(struct altcp_pcb * conn, u8_t interval)
+void matter_aws_altcp_default_set_poll(struct altcp_pcb * conn, u8_t interval)
 {
     if (conn && conn->inner_conn)
     {
-        altcp_poll(conn->inner_conn, conn->poll, interval);
+        matter_aws_altcp_poll(conn->inner_conn, conn->poll, interval);
     }
 }
 
-void altcp_default_recved(struct altcp_pcb * conn, u16_t len)
+void matter_aws_altcp_default_recved(struct altcp_pcb * conn, u16_t len)
 {
     if (conn && conn->inner_conn)
     {
-        altcp_recved(conn->inner_conn, len);
+        matter_aws_altcp_recved(conn->inner_conn, len);
     }
 }
 
-err_t altcp_default_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port)
+err_t matter_aws_altcp_default_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port)
 {
     if (conn && conn->inner_conn)
     {
-        return altcp_bind(conn->inner_conn, ipaddr, port);
+        return matter_aws_altcp_bind(conn->inner_conn, ipaddr, port);
     }
     return ERR_VAL;
 }
 
-err_t altcp_default_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx)
+err_t matter_aws_altcp_default_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx)
 {
     if (conn)
     {
@@ -552,129 +552,129 @@ err_t altcp_default_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx)
         }
         if (conn->inner_conn)
         {
-            return altcp_shutdown(conn->inner_conn, shut_rx, shut_tx);
+            return matter_aws_altcp_shutdown(conn->inner_conn, shut_rx, shut_tx);
         }
     }
     return ERR_VAL;
 }
 
-err_t altcp_default_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags)
+err_t matter_aws_altcp_default_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags)
 {
     if (conn && conn->inner_conn)
     {
-        return altcp_write(conn->inner_conn, dataptr, len, apiflags);
+        return matter_aws_altcp_write(conn->inner_conn, dataptr, len, apiflags);
     }
     return ERR_VAL;
 }
 
-err_t altcp_default_output(struct altcp_pcb * conn)
+err_t matter_aws_altcp_default_output(struct altcp_pcb * conn)
 {
     if (conn && conn->inner_conn)
     {
-        return altcp_output(conn->inner_conn);
+        return matter_aws_altcp_output(conn->inner_conn);
     }
     return ERR_VAL;
 }
 
-u16_t altcp_default_mss(struct altcp_pcb * conn)
+u16_t matter_aws_altcp_default_mss(struct altcp_pcb * conn)
 {
     if (conn && conn->inner_conn)
     {
-        return altcp_mss(conn->inner_conn);
+        return matter_aws_altcp_mss(conn->inner_conn);
     }
     return 0;
 }
 
-u16_t altcp_default_sndbuf(struct altcp_pcb * conn)
+u16_t matter_aws_altcp_default_sndbuf(struct altcp_pcb * conn)
 {
     if (conn && conn->inner_conn)
     {
-        return altcp_sndbuf(conn->inner_conn);
+        return matter_aws_altcp_sndbuf(conn->inner_conn);
     }
     return 0;
 }
 
-u16_t altcp_default_sndqueuelen(struct altcp_pcb * conn)
+u16_t matter_aws_altcp_default_sndqueuelen(struct altcp_pcb * conn)
 {
     if (conn && conn->inner_conn)
     {
-        return altcp_sndqueuelen(conn->inner_conn);
+        return matter_aws_altcp_sndqueuelen(conn->inner_conn);
     }
     return 0;
 }
 
-void altcp_default_nagle_disable(struct altcp_pcb * conn)
+void matter_aws_altcp_default_nagle_disable(struct altcp_pcb * conn)
 {
     if (conn && conn->inner_conn)
     {
-        altcp_nagle_disable(conn->inner_conn);
+        matter_aws_altcp_nagle_disable(conn->inner_conn);
     }
 }
 
-void altcp_default_nagle_enable(struct altcp_pcb * conn)
+void matter_aws_altcp_default_nagle_enable(struct altcp_pcb * conn)
 {
     if (conn && conn->inner_conn)
     {
-        altcp_nagle_enable(conn->inner_conn);
+        matter_aws_altcp_nagle_enable(conn->inner_conn);
     }
 }
 
-int altcp_default_nagle_disabled(struct altcp_pcb * conn)
+int matter_aws_altcp_default_nagle_disabled(struct altcp_pcb * conn)
 {
     if (conn && conn->inner_conn)
     {
-        return altcp_nagle_disabled(conn->inner_conn);
+        return matter_aws_altcp_nagle_disabled(conn->inner_conn);
     }
     return 0;
 }
 
-void altcp_default_setprio(struct altcp_pcb * conn, u8_t prio)
+void matter_aws_altcp_default_setprio(struct altcp_pcb * conn, u8_t prio)
 {
     if (conn && conn->inner_conn)
     {
-        altcp_setprio(conn->inner_conn, prio);
+        matter_aws_altcp_setprio(conn->inner_conn, prio);
     }
 }
 
-void altcp_default_dealloc(struct altcp_pcb * conn)
+void matter_aws_altcp_default_dealloc(struct altcp_pcb * conn)
 {
     TRANSPORT_UNUSED_ARG(conn);
     /* nothing to do */
 }
 
-err_t altcp_default_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_addr_t * addr, u16_t * port)
+err_t matter_aws_altcp_default_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_addr_t * addr, u16_t * port)
 {
     if (conn && conn->inner_conn)
     {
-        return altcp_get_tcp_addrinfo(conn->inner_conn, local, addr, port);
+        return matter_aws_altcp_get_tcp_addrinfo(conn->inner_conn, local, addr, port);
     }
     return ERR_VAL;
 }
 
-ip_addr_t * altcp_default_get_ip(struct altcp_pcb * conn, int local)
+ip_addr_t * matter_aws_altcp_default_get_ip(struct altcp_pcb * conn, int local)
 {
     if (conn && conn->inner_conn)
     {
-        return altcp_get_ip(conn->inner_conn, local);
+        return matter_aws_altcp_get_ip(conn->inner_conn, local);
     }
     return NULL;
 }
 
-u16_t altcp_default_get_port(struct altcp_pcb * conn, int local)
+u16_t matter_aws_altcp_default_get_port(struct altcp_pcb * conn, int local)
 {
     if (conn && conn->inner_conn)
     {
-        return altcp_get_port(conn->inner_conn, local);
+        return matter_aws_altcp_get_port(conn->inner_conn, local);
     }
     return 0;
 }
 
 #ifdef ALTCP_DEBUG
-enum tcp_state altcp_default_dbg_get_tcp_state(struct altcp_pcb * conn)
+enum tcp_state matter_aws_altcp_default_dbg_get_tcp_state(struct altcp_pcb * conn)
 {
     if (conn && conn->inner_conn)
     {
-        return altcp_dbg_get_tcp_state(conn->inner_conn);
+        return matter_aws_altcp_dbg_get_tcp_state(conn->inner_conn);
     }
     return CLOSED;
 }

--- a/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_alloc.c
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_alloc.c
@@ -56,29 +56,29 @@
 
 /** This standard allocator function creates an altcp pcb for
  * TLS over TCP */
-struct altcp_pcb * altcp_tls_new(struct altcp_tls_config * config, u8_t ip_type)
+struct altcp_pcb * matter_aws_altcp_tls_new(struct altcp_tls_config * config, u8_t ip_type)
 {
     struct altcp_pcb *inner_conn, *ret;
     TRANSPORT_UNUSED_ARG(ip_type);
 
-    inner_conn = altcp_tcp_new_ip_type(ip_type);
+    inner_conn = matter_aws_altcp_tcp_new_ip_type(ip_type);
     if (inner_conn == NULL)
     {
         return NULL;
     }
-    ret = altcp_tls_wrap(config, inner_conn);
+    ret = matter_aws_altcp_tls_wrap(config, inner_conn);
     if (ret == NULL)
     {
-        altcp_close(inner_conn);
+        matter_aws_altcp_close(inner_conn);
     }
     return ret;
 }
 
 /** This standard allocator function creates an altcp pcb for
  * TLS over TCP */
-struct altcp_pcb * altcp_tls_alloc(void * arg, u8_t ip_type)
+struct altcp_pcb * matter_aws_altcp_tls_alloc(void * arg, u8_t ip_type)
 {
-    return altcp_tls_new((struct altcp_tls_config *) arg, ip_type);
+    return matter_aws_altcp_tls_new((struct altcp_tls_config *) arg, ip_type);
 }
 
 #endif /* TRANSPORT_ALTCP_TLS */

--- a/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_tcp.c
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_tcp.c
@@ -68,29 +68,29 @@
 
 /* Variable prototype, the actual declaration is at the end of this file
    since it contains pointers to static functions declared here */
-extern const struct altcp_functions altcp_tcp_functions;
+extern const struct altcp_functions matter_aws_altcp_tcp_functions;
 
-static void altcp_tcp_setup(struct altcp_pcb * conn, struct tcp_pcb * tpcb);
+static void matter_aws_altcp_tcp_setup(struct altcp_pcb * conn, struct tcp_pcb * tpcb);
 
 /* callback functions for TCP */
-static err_t altcp_tcp_accept(void * arg, struct tcp_pcb * new_tpcb, err_t err)
+static err_t matter_aws_altcp_tcp_accept(void * arg, struct tcp_pcb * new_tpcb, err_t err)
 {
     struct altcp_pcb * listen_conn = (struct altcp_pcb *) arg;
     if (listen_conn && listen_conn->accept)
     {
         /* create a new altcp_conn to pass to the next 'accept' callback */
-        struct altcp_pcb * new_conn = altcp_alloc();
+        struct altcp_pcb * new_conn = matter_aws_altcp_alloc();
         if (new_conn == NULL)
         {
             return ERR_MEM;
         }
-        altcp_tcp_setup(new_conn, new_tpcb);
+        matter_aws_altcp_tcp_setup(new_conn, new_tpcb);
         return listen_conn->accept(listen_conn->arg, new_conn, err);
     }
     return ERR_ARG;
 }
 
-static err_t altcp_tcp_connected(void * arg, struct tcp_pcb * tpcb, err_t err)
+static err_t matter_aws_altcp_tcp_connected(void * arg, struct tcp_pcb * tpcb, err_t err)
 {
     struct altcp_pcb * conn = (struct altcp_pcb *) arg;
     if (conn)
@@ -104,7 +104,7 @@ static err_t altcp_tcp_connected(void * arg, struct tcp_pcb * tpcb, err_t err)
     return ERR_OK;
 }
 
-static err_t altcp_tcp_recv(void * arg, struct tcp_pcb * tpcb, struct pbuf * p, err_t err)
+static err_t matter_aws_altcp_tcp_recv(void * arg, struct tcp_pcb * tpcb, struct pbuf * p, err_t err)
 {
     struct altcp_pcb * conn = (struct altcp_pcb *) arg;
     if (conn)
@@ -123,7 +123,7 @@ static err_t altcp_tcp_recv(void * arg, struct tcp_pcb * tpcb, struct pbuf * p, 
     return ERR_OK;
 }
 
-static err_t altcp_tcp_sent(void * arg, struct tcp_pcb * tpcb, u16_t len)
+static err_t matter_aws_altcp_tcp_sent(void * arg, struct tcp_pcb * tpcb, u16_t len)
 {
     struct altcp_pcb * conn = (struct altcp_pcb *) arg;
     if (conn)
@@ -137,7 +137,7 @@ static err_t altcp_tcp_sent(void * arg, struct tcp_pcb * tpcb, u16_t len)
     return ERR_OK;
 }
 
-static err_t altcp_tcp_poll(void * arg, struct tcp_pcb * tpcb)
+static err_t matter_aws_altcp_tcp_poll(void * arg, struct tcp_pcb * tpcb)
 {
     struct altcp_pcb * conn = (struct altcp_pcb *) arg;
     if (conn)
@@ -151,7 +151,7 @@ static err_t altcp_tcp_poll(void * arg, struct tcp_pcb * tpcb)
     return ERR_OK;
 }
 
-static void altcp_tcp_err(void * arg, err_t err)
+static void matter_aws_altcp_tcp_err(void * arg, err_t err)
 {
     struct altcp_pcb * conn = (struct altcp_pcb *) arg;
     if (conn)
@@ -161,13 +161,13 @@ static void altcp_tcp_err(void * arg, err_t err)
         {
             conn->err(conn->arg, err);
         }
-        altcp_free(conn);
+        matter_aws_altcp_free(conn);
     }
 }
 
 /* setup functions */
 
-static void altcp_tcp_remove_callbacks(struct tcp_pcb * tpcb)
+static void matter_aws_altcp_tcp_remove_callbacks(struct tcp_pcb * tpcb)
 {
     tcp_arg(tpcb, NULL);
     tcp_recv(tpcb, NULL);
@@ -176,34 +176,34 @@ static void altcp_tcp_remove_callbacks(struct tcp_pcb * tpcb)
     tcp_poll(tpcb, NULL, tpcb->pollinterval);
 }
 
-static void altcp_tcp_setup_callbacks(struct altcp_pcb * conn, struct tcp_pcb * tpcb)
+static void matter_aws_altcp_tcp_setup_callbacks(struct altcp_pcb * conn, struct tcp_pcb * tpcb)
 {
     tcp_arg(tpcb, conn);
-    tcp_recv(tpcb, altcp_tcp_recv);
-    tcp_sent(tpcb, altcp_tcp_sent);
-    tcp_err(tpcb, altcp_tcp_err);
+    tcp_recv(tpcb, matter_aws_altcp_tcp_recv);
+    tcp_sent(tpcb, matter_aws_altcp_tcp_sent);
+    tcp_err(tpcb, matter_aws_altcp_tcp_err);
     /* tcp_poll is set when interval is set by application */
     /* listen is set totally different :-) */
 }
 
-static void altcp_tcp_setup(struct altcp_pcb * conn, struct tcp_pcb * tpcb)
+static void matter_aws_altcp_tcp_setup(struct altcp_pcb * conn, struct tcp_pcb * tpcb)
 {
-    altcp_tcp_setup_callbacks(conn, tpcb);
+    matter_aws_altcp_tcp_setup_callbacks(conn, tpcb);
     conn->state = tpcb;
-    conn->fns   = &altcp_tcp_functions;
+    conn->fns   = &matter_aws_altcp_tcp_functions;
 }
 
-struct altcp_pcb * altcp_tcp_new_ip_type(u8_t ip_type)
+struct altcp_pcb * matter_aws_altcp_tcp_new_ip_type(u8_t ip_type)
 {
     /* Allocate the tcp pcb first to invoke the priority handling code
        if we're out of pcbs */
     struct tcp_pcb * tpcb = tcp_new_ip_type(ip_type);
     if (tpcb != NULL)
     {
-        struct altcp_pcb * ret = altcp_alloc();
+        struct altcp_pcb * ret = matter_aws_altcp_alloc();
         if (ret != NULL)
         {
-            altcp_tcp_setup(ret, tpcb);
+            matter_aws_altcp_tcp_setup(ret, tpcb);
             return ret;
         }
         else
@@ -215,24 +215,24 @@ struct altcp_pcb * altcp_tcp_new_ip_type(u8_t ip_type)
     return NULL;
 }
 
-/** altcp_tcp allocator function fitting to @ref altcp_allocator_t / @ref altcp_new.
+/** altcp_tcp allocator function fitting to @ref altcp_allocator_t / @ref matter_aws_altcp_new.
  *
  * arg pointer is not used for TCP.
  */
-struct altcp_pcb * altcp_tcp_alloc(void * arg, u8_t ip_type)
+struct altcp_pcb * matter_aws_altcp_tcp_alloc(void * arg, u8_t ip_type)
 {
     TRANSPORT_UNUSED_ARG(arg);
-    return altcp_tcp_new_ip_type(ip_type);
+    return matter_aws_altcp_tcp_new_ip_type(ip_type);
 }
 
-struct altcp_pcb * altcp_tcp_wrap(struct tcp_pcb * tpcb)
+struct altcp_pcb * matter_aws_altcp_tcp_wrap(struct tcp_pcb * tpcb)
 {
     if (tpcb != NULL)
     {
-        struct altcp_pcb * ret = altcp_alloc();
+        struct altcp_pcb * ret = matter_aws_altcp_alloc();
         if (ret != NULL)
         {
-            altcp_tcp_setup(ret, tpcb);
+            matter_aws_altcp_tcp_setup(ret, tpcb);
             return ret;
         }
     }
@@ -240,17 +240,17 @@ struct altcp_pcb * altcp_tcp_wrap(struct tcp_pcb * tpcb)
 }
 
 /* "virtual" functions calling into tcp */
-static void altcp_tcp_set_poll(struct altcp_pcb * conn, u8_t interval)
+static void matter_aws_altcp_tcp_set_poll(struct altcp_pcb * conn, u8_t interval)
 {
     if (conn != NULL)
     {
         struct tcp_pcb * pcb = (struct tcp_pcb *) conn->state;
         ALTCP_TCP_ASSERT_CONN(conn);
-        tcp_poll(pcb, altcp_tcp_poll, interval);
+        tcp_poll(pcb, matter_aws_altcp_tcp_poll, interval);
     }
 }
 
-static void altcp_tcp_recved(struct altcp_pcb * conn, u16_t len)
+static void matter_aws_altcp_tcp_recved(struct altcp_pcb * conn, u16_t len)
 {
     if (conn != NULL)
     {
@@ -260,7 +260,7 @@ static void altcp_tcp_recved(struct altcp_pcb * conn, u16_t len)
     }
 }
 
-static err_t altcp_tcp_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port)
+static err_t matter_aws_altcp_tcp_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port)
 {
     struct tcp_pcb * pcb;
     if (conn == NULL)
@@ -272,7 +272,7 @@ static err_t altcp_tcp_bind(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u
     return tcp_bind(pcb, ipaddr, port);
 }
 
-static err_t altcp_tcp_connect(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port, altcp_connected_fn connected)
+static err_t matter_aws_altcp_tcp_connect(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port, altcp_connected_fn connected)
 {
     struct tcp_pcb * pcb;
     if (conn == NULL)
@@ -282,10 +282,10 @@ static err_t altcp_tcp_connect(struct altcp_pcb * conn, const ip_addr_t * ipaddr
     ALTCP_TCP_ASSERT_CONN(conn);
     conn->connected = connected;
     pcb             = (struct tcp_pcb *) conn->state;
-    return tcp_connect(pcb, ipaddr, port, altcp_tcp_connected);
+    return tcp_connect(pcb, ipaddr, port, matter_aws_altcp_tcp_connected);
 }
 
-static struct altcp_pcb * altcp_tcp_listen(struct altcp_pcb * conn, u8_t backlog, err_t * err)
+static struct altcp_pcb * matter_aws_altcp_tcp_listen(struct altcp_pcb * conn, u8_t backlog, err_t * err)
 {
     struct tcp_pcb * pcb;
     struct tcp_pcb * lpcb;
@@ -299,13 +299,13 @@ static struct altcp_pcb * altcp_tcp_listen(struct altcp_pcb * conn, u8_t backlog
     if (lpcb != NULL)
     {
         conn->state = lpcb;
-        tcp_accept(lpcb, altcp_tcp_accept);
+        tcp_accept(lpcb, matter_aws_altcp_tcp_accept);
         return conn;
     }
     return NULL;
 }
 
-static void altcp_tcp_abort(struct altcp_pcb * conn)
+static void matter_aws_altcp_tcp_abort(struct altcp_pcb * conn)
 {
     if (conn != NULL)
     {
@@ -318,7 +318,7 @@ static void altcp_tcp_abort(struct altcp_pcb * conn)
     }
 }
 
-static err_t altcp_tcp_close(struct altcp_pcb * conn)
+static err_t matter_aws_altcp_tcp_close(struct altcp_pcb * conn)
 {
     struct tcp_pcb * pcb;
     if (conn == NULL)
@@ -331,23 +331,23 @@ static err_t altcp_tcp_close(struct altcp_pcb * conn)
     {
         err_t err;
         tcp_poll_fn oldpoll = pcb->poll;
-        altcp_tcp_remove_callbacks(pcb);
+        matter_aws_altcp_tcp_remove_callbacks(pcb);
         err = tcp_close(pcb);
         if (err != ERR_OK)
         {
             /* not closed, set up all callbacks again */
-            altcp_tcp_setup_callbacks(conn, pcb);
+            matter_aws_altcp_tcp_setup_callbacks(conn, pcb);
             /* poll callback is not included in the above */
             tcp_poll(pcb, oldpoll, pcb->pollinterval);
             return err;
         }
         conn->state = NULL; /* unsafe to reference pcb after tcp_close(). */
     }
-    altcp_free(conn);
+    matter_aws_altcp_free(conn);
     return ERR_OK;
 }
 
-static err_t altcp_tcp_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx)
+static err_t matter_aws_altcp_tcp_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_tx)
 {
     struct tcp_pcb * pcb;
     if (conn == NULL)
@@ -359,7 +359,7 @@ static err_t altcp_tcp_shutdown(struct altcp_pcb * conn, int shut_rx, int shut_t
     return tcp_shutdown(pcb, shut_rx, shut_tx);
 }
 
-static err_t altcp_tcp_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags)
+static err_t matter_aws_altcp_tcp_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags)
 {
     struct tcp_pcb * pcb;
     if (conn == NULL)
@@ -371,7 +371,7 @@ static err_t altcp_tcp_write(struct altcp_pcb * conn, const void * dataptr, u16_
     return tcp_write(pcb, dataptr, len, apiflags);
 }
 
-static err_t altcp_tcp_output(struct altcp_pcb * conn)
+static err_t matter_aws_altcp_tcp_output(struct altcp_pcb * conn)
 {
     struct tcp_pcb * pcb;
     if (conn == NULL)
@@ -383,7 +383,7 @@ static err_t altcp_tcp_output(struct altcp_pcb * conn)
     return tcp_output(pcb);
 }
 
-static u16_t altcp_tcp_mss(struct altcp_pcb * conn)
+static u16_t matter_aws_altcp_tcp_mss(struct altcp_pcb * conn)
 {
     struct tcp_pcb * pcb;
     if (conn == NULL)
@@ -395,7 +395,7 @@ static u16_t altcp_tcp_mss(struct altcp_pcb * conn)
     return tcp_mss(pcb);
 }
 
-static u16_t altcp_tcp_sndbuf(struct altcp_pcb * conn)
+static u16_t matter_aws_altcp_tcp_sndbuf(struct altcp_pcb * conn)
 {
     struct tcp_pcb * pcb;
     if (conn == NULL)
@@ -407,7 +407,7 @@ static u16_t altcp_tcp_sndbuf(struct altcp_pcb * conn)
     return tcp_sndbuf(pcb);
 }
 
-static u16_t altcp_tcp_sndqueuelen(struct altcp_pcb * conn)
+static u16_t matter_aws_altcp_tcp_sndqueuelen(struct altcp_pcb * conn)
 {
     struct tcp_pcb * pcb;
     if (conn == NULL)
@@ -419,7 +419,7 @@ static u16_t altcp_tcp_sndqueuelen(struct altcp_pcb * conn)
     return tcp_sndqueuelen(pcb);
 }
 
-static void altcp_tcp_nagle_disable(struct altcp_pcb * conn)
+static void matter_aws_altcp_tcp_nagle_disable(struct altcp_pcb * conn)
 {
     if (conn && conn->state)
     {
@@ -429,7 +429,7 @@ static void altcp_tcp_nagle_disable(struct altcp_pcb * conn)
     }
 }
 
-static void altcp_tcp_nagle_enable(struct altcp_pcb * conn)
+static void matter_aws_altcp_tcp_nagle_enable(struct altcp_pcb * conn)
 {
     if (conn && conn->state)
     {
@@ -439,7 +439,7 @@ static void altcp_tcp_nagle_enable(struct altcp_pcb * conn)
     }
 }
 
-static int altcp_tcp_nagle_disabled(struct altcp_pcb * conn)
+static int matter_aws_altcp_tcp_nagle_disabled(struct altcp_pcb * conn)
 {
     if (conn && conn->state)
     {
@@ -450,7 +450,7 @@ static int altcp_tcp_nagle_disabled(struct altcp_pcb * conn)
     return 0;
 }
 
-static void altcp_tcp_setprio(struct altcp_pcb * conn, u8_t prio)
+static void matter_aws_altcp_tcp_setprio(struct altcp_pcb * conn, u8_t prio)
 {
     if (conn != NULL)
     {
@@ -460,14 +460,14 @@ static void altcp_tcp_setprio(struct altcp_pcb * conn, u8_t prio)
     }
 }
 
-static void altcp_tcp_dealloc(struct altcp_pcb * conn)
+static void matter_aws_altcp_tcp_dealloc(struct altcp_pcb * conn)
 {
     TRANSPORT_UNUSED_ARG(conn);
     ALTCP_TCP_ASSERT_CONN(conn);
     /* no private state to clean up */
 }
 
-static err_t altcp_tcp_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_addr_t * addr, u16_t * port)
+static err_t matter_aws_altcp_tcp_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_addr_t * addr, u16_t * port)
 {
     if (conn)
     {
@@ -499,7 +499,7 @@ static err_t altcp_tcp_get_tcp_addrinfo(struct altcp_pcb * conn, int local, ip_a
     return ERR_VAL;
 }
 
-static ip_addr_t * altcp_tcp_get_ip(struct altcp_pcb * conn, int local)
+static ip_addr_t * matter_aws_altcp_tcp_get_ip(struct altcp_pcb * conn, int local)
 {
     if (conn)
     {
@@ -520,7 +520,7 @@ static ip_addr_t * altcp_tcp_get_ip(struct altcp_pcb * conn, int local)
     return NULL;
 }
 
-static u16_t altcp_tcp_get_port(struct altcp_pcb * conn, int local)
+static u16_t matter_aws_altcp_tcp_get_port(struct altcp_pcb * conn, int local)
 {
     if (conn)
     {
@@ -542,7 +542,7 @@ static u16_t altcp_tcp_get_port(struct altcp_pcb * conn, int local)
 }
 
 #ifdef ALTCP_DEBUG
-static enum tcp_state altcp_tcp_dbg_get_tcp_state(struct altcp_pcb * conn)
+static enum tcp_state matter_aws_altcp_tcp_dbg_get_tcp_state(struct altcp_pcb * conn)
 {
     if (conn)
     {
@@ -556,30 +556,30 @@ static enum tcp_state altcp_tcp_dbg_get_tcp_state(struct altcp_pcb * conn)
     return CLOSED;
 }
 #endif
-const struct altcp_functions altcp_tcp_functions = { altcp_tcp_set_poll,
-                                                     altcp_tcp_recved,
-                                                     altcp_tcp_bind,
-                                                     altcp_tcp_connect,
-                                                     altcp_tcp_listen,
-                                                     altcp_tcp_abort,
-                                                     altcp_tcp_close,
-                                                     altcp_tcp_shutdown,
-                                                     altcp_tcp_write,
-                                                     altcp_tcp_output,
-                                                     altcp_tcp_mss,
-                                                     altcp_tcp_sndbuf,
-                                                     altcp_tcp_sndqueuelen,
-                                                     altcp_tcp_nagle_disable,
-                                                     altcp_tcp_nagle_enable,
-                                                     altcp_tcp_nagle_disabled,
-                                                     altcp_tcp_setprio,
-                                                     altcp_tcp_dealloc,
-                                                     altcp_tcp_get_tcp_addrinfo,
-                                                     altcp_tcp_get_ip,
-                                                     altcp_tcp_get_port
+const struct altcp_functions matter_aws_altcp_tcp_functions = { matter_aws_altcp_tcp_set_poll,
+                                                     matter_aws_altcp_tcp_recved,
+                                                     matter_aws_altcp_tcp_bind,
+                                                     matter_aws_altcp_tcp_connect,
+                                                     matter_aws_altcp_tcp_listen,
+                                                     matter_aws_altcp_tcp_abort,
+                                                     matter_aws_altcp_tcp_close,
+                                                     matter_aws_altcp_tcp_shutdown,
+                                                     matter_aws_altcp_tcp_write,
+                                                     matter_aws_altcp_tcp_output,
+                                                     matter_aws_altcp_tcp_mss,
+                                                     matter_aws_altcp_tcp_sndbuf,
+                                                     matter_aws_altcp_tcp_sndqueuelen,
+                                                     matter_aws_altcp_tcp_nagle_disable,
+                                                     matter_aws_altcp_tcp_nagle_enable,
+                                                     matter_aws_altcp_tcp_nagle_disabled,
+                                                     matter_aws_altcp_tcp_setprio,
+                                                     matter_aws_altcp_tcp_dealloc,
+                                                     matter_aws_altcp_tcp_get_tcp_addrinfo,
+                                                     matter_aws_altcp_tcp_get_ip,
+                                                     matter_aws_altcp_tcp_get_port
 #ifdef ALTCP_DEBUG
                                                      ,
-                                                     altcp_tcp_dbg_get_tcp_state
+                                                     matter_aws_altcp_tcp_dbg_get_tcp_state
 #endif
 };
 

--- a/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls.c
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls.c
@@ -99,7 +99,7 @@
 
 /* Variable prototype, the actual declaration is at the end of this file
    since it contains pointers to static functions declared here */
-extern const struct altcp_functions altcp_mbedtls_functions;
+extern const struct altcp_functions matter_aws_altcp_mbedtls_functions;
 
 /** Our global mbedTLS configuration (server-specific, not connection-specific) */
 struct altcp_tls_config
@@ -116,12 +116,12 @@ struct altcp_tls_config
 #endif
 };
 
-static err_t altcp_mbedtls_lower_recv(void * arg, struct altcp_pcb * inner_conn, struct pbuf * p, err_t err);
-static err_t altcp_mbedtls_setup(void * conf, struct altcp_pcb * conn, struct altcp_pcb * inner_conn);
-// static err_t altcp_mbedtls_lower_recv_process(struct altcp_pcb *conn, altcp_mbedtls_state_t *state);
-static err_t altcp_mbedtls_handle_rx_appldata(struct altcp_pcb * conn, altcp_mbedtls_state_t * state);
-static int altcp_mbedtls_bio_send(void * ctx, const unsigned char * dataptr, size_t size);
-static void altcp_mbedtls_lower_recv_signal(struct altcp_pcb * conn);
+static err_t matter_aws_altcp_mbedtls_lower_recv(void * arg, struct altcp_pcb * inner_conn, struct pbuf * p, err_t err);
+static err_t matter_aws_altcp_mbedtls_setup(void * conf, struct altcp_pcb * conn, struct altcp_pcb * inner_conn);
+// static err_t matter_aws_altcp_mbedtls_lower_recv_process(struct altcp_pcb *conn, altcp_mbedtls_state_t *state);
+static err_t matter_aws_altcp_mbedtls_handle_rx_appldata(struct altcp_pcb * conn, altcp_mbedtls_state_t * state);
+static int matter_aws_altcp_mbedtls_bio_send(void * ctx, const unsigned char * dataptr, size_t size);
+static void matter_aws_altcp_mbedtls_lower_recv_signal(struct altcp_pcb * conn);
 
 /* callback functions from inner/lower connection: */
 
@@ -130,7 +130,7 @@ static void altcp_mbedtls_lower_recv_signal(struct altcp_pcb * conn);
  * call the new connection's 'accepted' callback. If that succeeds, we wait
  * to receive connection setup handshake bytes from the client.
  */
-static err_t altcp_mbedtls_lower_accept(void * arg, struct altcp_pcb * accepted_conn, err_t err)
+static err_t matter_aws_altcp_mbedtls_lower_accept(void * arg, struct altcp_pcb * accepted_conn, err_t err)
 {
     struct altcp_pcb * listen_conn = (struct altcp_pcb *) arg;
     if (listen_conn && listen_conn->state && listen_conn->accept)
@@ -138,15 +138,15 @@ static err_t altcp_mbedtls_lower_accept(void * arg, struct altcp_pcb * accepted_
         err_t setup_err;
         altcp_mbedtls_state_t * listen_state = (altcp_mbedtls_state_t *) listen_conn->state;
         /* create a new altcp_conn to pass to the next 'accept' callback */
-        struct altcp_pcb * new_conn = altcp_alloc();
+        struct altcp_pcb * new_conn = matter_aws_altcp_alloc();
         if (new_conn == NULL)
         {
             return ERR_MEM;
         }
-        setup_err = altcp_mbedtls_setup(listen_state->conf, new_conn, accepted_conn);
+        setup_err = matter_aws_altcp_mbedtls_setup(listen_state->conf, new_conn, accepted_conn);
         if (setup_err != ERR_OK)
         {
-            altcp_free(new_conn);
+            matter_aws_altcp_free(new_conn);
             return setup_err;
         }
         return listen_conn->accept(listen_conn->arg, new_conn, err);
@@ -157,7 +157,7 @@ static err_t altcp_mbedtls_lower_accept(void * arg, struct altcp_pcb * accepted_
 /** Connected callback from lower connection (i.e. TCP).
  * Not really implemented/tested yet...
  */
-static err_t altcp_mbedtls_lower_connected(void * arg, struct altcp_pcb * inner_conn, err_t err)
+static err_t matter_aws_altcp_mbedtls_lower_connected(void * arg, struct altcp_pcb * inner_conn, err_t err)
 {
     struct altcp_pcb * conn = (struct altcp_pcb *) arg;
     TRANSPORT_UNUSED_ARG(inner_conn); /* for TRANSPORT_NOASSERT */
@@ -175,20 +175,20 @@ static err_t altcp_mbedtls_lower_connected(void * arg, struct altcp_pcb * inner_
                 return conn->connected(conn->arg, conn, err);
             }
         }
-        // return altcp_mbedtls_lower_recv_process(conn, (altcp_mbedtls_state_t *)conn->state);
-        altcp_mbedtls_lower_recv_signal(conn);
+        // return matter_aws_altcp_mbedtls_lower_recv_process(conn, (altcp_mbedtls_state_t *)conn->state);
+        matter_aws_altcp_mbedtls_lower_recv_signal(conn);
         return ERR_OK;
     }
     return ERR_VAL;
 }
 
 /* Call recved for possibly more than an u16_t */
-static void altcp_mbedtls_lower_recved(struct altcp_pcb * inner_conn, int recvd_cnt)
+static void matter_aws_altcp_mbedtls_lower_recved(struct altcp_pcb * inner_conn, int recvd_cnt)
 {
     while (recvd_cnt > 0)
     {
         u16_t recvd_part = (u16_t) TRANSPORT_MIN(recvd_cnt, 0xFFFF);
-        altcp_recved(inner_conn, recvd_part);
+        matter_aws_altcp_recved(inner_conn, recvd_part);
         recvd_cnt -= recvd_part;
     }
 }
@@ -197,7 +197,7 @@ static void altcp_mbedtls_lower_recved(struct altcp_pcb * inner_conn, int recvd_
  * This one mainly differs between connection setup/handshake (data is fed into mbedTLS only)
  * and application phase (data is decoded by mbedTLS and passed on to the application).
  */
-static err_t altcp_mbedtls_lower_recv(void * arg, struct altcp_pcb * inner_conn, struct pbuf * p, err_t err)
+static err_t matter_aws_altcp_mbedtls_lower_recv(void * arg, struct altcp_pcb * inner_conn, struct pbuf * p, err_t err)
 {
     altcp_mbedtls_state_t * state;
     struct altcp_pcb * conn = (struct altcp_pcb *) arg;
@@ -212,7 +212,7 @@ static err_t altcp_mbedtls_lower_recv(void * arg, struct altcp_pcb * inner_conn,
         {
             pbuf_free(p);
         }
-        altcp_close(inner_conn);
+        matter_aws_altcp_close(inner_conn);
         return ERR_CLSD;
     }
     state = (altcp_mbedtls_state_t *) conn->state;
@@ -224,7 +224,7 @@ static err_t altcp_mbedtls_lower_recv(void * arg, struct altcp_pcb * inner_conn,
         {
             pbuf_free(p);
         }
-        altcp_close(inner_conn);
+        matter_aws_altcp_close(inner_conn);
         return ERR_CLSD;
     }
 
@@ -241,7 +241,7 @@ static err_t altcp_mbedtls_lower_recv(void * arg, struct altcp_pcb * inner_conn,
             {
                 state->flags |= ALTCP_MBEDTLS_FLAGS_RX_CLOSE_QUEUED;
                 /* this is a normal close (FIN) but we have unprocessed data, so delay the FIN */
-                altcp_mbedtls_handle_rx_appldata(conn, state);
+                matter_aws_altcp_mbedtls_handle_rx_appldata(conn, state);
                 return ERR_OK;
             }
             state->flags |= ALTCP_MBEDTLS_FLAGS_RX_CLOSED;
@@ -257,7 +257,7 @@ static err_t altcp_mbedtls_lower_recv(void * arg, struct altcp_pcb * inner_conn,
             {
                 conn->err(conn->arg, ERR_CLSD);
             }
-            altcp_close(conn);
+            matter_aws_altcp_close(conn);
         }
         return ERR_OK;
     }
@@ -279,21 +279,21 @@ static err_t altcp_mbedtls_lower_recv(void * arg, struct altcp_pcb * inner_conn,
     if (state->flags & ALTCP_MBEDTLS_FLAGS_HANDSHAKE_DONE)
     {
         /* Application data phase: acknowledge immediately */
-        altcp_recved(inner_conn, p->len);
+        matter_aws_altcp_recved(inner_conn, p->len);
     }
 
     /* Handshake phase: bytes will be acknowledged after mbedTLS processes them via bio_recv */
-    altcp_mbedtls_lower_recv_signal(conn);
+    matter_aws_altcp_mbedtls_lower_recv_signal(conn);
     return ERR_OK;
 }
 
-static void altcp_mbedtls_lower_recv_signal(struct altcp_pcb * conn)
+static void matter_aws_altcp_mbedtls_lower_recv_signal(struct altcp_pcb * conn)
 {
     extern void mbedtls_signal_app(void * arg);
     mbedtls_signal_app(conn->arg);
 }
 
-err_t altcp_mbedtls_lower_recv_process(struct altcp_pcb * conn)
+err_t matter_aws_altcp_mbedtls_lower_recv_process(struct altcp_pcb * conn)
 {
     altcp_mbedtls_state_t * state;
     if (conn == NULL || conn->state == NULL)
@@ -308,13 +308,13 @@ err_t altcp_mbedtls_lower_recv_process(struct altcp_pcb * conn)
         /* try to send data... (only if connection is still valid) */
         if (conn->inner_conn != NULL)
         {
-            altcp_output(conn->inner_conn);
+            matter_aws_altcp_output(conn->inner_conn);
         }
 
         if (state->bio_bytes_read && conn->inner_conn != NULL)
         {
             /* acknowledge all bytes read */
-            altcp_mbedtls_lower_recved(conn->inner_conn, state->bio_bytes_read);
+            matter_aws_altcp_mbedtls_lower_recved(conn->inner_conn, state->bio_bytes_read);
             state->bio_bytes_read = 0;
         }
 
@@ -333,9 +333,9 @@ err_t altcp_mbedtls_lower_recv_process(struct altcp_pcb * conn)
                 conn->err(conn->arg, ERR_CLSD);
             }
 
-            if (altcp_close(conn) != ERR_OK)
+            if (matter_aws_altcp_close(conn) != ERR_OK)
             {
-                altcp_abort(conn);
+                matter_aws_altcp_abort(conn);
             }
             return ERR_OK;
         }
@@ -359,11 +359,11 @@ err_t altcp_mbedtls_lower_recv_process(struct altcp_pcb * conn)
         }
     }
     /* handle application data */
-    return altcp_mbedtls_handle_rx_appldata(conn, state);
+    return matter_aws_altcp_mbedtls_handle_rx_appldata(conn, state);
 }
 
 /* Pass queued decoded rx data to application */
-static err_t altcp_mbedtls_pass_rx_data(struct altcp_pcb * conn, altcp_mbedtls_state_t * state)
+static err_t matter_aws_altcp_mbedtls_pass_rx_data(struct altcp_pcb * conn, altcp_mbedtls_state_t * state)
 {
     err_t err;
     struct pbuf * buf;
@@ -416,14 +416,14 @@ static err_t altcp_mbedtls_pass_rx_data(struct altcp_pcb * conn, altcp_mbedtls_s
     /* application may have close the connection */
     if (conn->state != state)
     {
-        /* return error code to ensure altcp_mbedtls_handle_rx_appldata() exits the loop */
+        /* return error code to ensure matter_aws_altcp_mbedtls_handle_rx_appldata() exits the loop */
         return ERR_CLSD;
     }
     return ERR_OK;
 }
 
 /* Helper function that processes rx application data stored in rx pbuf chain */
-static err_t altcp_mbedtls_handle_rx_appldata(struct altcp_pcb * conn, altcp_mbedtls_state_t * state)
+static err_t matter_aws_altcp_mbedtls_handle_rx_appldata(struct altcp_pcb * conn, altcp_mbedtls_state_t * state)
 {
     int ret;
     TRANSPORT_ASSERT("state != NULL", state != NULL);
@@ -472,7 +472,7 @@ static err_t altcp_mbedtls_handle_rx_appldata(struct altcp_pcb * conn, altcp_mbe
                 return ERR_OK;
             }
             pbuf_free(buf);
-            altcp_abort(conn);
+            matter_aws_altcp_abort(conn);
             return ERR_ABRT;
         }
         else
@@ -493,7 +493,7 @@ static err_t altcp_mbedtls_handle_rx_appldata(struct altcp_pcb * conn, altcp_mbe
                     int overhead_bytes;
                     TRANSPORT_ASSERT("bogus byte counts", state->bio_bytes_read > state->bio_bytes_appl);
                     overhead_bytes = state->bio_bytes_read - state->bio_bytes_appl;
-                    altcp_mbedtls_lower_recved(conn->inner_conn, overhead_bytes);
+                    matter_aws_altcp_mbedtls_lower_recved(conn->inner_conn, overhead_bytes);
                     state->bio_bytes_read = 0;
                     state->bio_bytes_appl = 0;
                 }
@@ -512,7 +512,7 @@ static err_t altcp_mbedtls_handle_rx_appldata(struct altcp_pcb * conn, altcp_mbe
                 pbuf_free(buf);
                 buf = NULL;
             }
-            err = altcp_mbedtls_pass_rx_data(conn, state);
+            err = matter_aws_altcp_mbedtls_pass_rx_data(conn, state);
             if (err != ERR_OK)
             {
                 if (err == ERR_ABRT)
@@ -531,7 +531,7 @@ static err_t altcp_mbedtls_handle_rx_appldata(struct altcp_pcb * conn, altcp_mbe
 /** Receive callback function called from mbedtls (set via mbedtls_ssl_set_bio)
  * This function mainly copies data from pbufs and frees the pbufs after copying.
  */
-static int altcp_mbedtls_bio_recv(void * ctx, unsigned char * buf, size_t len)
+static int matter_aws_altcp_mbedtls_bio_recv(void * ctx, unsigned char * buf, size_t len)
 {
     struct altcp_pcb * conn = (struct altcp_pcb *) ctx;
     altcp_mbedtls_state_t * state;
@@ -589,7 +589,7 @@ static int altcp_mbedtls_bio_recv(void * ctx, unsigned char * buf, size_t len)
  * This only informs the upper layer to try to send more, not about
  * the number of ACKed bytes.
  */
-static err_t altcp_mbedtls_lower_sent(void * arg, struct altcp_pcb * inner_conn, u16_t len)
+static err_t matter_aws_altcp_mbedtls_lower_sent(void * arg, struct altcp_pcb * inner_conn, u16_t len)
 {
     int ret;
     struct altcp_pcb * conn = (struct altcp_pcb *) arg;
@@ -624,7 +624,7 @@ static err_t altcp_mbedtls_lower_sent(void * arg, struct altcp_pcb * inner_conn,
  * Just pass this on to the application.
  * @todo: retry sending?
  */
-static err_t altcp_mbedtls_lower_poll(void * arg, struct altcp_pcb * inner_conn)
+static err_t matter_aws_altcp_mbedtls_lower_poll(void * arg, struct altcp_pcb * inner_conn)
 {
     int ret;
     struct altcp_pcb * conn = (struct altcp_pcb *) arg;
@@ -643,7 +643,7 @@ static err_t altcp_mbedtls_lower_poll(void * arg, struct altcp_pcb * inner_conn)
                 TRANSPORT_DEBUGF(("mbedtls_ssl_flash_output failed\n"));
                 return ret;
             }
-            if (altcp_mbedtls_handle_rx_appldata(conn, state) == ERR_ABRT)
+            if (matter_aws_altcp_mbedtls_handle_rx_appldata(conn, state) == ERR_ABRT)
             {
                 return ERR_ABRT;
             }
@@ -656,7 +656,7 @@ static err_t altcp_mbedtls_lower_poll(void * arg, struct altcp_pcb * inner_conn)
     return ERR_OK;
 }
 
-static void altcp_mbedtls_lower_err(void * arg, err_t err)
+static void matter_aws_altcp_mbedtls_lower_err(void * arg, err_t err)
 {
     struct altcp_pcb * conn = (struct altcp_pcb *) arg;
     if (conn)
@@ -666,32 +666,32 @@ static void altcp_mbedtls_lower_err(void * arg, err_t err)
         {
             conn->err(conn->arg, err);
         }
-        altcp_free(conn);
+        matter_aws_altcp_free(conn);
     }
 }
 
 /* setup functions */
 
-static void altcp_mbedtls_remove_callbacks(struct altcp_pcb * inner_conn)
+static void matter_aws_altcp_mbedtls_remove_callbacks(struct altcp_pcb * inner_conn)
 {
-    altcp_arg(inner_conn, NULL);
-    altcp_recv(inner_conn, NULL);
-    altcp_sent(inner_conn, NULL);
-    altcp_err(inner_conn, NULL);
-    altcp_poll(inner_conn, NULL, inner_conn->pollinterval);
+    matter_aws_altcp_arg(inner_conn, NULL);
+    matter_aws_altcp_recv(inner_conn, NULL);
+    matter_aws_altcp_sent(inner_conn, NULL);
+    matter_aws_altcp_err(inner_conn, NULL);
+    matter_aws_altcp_poll(inner_conn, NULL, inner_conn->pollinterval);
 }
 
-static void altcp_mbedtls_setup_callbacks(struct altcp_pcb * conn, struct altcp_pcb * inner_conn)
+static void matter_aws_altcp_mbedtls_setup_callbacks(struct altcp_pcb * conn, struct altcp_pcb * inner_conn)
 {
-    altcp_arg(inner_conn, conn);
-    altcp_recv(inner_conn, altcp_mbedtls_lower_recv);
-    altcp_sent(inner_conn, altcp_mbedtls_lower_sent);
-    altcp_err(inner_conn, altcp_mbedtls_lower_err);
+    matter_aws_altcp_arg(inner_conn, conn);
+    matter_aws_altcp_recv(inner_conn, matter_aws_altcp_mbedtls_lower_recv);
+    matter_aws_altcp_sent(inner_conn, matter_aws_altcp_mbedtls_lower_sent);
+    matter_aws_altcp_err(inner_conn, matter_aws_altcp_mbedtls_lower_err);
     /* tcp_poll is set when interval is set by application */
     /* listen is set totally different :-) */
 }
 
-static err_t altcp_mbedtls_setup(void * conf, struct altcp_pcb * conn, struct altcp_pcb * inner_conn)
+static err_t matter_aws_altcp_mbedtls_setup(void * conf, struct altcp_pcb * conn, struct altcp_pcb * inner_conn)
 {
     int ret;
     struct altcp_tls_config * config = (struct altcp_tls_config *) conf;
@@ -703,7 +703,7 @@ static err_t altcp_mbedtls_setup(void * conf, struct altcp_pcb * conn, struct al
     TRANSPORT_ASSERT("invalid inner_conn", conn != inner_conn);
 
     /* allocate mbedtls context */
-    state = altcp_mbedtls_alloc(conf);
+    state = matter_aws_altcp_mbedtls_alloc(conf);
     if (state == NULL)
     {
         return ERR_MEM;
@@ -715,39 +715,39 @@ static err_t altcp_mbedtls_setup(void * conf, struct altcp_pcb * conn, struct al
     {
         TRANSPORT_DEBUGF(("mbedtls_ssl_setup failed\n"));
         /* @todo: convert 'ret' to err_t */
-        altcp_mbedtls_free(conf, state);
+        matter_aws_altcp_mbedtls_free(conf, state);
         return ERR_MEM;
     }
     /* tell mbedtls about our I/O functions */
-    mbedtls_ssl_set_bio(&state->ssl_context, conn, altcp_mbedtls_bio_send, altcp_mbedtls_bio_recv, NULL);
+    mbedtls_ssl_set_bio(&state->ssl_context, conn, matter_aws_altcp_mbedtls_bio_send, matter_aws_altcp_mbedtls_bio_recv, NULL);
 
-    altcp_mbedtls_setup_callbacks(conn, inner_conn);
+    matter_aws_altcp_mbedtls_setup_callbacks(conn, inner_conn);
     conn->inner_conn = inner_conn;
-    conn->fns        = &altcp_mbedtls_functions;
+    conn->fns        = &matter_aws_altcp_mbedtls_functions;
     conn->state      = state;
     return ERR_OK;
 }
 
-struct altcp_pcb * altcp_tls_wrap(struct altcp_tls_config * config, struct altcp_pcb * inner_pcb)
+struct altcp_pcb * matter_aws_altcp_tls_wrap(struct altcp_tls_config * config, struct altcp_pcb * inner_pcb)
 {
     struct altcp_pcb * ret;
     if (inner_pcb == NULL)
     {
         return NULL;
     }
-    ret = altcp_alloc();
+    ret = matter_aws_altcp_alloc();
     if (ret != NULL)
     {
-        if (altcp_mbedtls_setup(config, ret, inner_pcb) != ERR_OK)
+        if (matter_aws_altcp_mbedtls_setup(config, ret, inner_pcb) != ERR_OK)
         {
-            altcp_free(ret);
+            matter_aws_altcp_free(ret);
             return NULL;
         }
     }
     return ret;
 }
 
-void * altcp_tls_context(struct altcp_pcb * conn)
+void * matter_aws_altcp_tls_context(struct altcp_pcb * conn)
 {
     if (conn && conn->state)
     {
@@ -758,7 +758,7 @@ void * altcp_tls_context(struct altcp_pcb * conn)
 }
 
 #if ALTCP_MBEDTLS_DEBUG
-static void altcp_mbedtls_debug(void * ctx, int level, const char * file, int line, const char * str)
+static void matter_aws_altcp_mbedtls_debug(void * ctx, int level, const char * file, int line, const char * str)
 {
     TRANSPORT_UNUSED_ARG(ctx);
     TRANSPORT_UNUSED_ARG(level);
@@ -772,7 +772,7 @@ static void altcp_mbedtls_debug(void * ctx, int level, const char * file, int li
 
 #ifndef ALTCP_MBEDTLS_RNG_FN
 /** ATTENTION: It is *really* important to *NOT* use this dummy RNG in production code!!!! */
-static int dummy_rng(void * ctx, unsigned char * buffer, size_t len)
+static int matter_aws_dummy_rng(void * ctx, unsigned char * buffer, size_t len)
 {
     static size_t ctr;
     size_t i;
@@ -783,7 +783,7 @@ static int dummy_rng(void * ctx, unsigned char * buffer, size_t len)
     }
     return 0;
 }
-#define ALTCP_MBEDTLS_RNG_FN dummy_rng
+#define ALTCP_MBEDTLS_RNG_FN matter_aws_dummy_rng
 #endif /* ALTCP_MBEDTLS_RNG_FN */
 
 static int ciphers[] = { MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
@@ -792,7 +792,7 @@ static int ciphers[] = { MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, MBEDTL
 /** Create new TLS configuration
  * ATTENTION: Server certificate and private key have to be added outside this function!
  */
-static struct altcp_tls_config * altcp_tls_create_config(int is_server, int have_cert, int have_pkey, int have_ca)
+static struct altcp_tls_config * matter_aws_altcp_tls_create_config(int is_server, int have_cert, int have_pkey, int have_ca)
 {
     size_t sz;
     int ret;
@@ -804,7 +804,7 @@ static struct altcp_tls_config * altcp_tls_create_config(int is_server, int have
         TRANSPORT_DEBUGF(("altcp_tls: TCP_WND is smaller than the RX decryption buffer, connection RX might stall!\n"));
     }
 
-    altcp_mbedtls_mem_init();
+    matter_aws_altcp_mbedtls_mem_init();
 
     sz = sizeof(struct altcp_tls_config);
     if (have_cert)
@@ -820,7 +820,7 @@ static struct altcp_tls_config * altcp_tls_create_config(int is_server, int have
         sz += sizeof(mbedtls_pk_context);
     }
 
-    conf = (struct altcp_tls_config *) altcp_mbedtls_alloc_config(sz);
+    conf = (struct altcp_tls_config *) matter_aws_altcp_mbedtls_alloc_config(sz);
     if (conf == NULL)
     {
         return NULL;
@@ -851,7 +851,7 @@ static struct altcp_tls_config * altcp_tls_create_config(int is_server, int have
     if (ret != 0)
     {
         TRANSPORT_DEBUGF(("mbedtls_ctr_drbg_seed failed: %d\n", ret));
-        altcp_mbedtls_free_config(conf);
+        matter_aws_altcp_mbedtls_free_config(conf);
         return NULL;
     }
 
@@ -865,14 +865,14 @@ static struct altcp_tls_config * altcp_tls_create_config(int is_server, int have
     if (ret != 0)
     {
         TRANSPORT_DEBUGF(("mbedtls_ssl_config_defaults failed: %d\n", ret));
-        altcp_mbedtls_free_config(conf);
+        matter_aws_altcp_mbedtls_free_config(conf);
         return NULL;
     }
     mbedtls_ssl_conf_authmode(&conf->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
     mbedtls_ssl_conf_ciphersuites(&conf->conf, (const int *) &ciphers);
     mbedtls_ssl_conf_rng(&conf->conf, mbedtls_ctr_drbg_random, &conf->ctr_drbg);
 #if ALTCP_MBEDTLS_DEBUG
-    mbedtls_ssl_conf_dbg(&conf->conf, altcp_mbedtls_debug, stdout);
+    mbedtls_ssl_conf_dbg(&conf->conf, matter_aws_altcp_mbedtls_debug, stdout);
     mbedtls_debug_set_threshold(ALTCP_MBEDTLS_DEBUG);
 #endif
 #if defined(MBEDTLS_SSL_CACHE_C) && ALTCP_MBEDTLS_SESSION_CACHE_TIMEOUT_SECONDS
@@ -888,14 +888,14 @@ static struct altcp_tls_config * altcp_tls_create_config(int is_server, int have
  * This is a suboptimal version that gets the encrypted private key and its password,
  * as well as the server certificate.
  */
-struct altcp_tls_config * altcp_tls_create_config_server_privkey_cert(const u8_t * privkey, size_t privkey_len,
+struct altcp_tls_config * matter_aws_altcp_tls_create_config_server_privkey_cert(const u8_t * privkey, size_t privkey_len,
                                                                       const u8_t * privkey_pass, size_t privkey_pass_len,
                                                                       const u8_t * cert, size_t cert_len)
 {
     int ret;
     mbedtls_x509_crt * srvcert;
     mbedtls_pk_context * pkey;
-    struct altcp_tls_config * conf = altcp_tls_create_config(1, 1, 1, 0);
+    struct altcp_tls_config * conf = matter_aws_altcp_tls_create_config(1, 1, 1, 0);
     if (conf == NULL)
     {
         return NULL;
@@ -912,7 +912,7 @@ struct altcp_tls_config * altcp_tls_create_config_server_privkey_cert(const u8_t
     if (ret != 0)
     {
         TRANSPORT_DEBUGF(("mbedtls_x509_crt_parse failed: %d\n", ret));
-        altcp_mbedtls_free_config(conf);
+        matter_aws_altcp_mbedtls_free_config(conf);
         return NULL;
     }
 
@@ -926,7 +926,7 @@ struct altcp_tls_config * altcp_tls_create_config_server_privkey_cert(const u8_t
     {
         TRANSPORT_DEBUGF(("mbedtls_pk_parse_public_key failed: %d\n", ret));
         mbedtls_x509_crt_free(srvcert);
-        altcp_mbedtls_free_config(conf);
+        matter_aws_altcp_mbedtls_free_config(conf);
         return NULL;
     }
 
@@ -937,16 +937,16 @@ struct altcp_tls_config * altcp_tls_create_config_server_privkey_cert(const u8_t
         TRANSPORT_DEBUGF(("mbedtls_ssl_conf_own_cert failed: %d\n", ret));
         mbedtls_x509_crt_free(srvcert);
         mbedtls_pk_free(pkey);
-        altcp_mbedtls_free_config(conf);
+        matter_aws_altcp_mbedtls_free_config(conf);
         return NULL;
     }
     return conf;
 }
 
-static struct altcp_tls_config * altcp_tls_create_config_client_common(const u8_t * ca, size_t ca_len, int is_2wayauth)
+static struct altcp_tls_config * matter_aws_altcp_tls_create_config_client_common(const u8_t * ca, size_t ca_len, int is_2wayauth)
 {
     int ret;
-    struct altcp_tls_config * conf = altcp_tls_create_config(0, is_2wayauth, is_2wayauth, ca != NULL);
+    struct altcp_tls_config * conf = matter_aws_altcp_tls_create_config(0, is_2wayauth, is_2wayauth, ca != NULL);
     if (conf == NULL)
     {
         return NULL;
@@ -963,7 +963,7 @@ static struct altcp_tls_config * altcp_tls_create_config_client_common(const u8_
         {
             TRANSPORT_DEBUGF(("mbedtls_x509_crt_parse ca failed: %d 0x%x", ret, -1 * ret));
             mbedtls_x509_crt_free(conf->ca);
-            altcp_mbedtls_free_config(conf);
+            matter_aws_altcp_mbedtls_free_config(conf);
             return NULL;
         }
 
@@ -972,12 +972,12 @@ static struct altcp_tls_config * altcp_tls_create_config_client_common(const u8_
     return conf;
 }
 
-struct altcp_tls_config * altcp_tls_create_config_client(const u8_t * ca, size_t ca_len)
+struct altcp_tls_config * matter_aws_altcp_tls_create_config_client(const u8_t * ca, size_t ca_len)
 {
-    return altcp_tls_create_config_client_common(ca, ca_len, 0);
+    return matter_aws_altcp_tls_create_config_client_common(ca, ca_len, 0);
 }
 
-struct altcp_tls_config * altcp_tls_create_config_client_2wayauth(const u8_t * ca, size_t ca_len, const u8_t * privkey,
+struct altcp_tls_config * matter_aws_altcp_tls_create_config_client_2wayauth(const u8_t * ca, size_t ca_len, const u8_t * privkey,
                                                                   size_t privkey_len, const u8_t * privkey_pass,
                                                                   size_t privkey_pass_len, const u8_t * cert, size_t cert_len)
 {
@@ -986,11 +986,11 @@ struct altcp_tls_config * altcp_tls_create_config_client_2wayauth(const u8_t * c
 
     if (!cert || !privkey)
     {
-        TRANSPORT_DEBUGF(("altcp_tls_create_config_client_2wayauth: certificate and priv key required"));
+        TRANSPORT_DEBUGF(("matter_aws_altcp_tls_create_config_client_2wayauth: certificate and priv key required"));
         return NULL;
     }
 
-    conf = altcp_tls_create_config_client_common(ca, ca_len, 1);
+    conf = matter_aws_altcp_tls_create_config_client_common(ca, ca_len, 1);
     if (conf == NULL)
     {
         return NULL;
@@ -1003,7 +1003,7 @@ struct altcp_tls_config * altcp_tls_create_config_client_2wayauth(const u8_t * c
     {
         SILABS_LOG("mbedtls_x509_crt_parse cert failed: %d 0x%x", ret, -1 * ret);
         mbedtls_x509_crt_free(conf->cert);
-        altcp_mbedtls_free_config(conf);
+        matter_aws_altcp_mbedtls_free_config(conf);
         return NULL;
     }
 
@@ -1018,7 +1018,7 @@ struct altcp_tls_config * altcp_tls_create_config_client_2wayauth(const u8_t * c
         SILABS_LOG("mbedtls_pk_parse_key failed: %d 0x%x", ret, -1 * ret);
         mbedtls_x509_crt_free(conf->cert);
         mbedtls_pk_free(conf->pkey);
-        altcp_mbedtls_free_config(conf);
+        matter_aws_altcp_mbedtls_free_config(conf);
         return NULL;
     }
 
@@ -1028,14 +1028,14 @@ struct altcp_tls_config * altcp_tls_create_config_client_2wayauth(const u8_t * c
         SILABS_LOG("mbedtls_ssl_conf_own_cert failed: %d 0x%x", ret, -1 * ret);
         mbedtls_x509_crt_free(conf->cert);
         mbedtls_pk_free(conf->pkey);
-        altcp_mbedtls_free_config(conf);
+        matter_aws_altcp_mbedtls_free_config(conf);
         return NULL;
     }
 
     return conf;
 }
 
-void altcp_tls_free_config(struct altcp_tls_config * conf)
+void matter_aws_altcp_tls_free_config(struct altcp_tls_config * conf)
 {
     if (conf->pkey)
     {
@@ -1049,19 +1049,19 @@ void altcp_tls_free_config(struct altcp_tls_config * conf)
     {
         mbedtls_x509_crt_free(conf->ca);
     }
-    altcp_mbedtls_free_config(conf);
+    matter_aws_altcp_mbedtls_free_config(conf);
 }
 
 /* "virtual" functions */
-static void altcp_mbedtls_set_poll(struct altcp_pcb * conn, u8_t interval)
+static void matter_aws_altcp_mbedtls_set_poll(struct altcp_pcb * conn, u8_t interval)
 {
     if (conn != NULL)
     {
-        altcp_poll(conn->inner_conn, altcp_mbedtls_lower_poll, interval);
+        matter_aws_altcp_poll(conn->inner_conn, matter_aws_altcp_mbedtls_lower_poll, interval);
     }
 }
 
-static void altcp_mbedtls_recved(struct altcp_pcb * conn, u16_t len)
+static void matter_aws_altcp_mbedtls_recved(struct altcp_pcb * conn, u16_t len)
 {
     u16_t lower_recved;
     altcp_mbedtls_state_t * state;
@@ -1086,45 +1086,45 @@ static void altcp_mbedtls_recved(struct altcp_pcb * conn, u16_t len)
     }
     state->rx_passed_unrecved -= lower_recved;
 
-    altcp_recved(conn->inner_conn, lower_recved);
+    matter_aws_altcp_recved(conn->inner_conn, lower_recved);
 }
 
-static err_t altcp_mbedtls_connect(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port, altcp_connected_fn connected)
+static err_t matter_aws_altcp_mbedtls_connect(struct altcp_pcb * conn, const ip_addr_t * ipaddr, u16_t port, altcp_connected_fn connected)
 {
     if (conn == NULL)
     {
         return ERR_VAL;
     }
     conn->connected = connected;
-    return altcp_connect(conn->inner_conn, ipaddr, port, altcp_mbedtls_lower_connected);
+    return matter_aws_altcp_connect(conn->inner_conn, ipaddr, port, matter_aws_altcp_mbedtls_lower_connected);
 }
 
-static struct altcp_pcb * altcp_mbedtls_listen(struct altcp_pcb * conn, u8_t backlog, err_t * err)
+static struct altcp_pcb * matter_aws_altcp_mbedtls_listen(struct altcp_pcb * conn, u8_t backlog, err_t * err)
 {
     struct altcp_pcb * lpcb;
     if (conn == NULL)
     {
         return NULL;
     }
-    lpcb = altcp_listen_with_backlog_and_err(conn->inner_conn, backlog, err);
+    lpcb = matter_aws_altcp_listen_with_backlog_and_err(conn->inner_conn, backlog, err);
     if (lpcb != NULL)
     {
         conn->inner_conn = lpcb;
-        altcp_accept(lpcb, altcp_mbedtls_lower_accept);
+        matter_aws_altcp_accept(lpcb, matter_aws_altcp_mbedtls_lower_accept);
         return conn;
     }
     return NULL;
 }
 
-static void altcp_mbedtls_abort(struct altcp_pcb * conn)
+static void matter_aws_altcp_mbedtls_abort(struct altcp_pcb * conn)
 {
     if (conn != NULL)
     {
-        altcp_abort(conn->inner_conn);
+        matter_aws_altcp_abort(conn->inner_conn);
     }
 }
 
-static err_t altcp_mbedtls_close(struct altcp_pcb * conn)
+static err_t matter_aws_altcp_mbedtls_close(struct altcp_pcb * conn)
 {
     struct altcp_pcb * inner_conn;
     if (conn == NULL)
@@ -1136,26 +1136,26 @@ static err_t altcp_mbedtls_close(struct altcp_pcb * conn)
     {
         err_t err;
         altcp_poll_fn oldpoll = inner_conn->poll;
-        altcp_mbedtls_remove_callbacks(conn->inner_conn);
-        err = altcp_close(conn->inner_conn);
+        matter_aws_altcp_mbedtls_remove_callbacks(conn->inner_conn);
+        err = matter_aws_altcp_close(conn->inner_conn);
         if (err != ERR_OK)
         {
             /* not closed, set up all callbacks again */
-            altcp_mbedtls_setup_callbacks(conn, inner_conn);
+            matter_aws_altcp_mbedtls_setup_callbacks(conn, inner_conn);
             /* poll callback is not included in the above */
-            altcp_poll(inner_conn, oldpoll, inner_conn->pollinterval);
+            matter_aws_altcp_poll(inner_conn, oldpoll, inner_conn->pollinterval);
             return err;
         }
         conn->inner_conn = NULL;
     }
-    altcp_free(conn);
+    matter_aws_altcp_free(conn);
     return ERR_OK;
 }
 
-/** Allow caller of altcp_write() to limit to negotiated chunk size
+/** Allow caller of matter_aws_altcp_write() to limit to negotiated chunk size
  *  or remaining sndbuf space of inner_conn.
  */
-static u16_t altcp_mbedtls_sndbuf(struct altcp_pcb * conn)
+static u16_t matter_aws_altcp_mbedtls_sndbuf(struct altcp_pcb * conn)
 {
     if (conn)
     {
@@ -1167,7 +1167,7 @@ static u16_t altcp_mbedtls_sndbuf(struct altcp_pcb * conn)
         }
         if (conn->inner_conn)
         {
-            u16_t sndbuf = altcp_sndbuf(conn->inner_conn);
+            u16_t sndbuf = matter_aws_altcp_sndbuf(conn->inner_conn);
             /* Take care of record header, IV, AuthTag */
             int ssl_expan = mbedtls_ssl_get_record_expansion(&state->ssl_context);
             if (ssl_expan > 0)
@@ -1194,13 +1194,13 @@ static u16_t altcp_mbedtls_sndbuf(struct altcp_pcb * conn)
         }
     }
     /* fallback: use sendbuf of the inner connection */
-    return altcp_default_sndbuf(conn);
+    return matter_aws_altcp_default_sndbuf(conn);
 }
 
 /** Write data to a TLS connection. Calls into mbedTLS, which in turn calls into
- * @ref altcp_mbedtls_bio_send() to send the encrypted data
+ * @ref matter_aws_altcp_mbedtls_bio_send() to send the encrypted data
  */
-static err_t altcp_mbedtls_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags)
+static err_t matter_aws_altcp_mbedtls_write(struct altcp_pcb * conn, const void * dataptr, u16_t len, u8_t apiflags)
 {
     int ret;
     altcp_mbedtls_state_t * state;
@@ -1244,7 +1244,7 @@ static err_t altcp_mbedtls_write(struct altcp_pcb * conn, const void * dataptr, 
     /* try to send data... (only if connection is still valid) */
     if (conn->inner_conn != NULL)
     {
-        altcp_output(conn->inner_conn);
+        matter_aws_altcp_output(conn->inner_conn);
     }
     if (ret >= 0)
     {
@@ -1274,9 +1274,9 @@ static err_t altcp_mbedtls_write(struct altcp_pcb * conn, const void * dataptr, 
 
 /** Send callback function called from mbedtls (set via mbedtls_ssl_set_bio)
  * This function is either called during handshake or when sending application
- * data via @ref altcp_mbedtls_write (or altcp_write)
+ * data via @ref matter_aws_altcp_mbedtls_write (or matter_aws_altcp_write)
  */
-static int altcp_mbedtls_bio_send(void * ctx, const unsigned char * dataptr, size_t size)
+static int matter_aws_altcp_mbedtls_bio_send(void * ctx, const unsigned char * dataptr, size_t size)
 {
     struct altcp_pcb * conn = (struct altcp_pcb *) ctx;
     int written             = 0;
@@ -1298,7 +1298,7 @@ static int altcp_mbedtls_bio_send(void * ctx, const unsigned char * dataptr, siz
     while (size_left)
     {
         u16_t write_len = (u16_t) TRANSPORT_MIN(size_left, 0xFFFF);
-        err_t err       = altcp_write(conn->inner_conn, (const void *) dataptr, write_len, apiflags);
+        err_t err       = matter_aws_altcp_write(conn->inner_conn, (const void *) dataptr, write_len, apiflags);
         if (err == ERR_OK)
         {
             written += write_len;
@@ -1322,22 +1322,22 @@ static int altcp_mbedtls_bio_send(void * ctx, const unsigned char * dataptr, siz
     // Send data immediately after write to avoid queuing (only if connection is still valid)
     if (conn->inner_conn != NULL)
     {
-        altcp_output(conn->inner_conn);
+        matter_aws_altcp_output(conn->inner_conn);
     }
     return written;
 }
 
-static u16_t altcp_mbedtls_mss(struct altcp_pcb * conn)
+static u16_t matter_aws_altcp_mbedtls_mss(struct altcp_pcb * conn)
 {
     if (conn == NULL)
     {
         return 0;
     }
     /* @todo: TRANSPORT_MIN(mss, mbedtls_ssl_get_max_frag_len()) ? */
-    return altcp_mss(conn->inner_conn);
+    return matter_aws_altcp_mss(conn->inner_conn);
 }
 
-static void altcp_mbedtls_dealloc(struct altcp_pcb * conn)
+static void matter_aws_altcp_mbedtls_dealloc(struct altcp_pcb * conn)
 {
     /* clean up and free tls state */
     if (conn)
@@ -1353,36 +1353,36 @@ static void altcp_mbedtls_dealloc(struct altcp_pcb * conn)
                 pbuf_free(state->rx);
                 state->rx = NULL;
             }
-            altcp_mbedtls_free(state->conf, state);
+            matter_aws_altcp_mbedtls_free(state->conf, state);
             conn->state = NULL;
         }
     }
 }
 
-const struct altcp_functions altcp_mbedtls_functions = { altcp_mbedtls_set_poll,
-                                                         altcp_mbedtls_recved,
-                                                         altcp_default_bind,
-                                                         altcp_mbedtls_connect,
-                                                         altcp_mbedtls_listen,
-                                                         altcp_mbedtls_abort,
-                                                         altcp_mbedtls_close,
-                                                         altcp_default_shutdown,
-                                                         altcp_mbedtls_write,
-                                                         altcp_default_output,
-                                                         altcp_mbedtls_mss,
-                                                         altcp_mbedtls_sndbuf,
-                                                         altcp_default_sndqueuelen,
-                                                         altcp_default_nagle_disable,
-                                                         altcp_default_nagle_enable,
-                                                         altcp_default_nagle_disabled,
-                                                         altcp_default_setprio,
-                                                         altcp_mbedtls_dealloc,
-                                                         altcp_default_get_tcp_addrinfo,
-                                                         altcp_default_get_ip,
-                                                         altcp_default_get_port
+const struct altcp_functions matter_aws_altcp_mbedtls_functions = { matter_aws_altcp_mbedtls_set_poll,
+                                                         matter_aws_altcp_mbedtls_recved,
+                                                         matter_aws_altcp_default_bind,
+                                                         matter_aws_altcp_mbedtls_connect,
+                                                         matter_aws_altcp_mbedtls_listen,
+                                                         matter_aws_altcp_mbedtls_abort,
+                                                         matter_aws_altcp_mbedtls_close,
+                                                         matter_aws_altcp_default_shutdown,
+                                                         matter_aws_altcp_mbedtls_write,
+                                                         matter_aws_altcp_default_output,
+                                                         matter_aws_altcp_mbedtls_mss,
+                                                         matter_aws_altcp_mbedtls_sndbuf,
+                                                         matter_aws_altcp_default_sndqueuelen,
+                                                         matter_aws_altcp_default_nagle_disable,
+                                                         matter_aws_altcp_default_nagle_enable,
+                                                         matter_aws_altcp_default_nagle_disabled,
+                                                         matter_aws_altcp_default_setprio,
+                                                         matter_aws_altcp_mbedtls_dealloc,
+                                                         matter_aws_altcp_default_get_tcp_addrinfo,
+                                                         matter_aws_altcp_default_get_ip,
+                                                         matter_aws_altcp_default_get_port
 #ifdef ALTCP_DEBUG
                                                          ,
-                                                         altcp_default_dbg_get_tcp_state
+                                                         matter_aws_altcp_default_dbg_get_tcp_state
 #endif
 };
 

--- a/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls_mem.c
+++ b/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls_mem.c
@@ -43,7 +43,7 @@
  * Missing things / @todo:
  * - RX data is acknowledged after receiving (tcp_recved is called when enqueueing
  *   the pbuf for mbedTLS receive, not when processed by mbedTLS or the inner
- *   connection; altcp_recved() from inner connection does nothing)
+ *   connection; matter_aws_altcp_recved() from inner connection does nothing)
  * - TX data is marked as 'sent' (i.e. acknowledged; sent callback is called) right
  *   after enqueueing for transmission, not when actually ACKed be the remote host.
  */
@@ -98,7 +98,7 @@ altcp_mbedtls_malloc_stats_t altcp_mbedtls_malloc_stats;
 volatile int altcp_mbedtls_malloc_clear_stats;
 #endif
 
-static void * tls_malloc(size_t c, size_t len)
+static void * matter_aws_tls_malloc(size_t c, size_t len)
 {
     altcp_mbedtls_malloc_helper_t * hlpr;
     void * ret;
@@ -142,7 +142,7 @@ static void * tls_malloc(size_t c, size_t len)
     return ret;
 }
 
-static void tls_free(void * ptr)
+static void matter_aws_tls_free(void * ptr)
 {
     altcp_mbedtls_malloc_helper_t * hlpr;
     if (ptr == NULL)
@@ -161,17 +161,17 @@ static void tls_free(void * ptr)
 }
 #endif /* ALTCP_MBEDTLS_PLATFORM_ALLOC*/
 
-void altcp_mbedtls_mem_init(void)
+void matter_aws_altcp_mbedtls_mem_init(void)
 {
     /* not much to do here when using the heap */
 
 #if ALTCP_MBEDTLS_PLATFORM_ALLOC
     /* set mbedtls allocation methods */
-    mbedtls_platform_set_calloc_free(&tls_malloc, &tls_free);
+    mbedtls_platform_set_calloc_free(&matter_aws_tls_malloc, &matter_aws_tls_free);
 #endif
 }
 
-altcp_mbedtls_state_t * altcp_mbedtls_alloc(void * conf)
+altcp_mbedtls_state_t * matter_aws_altcp_mbedtls_alloc(void * conf)
 {
     altcp_mbedtls_state_t * ret = (altcp_mbedtls_state_t *) pvPortMalloc(sizeof(altcp_mbedtls_state_t));
     if (ret != NULL)
@@ -182,14 +182,14 @@ altcp_mbedtls_state_t * altcp_mbedtls_alloc(void * conf)
     return ret;
 }
 
-void altcp_mbedtls_free(void * conf, altcp_mbedtls_state_t * state)
+void matter_aws_altcp_mbedtls_free(void * conf, altcp_mbedtls_state_t * state)
 {
     TRANSPORT_UNUSED_ARG(conf);
     TRANSPORT_ASSERT("state != NULL", state != NULL);
     vPortFree(state);
 }
 
-void * altcp_mbedtls_alloc_config(size_t size)
+void * matter_aws_altcp_mbedtls_alloc_config(size_t size)
 {
     void * ret;
     size_t checked_size = (mem_size_t) size;
@@ -206,7 +206,7 @@ void * altcp_mbedtls_alloc_config(size_t size)
     return ret;
 }
 
-void altcp_mbedtls_free_config(void * item)
+void matter_aws_altcp_mbedtls_free_config(void * item)
 {
     TRANSPORT_ASSERT("item != NULL", item != NULL);
     vPortFree(item);


### PR DESCRIPTION
#### Summary

The application failed to compile when MATTER AWS and ALTCP components are enabled together in the Studio or SLC build system.

#### Related issues

Fixes MATTER-6156 MATTER-6350

#### Testing

Manually tested by adding respective MATTER AWS credentials.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See:
[Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
