### PR TITLE
[SL-ONLY] MATTER-6655: Add briefs to refactored AppTask methods (#998)

### DIFF
--- a/examples/base-platform-app/silabs/include/AppTask.h
+++ b/examples/base-platform-app/silabs/include/AppTask.h
@@ -51,7 +51,6 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
-    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -61,7 +60,6 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
-    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**

--- a/examples/base-platform-app/silabs/include/AppTask.h
+++ b/examples/base-platform-app/silabs/include/AppTask.h
@@ -51,6 +51,7 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -60,6 +61,7 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**

--- a/examples/onoff-plug-app/silabs/include/AppTask.h
+++ b/examples/onoff-plug-app/silabs/include/AppTask.h
@@ -55,11 +55,12 @@ public:
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
     /**
-     * @brief Data model hook invoked when a cluster attribute changes.
+     * @brief Matter stack callback after a server attribute write, syncs plug LED and LCD demo UI
+     *        when @c OnOff::OnOff changes.
      *
      * @param attributePath Endpoint, cluster, and attribute that changed
-     * @param type          Ember attribute type of @p value
-     * @param size          Size of @p value in bytes
+     * @param type          TLV encoding type of @p value
+     * @param size          Size in bytes of @p value
      * @param value         Pointer to the new attribute value
      */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,

--- a/examples/onoff-plug-app/silabs/include/AppTask.h
+++ b/examples/onoff-plug-app/silabs/include/AppTask.h
@@ -79,7 +79,7 @@ protected:
     CHIP_ERROR InitPlug();
 
     /**
-     * @brief Chip-thread work item: push the OnOff cluster state via @c OnOffServer::setOnOffValue.
+     * @brief Handler scheduled on the Matter thread to push the OnOff cluster state via @c OnOffServer::setOnOffValue.
      *
      * @param context On/off state encoded as @c intptr_t (0 = off, non-zero = on)
      */

--- a/examples/onoff-plug-app/silabs/include/AppTask.h
+++ b/examples/onoff-plug-app/silabs/include/AppTask.h
@@ -35,7 +35,6 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
-    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -45,7 +44,6 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
-    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**
@@ -56,20 +54,33 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
-    /** @brief Data model hook invoked when a cluster attribute changes */
+    /**
+     * @brief Data model hook invoked when a cluster attribute changes.
+     *
+     * @param attributePath Endpoint, cluster, and attribute that changed
+     * @param type          Ember attribute type of @p value
+     * @param size          Size of @p value in bytes
+     * @param value         Pointer to the new attribute value
+     */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
-    /** @brief AppTask thread event handler that applies an OnOff action */
+    /**
+     * @brief Toggles plug on/off, updates LED/display, and schedules cluster sync on the CHIP thread.
+     *
+     * @param aEvent Button AppEvent posted from @c ButtonEventHandler
+     */
     static void OnOffActionEventHandler(AppEvent * aEvent);
 
 protected:
-    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
-    /** @brief Plug specific initialization */
     CHIP_ERROR InitPlug();
 
-    /** @brief Chip-thread work item: push the OnOff cluster state via `OnOffServer::setOnOffValue` */
+    /**
+     * @brief Chip-thread work item: push the OnOff cluster state via @c OnOffServer::setOnOffValue.
+     *
+     * @param context On/off state encoded as @c intptr_t (0 = off, non-zero = on)
+     */
     static void UpdateOnOffClusterState(intptr_t context);
 };

--- a/examples/onoff-plug-app/silabs/include/AppTask.h
+++ b/examples/onoff-plug-app/silabs/include/AppTask.h
@@ -55,7 +55,7 @@ public:
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
     /**
-     * @brief Matter stack callback after a server attribute write, syncs plug LED and LCD demo UI
+     * @brief Matter stack callback after a server attribute change, syncs plug LED and LCD demo UI
      *        when @c OnOff::OnOff changes.
      *
      * @param attributePath Endpoint, cluster, and attribute that changed
@@ -67,7 +67,7 @@ public:
                                        uint8_t * value);
 
     /**
-     * @brief Toggles plug on/off, updates LED/display, and schedules cluster sync on the CHIP thread.
+     * @brief Toggles plug on/off, updates LED/display, and schedules cluster sync on the Matter thread.
      *
      * @param aEvent Button AppEvent posted from @c ButtonEventHandler
      */

--- a/examples/onoff-plug-app/silabs/include/AppTask.h
+++ b/examples/onoff-plug-app/silabs/include/AppTask.h
@@ -35,6 +35,7 @@ class AppTask : public BaseApplication
 public:
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     /**
@@ -44,6 +45,7 @@ public:
      */
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /**
@@ -54,14 +56,20 @@ public:
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
 
+    /** @brief Data model hook invoked when a cluster attribute changes */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
+    /** @brief AppTask thread event handler that applies an OnOff action */
     static void OnOffActionEventHandler(AppEvent * aEvent);
 
 protected:
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
+
+    /** @brief Plug specific initialization */
     CHIP_ERROR InitPlug();
 
