### PR TITLE
[SL-ONLY] MATTER-6652: Add docs to AppTaskImpl.h files

### DIFF
--- a/examples/base-platform-app/silabs/include/AppTaskImpl.h
+++ b/examples/base-platform-app/silabs/include/AppTaskImpl.h
@@ -38,16 +38,15 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
-    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
-    // Handle button press
+    // Platform button callback, posts an AppEvent to the AppTask queue for processing.
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
-    // AppTask thread event handler
+    // AppTask thread handler for PB1 button events, triggers application actions on the CHIP task.
     static void ApplicationEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ApplicationEventHandlerImpl, aEvent);
@@ -81,7 +80,6 @@ private:
     void ApplicationEventHandlerImpl(AppEvent * aEvent) { AppTask::ApplicationEventHandler(aEvent); }
 
 #if defined(CHIP_CONFIG_ENABLE_ICD_SERVER) && CHIP_CONFIG_ENABLE_ICD_SERVER
-    // Default ICD power mode hooks: forward to the AppTask::*Default() behavior
     void OnEnterActiveModeImpl() { AppTask::OnEnterActiveModeDefault(); }
 
     void OnEnterIdleModeImpl() { AppTask::OnEnterIdleModeDefault(); }

--- a/examples/base-platform-app/silabs/include/AppTaskImpl.h
+++ b/examples/base-platform-app/silabs/include/AppTaskImpl.h
@@ -46,14 +46,14 @@ public:
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
-    // AppTask thread handler for PB1 button events, triggers application actions on the CHIP task.
+    // AppTask thread handler for PB1 button events, triggers application actions on the Matter task.
     static void ApplicationEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ApplicationEventHandlerImpl, aEvent);
     }
 
 #if defined(CHIP_CONFIG_ENABLE_ICD_SERVER) && CHIP_CONFIG_ENABLE_ICD_SERVER
-    // ICD lifecycle hooks invoked by the ICD manager
+    // ICDStateObserver callbacks invoked by the ICD manager
     // Override to react to power mode transitions
     void OnEnterActiveMode() override
     {

--- a/examples/base-platform-app/silabs/include/AppTaskImpl.h
+++ b/examples/base-platform-app/silabs/include/AppTaskImpl.h
@@ -38,19 +38,24 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
+    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
+    // Handle button press
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
+    // AppTask thread event handler
     static void ApplicationEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ApplicationEventHandlerImpl, aEvent);
     }
 
 #if defined(CHIP_CONFIG_ENABLE_ICD_SERVER) && CHIP_CONFIG_ENABLE_ICD_SERVER
+    // ICD lifecycle hooks invoked by the ICD manager
+    // Override to react to power mode transitions
     void OnEnterActiveMode() override
     {
         CRTP_OPTIONAL_VOID_DISPATCH(AppTaskImpl, Derived, OnEnterActiveModeImpl);
@@ -66,6 +71,9 @@ public:
 private:
     friend Derived;
 
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
+
     CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
 
     void ButtonEventHandlerImpl(uint8_t button, uint8_t btnAction) { AppTask::ButtonEventHandler(button, btnAction); }
@@ -73,6 +81,7 @@ private:
     void ApplicationEventHandlerImpl(AppEvent * aEvent) { AppTask::ApplicationEventHandler(aEvent); }
 
 #if defined(CHIP_CONFIG_ENABLE_ICD_SERVER) && CHIP_CONFIG_ENABLE_ICD_SERVER
+    // Default ICD power mode hooks: forward to the AppTask::*Default() behavior
     void OnEnterActiveModeImpl() { AppTask::OnEnterActiveModeDefault(); }
 
     void OnEnterIdleModeImpl() { AppTask::OnEnterIdleModeDefault(); }

--- a/examples/onoff-plug-app/silabs/include/AppTaskImpl.h
+++ b/examples/onoff-plug-app/silabs/include/AppTaskImpl.h
@@ -39,25 +39,23 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
-    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
-    // Plug specific initialization
     CHIP_ERROR InitPlug() { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, InitPlugImpl); }
 
-    // Handle button press
+    // Platform button callback, posts on/off toggle or base-application button events.
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
-    // AppTask thread event handler that applies an OnOff action
+    // Toggles plug on/off, updates LED/display, and schedules OnOff cluster sync on the CHIP thread.
     static void OnOffActionEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, OnOffActionEventHandlerImpl, aEvent);
     }
 
-    // Data model hook invoked when a cluster attribute changes
+    // Matter stack callback after a server attribute write, syncs plug LED and display on OnOff changes.
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {

--- a/examples/onoff-plug-app/silabs/include/AppTaskImpl.h
+++ b/examples/onoff-plug-app/silabs/include/AppTaskImpl.h
@@ -39,20 +39,25 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
+    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
+    // Plug specific initialization
     CHIP_ERROR InitPlug() { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, InitPlugImpl); }
 
+    // Handle button press
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
+    // AppTask thread event handler that applies an OnOff action
     static void OnOffActionEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, OnOffActionEventHandlerImpl, aEvent);
     }
 
+    // Data model hook invoked when a cluster attribute changes
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {
@@ -62,7 +67,8 @@ public:
 private:
     friend Derived;
 
-    /** Default implementations - override in Derived to customize. **/
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
 
     CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
 

--- a/examples/onoff-plug-app/silabs/include/AppTaskImpl.h
+++ b/examples/onoff-plug-app/silabs/include/AppTaskImpl.h
@@ -49,7 +49,7 @@ public:
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
-    // Toggles plug on/off, updates LED/display, and schedules OnOff cluster sync on the CHIP thread.
+    // Toggles plug on/off, updates LED/display, and schedules OnOff cluster sync on the Matter thread.
     static void OnOffActionEventHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, OnOffActionEventHandlerImpl, aEvent);

--- a/examples/rangehood-app/silabs/include/AppTaskImpl.h
+++ b/examples/rangehood-app/silabs/include/AppTaskImpl.h
@@ -21,29 +21,48 @@
 #include "AppTask.h"
 #include "CRTPHelpers.h"
 
+/**
+ * @brief CRTP override layer for `AppTask`.
+ *
+ * Each public entry point dispatches to a corresponding `Derived::*Impl()` hook.
+ * The default `*Impl()` (declared private below) forwards to `AppTask`, so
+ * `Derived` only needs to override the hooks whose behavior it wants to
+ * customize.
+ *
+ * Customer code overrides these hooks in `CustomerAppTask`; see the app README
+ * ("How to Override APIs").
+ *
+ * @tparam Derived The CRTP derived class (`CustomerAppTask`).
+ */
 template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
+    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
+    // Rangehood specific initialization
     CHIP_ERROR InitRangeHood() { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, InitRangeHoodImpl); }
 
+    // Handle button press
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
+    // AppTask thread event handler for a queued rangehood action event
     static void ActionTriggerHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ActionTriggerHandlerImpl, aEvent);
     }
 
+    // AppTask thread event handler that drives the FanControl cluster from a button press
     static void FanControlButtonHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, FanControlButtonHandlerImpl, aEvent);
     }
 
+    // Data model hook invoked when a cluster attribute changes
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {
@@ -52,6 +71,9 @@ public:
 
 private:
     friend Derived;
+
+    // Default *Impl() hooks, each forwards to the matching AppTask method
+    // Override the corresponding hook in CustomerAppTask to customize behavior
 
     CHIP_ERROR AppInitImpl() { return AppTask::AppInit(); }
 

--- a/examples/rangehood-app/silabs/include/AppTaskImpl.h
+++ b/examples/rangehood-app/silabs/include/AppTaskImpl.h
@@ -60,7 +60,7 @@ public:
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, FanControlButtonHandlerImpl, aEvent);
     }
 
-    // Matter stack callback after a server attribute write, forwards FanControl and OnOff updates.
+    // Matter stack callback after a server attribute change, forwards FanControl and OnOff updates.
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {

--- a/examples/rangehood-app/silabs/include/AppTaskImpl.h
+++ b/examples/rangehood-app/silabs/include/AppTaskImpl.h
@@ -38,31 +38,29 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
-    // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
-    // Rangehood specific initialization
     CHIP_ERROR InitRangeHood() { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, InitRangeHoodImpl); }
 
-    // Handle button press
+    // Platform button callback, posts fan-control or base application events.
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ButtonEventHandlerImpl, button, btnAction);
     }
 
-    // AppTask thread event handler for a queued rangehood action event
+    // Applies light/fan actions to LED and display after attribute driven updates.
     static void ActionTriggerHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, ActionTriggerHandlerImpl, aEvent);
     }
 
-    // AppTask thread event handler that drives the FanControl cluster from a button press
+    // Action button handler, toggles extractor hood fan mode.
     static void FanControlButtonHandler(AppEvent * aEvent)
     {
         CRTP_OPTIONAL_STATIC_DISPATCH(AppTaskImpl, Derived, FanControlButtonHandlerImpl, aEvent);
     }
 
-    // Data model hook invoked when a cluster attribute changes
+    // Matter stack callback after a server attribute write, forwards FanControl and OnOff updates.
     void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
     {


### PR DESCRIPTION
### Summary
In customer documentation in app README files, we point user to AppTaskImpl.h to see declarations of every overridable method. However, these files are lacking proper documentation to explain to users what each method actually does and is responsible for.

For each refactored app, add some descriptions to each method in corresponding AppTaskImpl.h file to give user high level idea of the Silabs implemented methods

This is a cherry-pick PR for SL-ONLY apps in the original PR. Upstream apps will be a part of https://github.com/project-chip/connectedhomeip/pull/72999

### Related issues
MATTER-6652

### Testing
n/a comment only