+    /** @brief Chip-thread work item: push the OnOff cluster state via `OnOffServer::setOnOffValue` */
     static void UpdateOnOffClusterState(intptr_t context);
 };

--- a/examples/rangehood-app/silabs/include/AppTask.h
+++ b/examples/rangehood-app/silabs/include/AppTask.h
@@ -42,10 +42,12 @@ public:
 
     AppTask() = default;
 
+    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     static void AppTaskMain(void * pvParameter);
 
+    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /** @brief Platform button callback; posts fan-control or base application events. */
@@ -67,6 +69,9 @@ public:
     static LightEndpoint & GetLightEndpoint();
 
 protected:
+    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
+
+    /** @brief Rangehood specific initialization */
     CHIP_ERROR InitRangeHood();
 };

--- a/examples/rangehood-app/silabs/include/AppTask.h
+++ b/examples/rangehood-app/silabs/include/AppTask.h
@@ -42,12 +42,10 @@ public:
 
     AppTask() = default;
 
-    /** @brief Returns the active app instance */
     static AppTask & GetAppTask();
 
     static void AppTaskMain(void * pvParameter);
 
-    /** @brief Creates and starts the AppTask thread */
     CHIP_ERROR StartAppTask();
 
     /** @brief Platform button callback; posts fan-control or base application events. */
@@ -56,22 +54,29 @@ public:
     /** @brief Applies range-hood actions (light/fan) to LED and display after attribute changes. */
     static void ActionTriggerHandler(AppEvent * aEvent);
 
-    /** @brief Action-button handler; toggles extractor-hood fan mode. */
     static void FanControlButtonHandler(AppEvent * aEvent);
 
-    /** @brief Data-model attribute-change hook; forwards FanControl and OnOff updates. */
+    /**
+     * @brief Data-model attribute-change hook; forwards FanControl and OnOff updates.
+     *
+     * @param attributePath Endpoint, cluster, and attribute that changed
+     * @param type          Ember attribute type of @p value
+     * @param size          Size of @p value in bytes
+     * @param value         Pointer to the new attribute value
+     */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value);
 
-    /** @brief Returns the extractor-hood endpoint (EP1) helper. */
     static ExtractorHoodEndpoint & GetExtractorHoodEndpoint();
-    /** @brief Returns the light endpoint (EP2) helper. */
     static LightEndpoint & GetLightEndpoint();
 
 protected:
-    /** @brief Override of `BaseApplication::AppInit()` */
     CHIP_ERROR AppInit() override;
 
-    /** @brief Rangehood specific initialization */
+    /**
+     * @brief Initializes extractor-hood/light endpoints and syncs the light LED to the OnOff cluster state.
+     *
+     * @return CHIP_NO_ERROR on success, or CHIP_ERROR_INTERNAL if ExtractorHoodEndpoint init fails.
+     */
     CHIP_ERROR InitRangeHood();
 };

--- a/examples/rangehood-app/silabs/include/AppTask.h
+++ b/examples/rangehood-app/silabs/include/AppTask.h
@@ -57,11 +57,12 @@ public:
     static void FanControlButtonHandler(AppEvent * aEvent);
 
     /**
-     * @brief Data-model attribute-change hook; forwards FanControl and OnOff updates.
+     * @brief Matter stack callback after a server attribute write, forwards @c FanControl and @c OnOff
+     *        updates to endpoint handlers to refresh range-hood UI and LEDs.
      *
      * @param attributePath Endpoint, cluster, and attribute that changed
-     * @param type          Ember attribute type of @p value
-     * @param size          Size of @p value in bytes
+     * @param type          TLV encoding type of @p value
+     * @param size          Size in bytes of @p value
      * @param value         Pointer to the new attribute value
      */
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,

--- a/examples/rangehood-app/silabs/include/AppTask.h
+++ b/examples/rangehood-app/silabs/include/AppTask.h
@@ -57,7 +57,7 @@ public:
     static void FanControlButtonHandler(AppEvent * aEvent);
 
     /**
-     * @brief Matter stack callback after a server attribute write, forwards @c FanControl and @c OnOff
+     * @brief Matter stack callback after a server attribute change, forwards @c FanControl and @c OnOff
      *        updates to endpoint handlers to refresh range-hood UI and LEDs.
      *
      * @param attributePath Endpoint, cluster, and attribute that changed


### PR DESCRIPTION
### Summary
Late in cycle point was made to add doxygen style briefs to all AppTask methods in AppTask.h. Some apps/methods have this, but there are some gaps.

Add doxygen style briefs to refactored app APIs where they are missing

This is a cherry-pick PR for SL-ONLY apps in the original PR. Upstream apps will be a part of https://github.com/project-chip/connectedhomeip/pull/72998

### Related issues
MATTER-6655

### Testing
n/a comment only
