### PR TITLE
[SL-ONLY] Fan control cascading updates fix

### DIFF
--- a/.github/silabs-apis.yaml
+++ b/.github/silabs-apis.yaml
@@ -126,6 +126,8 @@ apps:
           signature: static void FanUiUpdateEventHandler(AppEvent *aEvent)
         - name: HandleFanModeChange
           signature: void HandleFanModeChange(FanModeEnum aNewFanMode)
+        - name: DeriveFanModeFromPercent
+          signature: FanModeEnum DeriveFanModeFromPercent(Percent percent)
         - name: HandlePercentSettingChange
           signature: void HandlePercentSettingChange(uint8_t aNewPercentSetting)
         - name: HandleSpeedSettingChange

--- a/examples/fan-control-app/silabs/include/AppTask.h
+++ b/examples/fan-control-app/silabs/include/AppTask.h
@@ -103,18 +103,20 @@ public:
     static void FanUiUpdateEventHandler(AppEvent * aEvent);
 
     /**
-     * @brief Reconcile PercentSetting whenever FanMode changes so the new mode lands
-     *        inside its configured speed band. Invoked from DMPostAttributeChangeCallback.
+     * @brief Reconcile PercentSetting or SpeedSetting when FanMode changes, depending on
+     *        MultiSpeed feature support. Invoked from DMPostAttributeChangeCallback when
+     *        MultiSpeed is disabled.
      */
     void HandleFanModeChange(FanModeEnum aNewFanMode);
 
     /**
      * @brief Mirror PercentSetting writes onto PercentCurrent (when not in Auto and not a no-op).
+     *        When MultiSpeed is disabled, also synchronizes FanMode from the percent value.
      */
     void HandlePercentSettingChange(uint8_t aNewPercentSetting);
 
     /**
-     * @brief Mirror SpeedSetting writes onto SpeedCurrent and refresh FanMode from the new speed.
+     * @brief Mirror SpeedSetting writes onto SpeedCurrent when MultiSpeed is enabled.
      */
     void HandleSpeedSettingChange(uint8_t aNewSpeedSetting);
 

--- a/examples/fan-control-app/silabs/include/AppTask.h
+++ b/examples/fan-control-app/silabs/include/AppTask.h
@@ -112,13 +112,13 @@ public:
 
     /**
      * @brief Mirror PercentSetting writes onto PercentCurrent (when not in Auto and not a no-op).
-     *        When MultiSpeed is disabled, also synchronizes FanMode from the percent value.
+     *        FanMode is updated by the cluster on PercentSetting writes; the app does not re-derive it.
      */
     void HandlePercentSettingChange(uint8_t aNewPercentSetting);
 
     /**
      * @brief Derive FanMode from a PercentSetting value using SpeedMax-derived bands.
-     *        Override via DeriveFanModeFromPercentImpl() in CustomerAppTask.
+     *        Optional customer override hook; default handlers rely on cluster FanMode updates.
      */
     FanModeEnum DeriveFanModeFromPercent(Percent percent);
 
@@ -145,13 +145,13 @@ public:
      * @brief Write SpeedSetting synchronously on the Matter thread. No-op when MultiSpeed is
      *        disabled. Exposed for customer code; not overridable.
      */
-    void SetSpeedSetting(uint8_t aNewSpeedSetting);
+    Status SetSpeedSetting(uint8_t aNewSpeedSetting);
 
     /**
      * @brief Schedule a PercentSetting write on the Matter thread. Exposed for customer code;
      *        not overridable.
      */
-    void SetPercentSetting(Percent aNewPercentSetting);
+    Status SetPercentSetting(Percent aNewPercentSetting);
 
     /**
      * @brief PlatformMgr().ScheduleWork() callback that flushes pending FanControl attribute writes

--- a/examples/fan-control-app/silabs/include/AppTask.h
+++ b/examples/fan-control-app/silabs/include/AppTask.h
@@ -128,10 +128,11 @@ public:
     void HandleSpeedSettingChange(uint8_t aNewSpeedSetting);
 
     /**
-     * @brief Returns whether the FanControl cluster advertises the MultiSpeed feature.
-     *        Cached during InitFanControl(). Exposed for customer code; not overridable.
+     * @brief Read MultiSpeed support from the FanControl FeatureMap and refresh the
+     *        sSupportsMultiSpeed cache. Call during InitFanControl() (including custom
+     *        overrides) with the chip stack locked. Exposed for customer code; not overridable.
      */
-    bool SupportsMultiSpeed() const;
+    bool ReadSupportsMultiSpeedFromFeatureMap();
 
     /**
      * @brief Convert a discrete speed step into a percent using SpeedMax.

--- a/examples/fan-control-app/silabs/include/AppTask.h
+++ b/examples/fan-control-app/silabs/include/AppTask.h
@@ -39,6 +39,7 @@ public:
     // Bring frequently-used cluster types into class scope. Available to derived classes
     // (e.g. AppTaskImpl, CustomerAppTask) without re-qualification.
     using FanModeEnum       = chip::app::Clusters::FanControl::FanModeEnum;
+    using Percent           = chip::Percent;
     using StepDirectionEnum = chip::app::Clusters::FanControl::StepDirectionEnum;
     using Status            = chip::Protocols::InteractionModel::Status;
 
@@ -116,9 +117,41 @@ public:
     void HandlePercentSettingChange(uint8_t aNewPercentSetting);
 
     /**
+     * @brief Derive FanMode from a PercentSetting value using SpeedMax-derived bands.
+     *        Override via DeriveFanModeFromPercentImpl() in CustomerAppTask.
+     */
+    FanModeEnum DeriveFanModeFromPercent(Percent percent);
+
+    /**
      * @brief Mirror SpeedSetting writes onto SpeedCurrent when MultiSpeed is enabled.
      */
     void HandleSpeedSettingChange(uint8_t aNewSpeedSetting);
+
+    /**
+     * @brief Returns whether the FanControl cluster advertises the MultiSpeed feature.
+     *        Cached during InitFanControl(). Exposed for customer code; not overridable.
+     */
+    bool SupportsMultiSpeed() const;
+
+    /**
+     * @brief Convert a discrete speed step into a percent using SpeedMax.
+     */
+    static uint8_t SpeedToPercent(uint8_t speed, uint8_t speedMax);
+
+    chip::app::DataModel::Nullable<uint8_t> GetSpeedSetting();
+    chip::app::DataModel::Nullable<Percent> GetPercentSetting();
+
+    /**
+     * @brief Write SpeedSetting synchronously on the Matter thread. No-op when MultiSpeed is
+     *        disabled. Exposed for customer code; not overridable.
+     */
+    void SetSpeedSetting(uint8_t aNewSpeedSetting);
+
+    /**
+     * @brief Schedule a PercentSetting write on the Matter thread. Exposed for customer code;
+     *        not overridable.
+     */
+    void SetPercentSetting(Percent aNewPercentSetting);
 
     /**
      * @brief PlatformMgr().ScheduleWork() callback that flushes pending FanControl attribute writes
@@ -134,4 +167,10 @@ public:
 protected:
     /** Override of `BaseApplication::AppInit()`. */
     CHIP_ERROR AppInit() override;
+
+    /**
+     * @brief Write FanMode when it differs from the data model. Used by default attribute
+     *        handlers; exposed for customer overrides that reuse SDK sync behavior.
+     */
+    void SyncFanMode(FanModeEnum aNewFanMode);
 };

--- a/examples/fan-control-app/silabs/include/AppTaskImpl.h
+++ b/examples/fan-control-app/silabs/include/AppTaskImpl.h
@@ -35,6 +35,8 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
+    using Percent = AppTask::Percent;
+
     // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
@@ -69,6 +71,12 @@ public:
     void HandlePercentSettingChange(uint8_t aNewPercentSetting)
     {
         CRTP_OPTIONAL_VOID_DISPATCH(AppTaskImpl, Derived, HandlePercentSettingChangeImpl, aNewPercentSetting);
+    }
+
+    // Derive FanMode from PercentSetting
+    FanModeEnum DeriveFanModeFromPercent(Percent percent)
+    {
+        CRTP_OPTIONAL_DISPATCH_ARGS(AppTaskImpl, Derived, DeriveFanModeFromPercentImpl, percent);
     }
 
     // Handle SpeedSetting attribute changes
@@ -106,6 +114,8 @@ private:
     {
         AppTask::HandlePercentSettingChange(aNewPercentSetting);
     }
+
+    FanModeEnum DeriveFanModeFromPercentImpl(Percent percent) { return AppTask::DeriveFanModeFromPercent(percent); }
 
     void HandleSpeedSettingChangeImpl(uint8_t aNewSpeedSetting) { AppTask::HandleSpeedSettingChange(aNewSpeedSetting); }
 

--- a/examples/fan-control-app/silabs/src/AppTask.cpp
+++ b/examples/fan-control-app/silabs/src/AppTask.cpp
@@ -166,7 +166,7 @@ CHIP_ERROR AppTask::InitFanControl()
     sSupportsMultiSpeed = ReadSupportsMultiSpeedFromFeatureMap();
     if (Attributes::SpeedMax::Get(kFanEndpoint, &sSpeedMax) != Status::Success || sSpeedMax == 0)
     {
-        sSpeedMax = static_cast<uint8_t>(FAN_MODE_HIGH_LOWER_BOUND);
+        sSpeedMax = static_cast<uint8_t>(FAN_MODE_HIGH_UPPER_BOUND);
     }
     FanModeEnum fanMode = sFanMode;
     Status fanModeStatus = Attributes::FanMode::Get(kFanEndpoint, &fanMode);

--- a/examples/fan-control-app/silabs/src/AppTask.cpp
+++ b/examples/fan-control-app/silabs/src/AppTask.cpp
@@ -87,16 +87,7 @@ uint8_t sPercentCurrent      = 0;
 uint8_t sSpeedCurrent        = 0;
 bool sSupportsMultiSpeed     = false;
 
-uint8_t SpeedToPercent(uint8_t speed, uint8_t speedMax)
-{
-    if (speedMax == 0)
-    {
-        return 0;
-    }
-    return static_cast<uint8_t>((static_cast<uint16_t>(speed) * 100) / speedMax);
-}
-
-bool SupportsMultiSpeed()
+bool ReadSupportsMultiSpeedFromFeatureMap()
 {
     uint32_t featureMap = 0;
     if (Attributes::FeatureMap::Get(kFanEndpoint, &featureMap) != Status::Success)
@@ -104,218 +95,6 @@ bool SupportsMultiSpeed()
         return false;
     }
     return (featureMap & to_underlying(Feature::kMultiSpeed)) != 0;
-}
-
-FanModeEnum DeriveFanModeFromPercent(Percent percent)
-{
-    if (percent == 0)
-    {
-        return FanModeEnum::kOff;
-    }
-    if (percent <= SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax))
-    {
-        return FanModeEnum::kLow;
-    }
-    if (percent <= SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax))
-    {
-        return FanModeEnum::kMedium;
-    }
-    return FanModeEnum::kHigh;
-}
-
-DataModel::Nullable<uint8_t> GetSpeedSetting()
-{
-    DataModel::Nullable<uint8_t> speedSetting;
-
-    Status status = Attributes::SpeedSetting::Get(kFanEndpoint, speedSetting);
-    if (status != Status::Success)
-    {
-        ChipLogError(NotSpecified, "GetSpeedSetting: failed to get SpeedSetting attribute: %d", to_underlying(status));
-    }
-
-    return speedSetting;
-}
-
-DataModel::Nullable<Percent> GetPercentSetting()
-{
-    DataModel::Nullable<Percent> percentSetting;
-
-    Status status = Attributes::PercentSetting::Get(kFanEndpoint, percentSetting);
-    if (status != Status::Success)
-    {
-        ChipLogError(NotSpecified, "GetPercentSetting: failed to get PercentSetting attribute: %d", to_underlying(status));
-    }
-
-    return percentSetting;
-}
-
-void SetPercentSetting(Percent aNewPercentSetting)
-{
-    DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
-    if (!percentSettingNullable.IsNull() && percentSettingNullable.Value() == aNewPercentSetting)
-    {
-        return;
-    }
-
-    AppTask::AttributeUpdateInfo * data = chip::Platform::New<AppTask::AttributeUpdateInfo>();
-    data->percentSetting       = aNewPercentSetting;
-    data->endPoint             = kFanEndpoint;
-    data->isPercentSetting     = true;
-    if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "SetPercentSetting: failed to update PercentSetting attribute");
-    }
-}
-
-void SetSpeedSetting(uint8_t aNewSpeedSetting)
-{
-    VerifyOrReturn(sSupportsMultiSpeed);
-
-    DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
-    if (!speedSettingNullable.IsNull() && speedSettingNullable.Value() == aNewSpeedSetting)
-    {
-        return;
-    }
-
-    Status status = Attributes::SpeedSetting::Set(kFanEndpoint, aNewSpeedSetting);
-    if (status != Status::Success)
-    {
-        ChipLogError(NotSpecified, "SetSpeedSetting: failed to set SpeedSetting attribute: %d", to_underlying(status));
-    }
-}
-
-void SyncFanMode(FanModeEnum aNewFanMode)
-{
-    FanModeEnum currentFanMode;
-    if (Attributes::FanMode::Get(kFanEndpoint, &currentFanMode) == Status::Success && currentFanMode == aNewFanMode)
-    {
-        sFanMode = aNewFanMode;
-        return;
-    }
-
-    sFanMode                   = aNewFanMode;
-    AppTask::AttributeUpdateInfo * data = chip::Platform::New<AppTask::AttributeUpdateInfo>();
-    data->endPoint             = kFanEndpoint;
-    data->fanMode              = sFanMode;
-    data->isFanMode            = true;
-    if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "SyncFanMode: failed to update FanMode attribute");
-    }
-}
-
-void ApplyFanModeMapping(FanModeEnum aNewFanMode)
-{
-    ChipLogDetail(NotSpecified, "ApplyFanModeMapping: %d", to_underlying(aNewFanMode));
-
-    if (sSupportsMultiSpeed)
-    {
-        uint8_t speedSettingCurrent = GetSpeedSetting().ValueOr(101);
-        uint8_t highSpeedSetting =
-            (sSpeedMax >= FAN_MODE_HIGH_LOWER_BOUND) ? static_cast<uint8_t>(FAN_MODE_HIGH_LOWER_BOUND) : sSpeedMax;
-
-        switch (aNewFanMode)
-        {
-        case FanModeEnum::kOff: {
-            if (speedSettingCurrent != 0)
-            {
-                SetSpeedSetting(0);
-            }
-            break;
-        }
-        case FanModeEnum::kLow: {
-            if (speedSettingCurrent < FAN_MODE_LOW_LOWER_BOUND || speedSettingCurrent > FAN_MODE_LOW_UPPER_BOUND)
-            {
-                SetSpeedSetting(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND));
-            }
-            break;
-        }
-        case FanModeEnum::kMedium: {
-            if (speedSettingCurrent < FAN_MODE_MEDIUM_LOWER_BOUND || speedSettingCurrent > FAN_MODE_MEDIUM_UPPER_BOUND)
-            {
-                SetSpeedSetting(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND));
-            }
-            break;
-        }
-        case FanModeEnum::kOn:
-        case FanModeEnum::kHigh: {
-            if (speedSettingCurrent < highSpeedSetting || speedSettingCurrent > sSpeedMax)
-            {
-                SetSpeedSetting(highSpeedSetting);
-            }
-            break;
-        }
-        case FanModeEnum::kSmart:
-        case FanModeEnum::kAuto: {
-            ChipLogProgress(NotSpecified, "ApplyFanModeMapping: Auto");
-            break;
-        }
-        case FanModeEnum::kUnknownEnumValue: {
-            ChipLogProgress(NotSpecified, "ApplyFanModeMapping: Unknown");
-            break;
-        }
-        default:
-            break;
-        }
-    }
-    else
-    {
-        uint8_t percentSettingCurrent = GetPercentSetting().ValueOr(101);
-        const uint8_t lowPercentMin   = 1;
-        const uint8_t lowPercentMax   = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax);
-        const uint8_t mediumPercentMin =
-            SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND), sSpeedMax);
-        const uint8_t mediumPercentMax =
-            SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax);
-        const uint8_t highPercentMin =
-            SpeedToPercent(static_cast<uint8_t>((sSpeedMax >= FAN_MODE_HIGH_LOWER_BOUND) ? FAN_MODE_HIGH_LOWER_BOUND : sSpeedMax),
-                           sSpeedMax);
-        const uint8_t highPercentMax = 100;
-
-        switch (aNewFanMode)
-        {
-        case FanModeEnum::kOff: {
-            if (percentSettingCurrent != 0)
-            {
-                SetPercentSetting(0);
-            }
-            break;
-        }
-        case FanModeEnum::kLow: {
-            if (percentSettingCurrent < lowPercentMin || percentSettingCurrent > lowPercentMax)
-            {
-                SetPercentSetting(SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND), sSpeedMax));
-            }
-            break;
-        }
-        case FanModeEnum::kMedium: {
-            if (percentSettingCurrent < mediumPercentMin || percentSettingCurrent > mediumPercentMax)
-            {
-                SetPercentSetting(mediumPercentMin);
-            }
-            break;
-        }
-        case FanModeEnum::kOn:
-        case FanModeEnum::kHigh: {
-            if (percentSettingCurrent < highPercentMin || percentSettingCurrent > highPercentMax)
-            {
-                SetPercentSetting(highPercentMin);
-            }
-            break;
-        }
-        case FanModeEnum::kSmart:
-        case FanModeEnum::kAuto: {
-            ChipLogProgress(NotSpecified, "ApplyFanModeMapping: Auto");
-            break;
-        }
-        case FanModeEnum::kUnknownEnumValue: {
-            ChipLogProgress(NotSpecified, "ApplyFanModeMapping: Unknown");
-            break;
-        }
-        default:
-            break;
-        }
-    }
 }
 
 void UpdateFanControlLED()
@@ -384,7 +163,7 @@ CHIP_ERROR AppTask::InitFanControl()
     LinkAppLed(&sFanLED);
 
     PlatformMgr().LockChipStack();
-    sSupportsMultiSpeed = SupportsMultiSpeed();
+    sSupportsMultiSpeed = ReadSupportsMultiSpeedFromFeatureMap();
     if (Attributes::SpeedMax::Get(kFanEndpoint, &sSpeedMax) != Status::Success || sSpeedMax == 0)
     {
         sSpeedMax = static_cast<uint8_t>(FAN_MODE_HIGH_LOWER_BOUND);
@@ -407,7 +186,7 @@ CHIP_ERROR AppTask::InitFanControl()
     uint8_t percentSettingCB = percentSettingNullable.IsNull() ? 0 : percentSettingNullable.Value();
     AppInstance().HandlePercentSettingChange(percentSettingCB);
 
-    if (sSupportsMultiSpeed)
+    if (AppInstance().SupportsMultiSpeed())
     {
         uint8_t speedSettingCB = speedSettingNullable.IsNull() ? 0 : speedSettingNullable.Value();
         AppInstance().HandleSpeedSettingChange(speedSettingCB);
@@ -418,9 +197,230 @@ CHIP_ERROR AppTask::InitFanControl()
     return CHIP_NO_ERROR;
 }
 
+bool AppTask::SupportsMultiSpeed() const
+{
+    return sSupportsMultiSpeed;
+}
+
+uint8_t AppTask::SpeedToPercent(uint8_t speed, uint8_t speedMax)
+{
+    if (speedMax == 0)
+    {
+        return 0;
+    }
+    return static_cast<uint8_t>((static_cast<uint16_t>(speed) * 100) / speedMax);
+}
+
+DataModel::Nullable<uint8_t> AppTask::GetSpeedSetting()
+{
+    DataModel::Nullable<uint8_t> speedSetting;
+
+    Status status = Attributes::SpeedSetting::Get(kFanEndpoint, speedSetting);
+    if (status != Status::Success)
+    {
+        ChipLogError(NotSpecified, "GetSpeedSetting: failed to get SpeedSetting attribute: %d", to_underlying(status));
+    }
+
+    return speedSetting;
+}
+
+DataModel::Nullable<Percent> AppTask::GetPercentSetting()
+{
+    DataModel::Nullable<Percent> percentSetting;
+
+    Status status = Attributes::PercentSetting::Get(kFanEndpoint, percentSetting);
+    if (status != Status::Success)
+    {
+        ChipLogError(NotSpecified, "GetPercentSetting: failed to get PercentSetting attribute: %d", to_underlying(status));
+    }
+
+    return percentSetting;
+}
+
+void AppTask::SetPercentSetting(Percent aNewPercentSetting)
+{
+    DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
+    if (!percentSettingNullable.IsNull() && percentSettingNullable.Value() == aNewPercentSetting)
+    {
+        return;
+    }
+
+    AttributeUpdateInfo * data = chip::Platform::New<AttributeUpdateInfo>();
+    data->percentSetting       = aNewPercentSetting;
+    data->endPoint             = kFanEndpoint;
+    data->isPercentSetting     = true;
+    if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "SetPercentSetting: failed to update PercentSetting attribute");
+    }
+}
+
+void AppTask::SetSpeedSetting(uint8_t aNewSpeedSetting)
+{
+    VerifyOrReturn(SupportsMultiSpeed());
+
+    DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
+    if (!speedSettingNullable.IsNull() && speedSettingNullable.Value() == aNewSpeedSetting)
+    {
+        return;
+    }
+
+    Status status = Attributes::SpeedSetting::Set(kFanEndpoint, aNewSpeedSetting);
+    if (status != Status::Success)
+    {
+        ChipLogError(NotSpecified, "SetSpeedSetting: failed to set SpeedSetting attribute: %d", to_underlying(status));
+    }
+}
+
+void AppTask::SyncFanMode(FanModeEnum aNewFanMode)
+{
+    FanModeEnum currentFanMode;
+    if (Attributes::FanMode::Get(kFanEndpoint, &currentFanMode) == Status::Success && currentFanMode == aNewFanMode)
+    {
+        sFanMode = aNewFanMode;
+        return;
+    }
+
+    sFanMode            = aNewFanMode;
+    AttributeUpdateInfo * data = chip::Platform::New<AttributeUpdateInfo>();
+    data->endPoint      = kFanEndpoint;
+    data->fanMode       = sFanMode;
+    data->isFanMode     = true;
+    if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "SyncFanMode: failed to update FanMode attribute");
+    }
+}
+
+FanModeEnum AppTask::DeriveFanModeFromPercent(Percent percent)
+{
+    if (percent == 0)
+    {
+        return FanModeEnum::kOff;
+    }
+    if (percent <= SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax))
+    {
+        return FanModeEnum::kLow;
+    }
+    if (percent <= SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax))
+    {
+        return FanModeEnum::kMedium;
+    }
+    return FanModeEnum::kHigh;
+}
+
 void AppTask::HandleFanModeChange(FanModeEnum aNewFanMode)
 {
-    ApplyFanModeMapping(aNewFanMode);
+    ChipLogDetail(NotSpecified, "HandleFanModeChange: %d", to_underlying(aNewFanMode));
+
+    if (SupportsMultiSpeed())
+    {
+        uint8_t speedSettingCurrent = GetSpeedSetting().ValueOr(101);
+        uint8_t highSpeedSetting =
+            (sSpeedMax >= FAN_MODE_HIGH_LOWER_BOUND) ? static_cast<uint8_t>(FAN_MODE_HIGH_LOWER_BOUND) : sSpeedMax;
+
+        switch (aNewFanMode)
+        {
+        case FanModeEnum::kOff: {
+            if (speedSettingCurrent != 0)
+            {
+                SetSpeedSetting(0);
+            }
+            break;
+        }
+        case FanModeEnum::kLow: {
+            if (speedSettingCurrent < FAN_MODE_LOW_LOWER_BOUND || speedSettingCurrent > FAN_MODE_LOW_UPPER_BOUND)
+            {
+                SetSpeedSetting(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND));
+            }
+            break;
+        }
+        case FanModeEnum::kMedium: {
+            if (speedSettingCurrent < FAN_MODE_MEDIUM_LOWER_BOUND || speedSettingCurrent > FAN_MODE_MEDIUM_UPPER_BOUND)
+            {
+                SetSpeedSetting(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND));
+            }
+            break;
+        }
+        case FanModeEnum::kOn:
+        case FanModeEnum::kHigh: {
+            if (speedSettingCurrent < highSpeedSetting || speedSettingCurrent > sSpeedMax)
+            {
+                SetSpeedSetting(highSpeedSetting);
+            }
+            break;
+        }
+        case FanModeEnum::kSmart:
+        case FanModeEnum::kAuto: {
+            ChipLogProgress(NotSpecified, "HandleFanModeChange: Auto");
+            break;
+        }
+        case FanModeEnum::kUnknownEnumValue: {
+            ChipLogProgress(NotSpecified, "HandleFanModeChange: Unknown");
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    else
+    {
+        uint8_t percentSettingCurrent = GetPercentSetting().ValueOr(101);
+        const uint8_t lowPercentMin   = 1;
+        const uint8_t lowPercentMax   = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax);
+        const uint8_t mediumPercentMin =
+            SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND), sSpeedMax);
+        const uint8_t mediumPercentMax =
+            SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax);
+        const uint8_t highPercentMin =
+            SpeedToPercent(static_cast<uint8_t>((sSpeedMax >= FAN_MODE_HIGH_LOWER_BOUND) ? FAN_MODE_HIGH_LOWER_BOUND : sSpeedMax),
+                           sSpeedMax);
+        const uint8_t highPercentMax = 100;
+
+        switch (aNewFanMode)
+        {
+        case FanModeEnum::kOff: {
+            if (percentSettingCurrent != 0)
+            {
+                SetPercentSetting(0);
+            }
+            break;
+        }
+        case FanModeEnum::kLow: {
+            if (percentSettingCurrent < lowPercentMin || percentSettingCurrent > lowPercentMax)
+            {
+                SetPercentSetting(SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND), sSpeedMax));
+            }
+            break;
+        }
+        case FanModeEnum::kMedium: {
+            if (percentSettingCurrent < mediumPercentMin || percentSettingCurrent > mediumPercentMax)
+            {
+                SetPercentSetting(mediumPercentMin);
+            }
+            break;
+        }
+        case FanModeEnum::kOn:
+        case FanModeEnum::kHigh: {
+            if (percentSettingCurrent < highPercentMin || percentSettingCurrent > highPercentMax)
+            {
+                SetPercentSetting(highPercentMin);
+            }
+            break;
+        }
+        case FanModeEnum::kSmart:
+        case FanModeEnum::kAuto: {
+            ChipLogProgress(NotSpecified, "HandleFanModeChange: Auto");
+            break;
+        }
+        case FanModeEnum::kUnknownEnumValue: {
+            ChipLogProgress(NotSpecified, "HandleFanModeChange: Unknown");
+            break;
+        }
+        default:
+            break;
+        }
+    }
 }
 
 void AppTask::HandlePercentSettingChange(uint8_t aNewPercentSetting)
@@ -440,9 +440,9 @@ void AppTask::HandlePercentSettingChange(uint8_t aNewPercentSetting)
         ChipLogError(NotSpecified, "HandlePercentSettingChange: failed to set PercentCurrent attribute");
     }
 
-    if (!sSupportsMultiSpeed)
+    if (!SupportsMultiSpeed())
     {
-        FanModeEnum newFanMode = DeriveFanModeFromPercent(aNewPercentSetting);
+        FanModeEnum newFanMode = AppInstance().DeriveFanModeFromPercent(aNewPercentSetting);
         if (newFanMode != sFanMode)
         {
             SyncFanMode(newFanMode);
@@ -452,7 +452,7 @@ void AppTask::HandlePercentSettingChange(uint8_t aNewPercentSetting)
 
 void AppTask::HandleSpeedSettingChange(uint8_t aNewSpeedSetting)
 {
-    VerifyOrReturn(sSupportsMultiSpeed);
+    VerifyOrReturn(SupportsMultiSpeed());
     VerifyOrReturn(aNewSpeedSetting != sSpeedCurrent);
     VerifyOrReturn(sFanMode != FanModeEnum::kAuto);
     ChipLogDetail(NotSpecified, "HandleSpeedSettingChange: %d", aNewSpeedSetting);
@@ -512,7 +512,7 @@ Status AppTask::HandleStep(StepDirectionEnum aDirection, bool aWrap, bool aLowes
 
     uint8_t speedMin = aLowestOff ? kaLowestOffTrue : kaLowestOffFalse;
 
-    if (sSupportsMultiSpeed)
+    if (SupportsMultiSpeed())
     {
         DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
         uint8_t curSpeedSetting                         = speedSettingNullable.IsNull() ? speedMin : speedSettingNullable.Value();
@@ -642,7 +642,7 @@ void AppTask::DMPostAttributeChangeCallback(const ConcreteAttributePath & attrib
         break;
     }
     case Attributes::SpeedSetting::Id: {
-        if (sSupportsMultiSpeed)
+        if (AppInstance().SupportsMultiSpeed())
         {
             AppInstance().HandleSpeedSettingChange(*value);
         }
@@ -651,7 +651,7 @@ void AppTask::DMPostAttributeChangeCallback(const ConcreteAttributePath & attrib
     case Attributes::FanMode::Id: {
         sFanMode = *reinterpret_cast<FanModeEnum *>(value);
         // MultiSpeed: cluster keeps FanMode / PercentSetting / SpeedSetting consistent.
-        if (!sSupportsMultiSpeed)
+        if (!AppInstance().SupportsMultiSpeed())
         {
             AppInstance().HandleFanModeChange(sFanMode);
         }

--- a/examples/fan-control-app/silabs/src/AppTask.cpp
+++ b/examples/fan-control-app/silabs/src/AppTask.cpp
@@ -154,7 +154,7 @@ CHIP_ERROR AppTask::InitFanControl()
 
     PlatformMgr().LockChipStack();
     ReadSupportsMultiSpeedFromFeatureMap();
-    if (Attributes::SpeedMax::Get(kFanEndpoint, &sSpeedMax) != Status::Success || sSpeedMax == 0)
+    if (Attributes::SpeedMax::Get(kFanEndpoint, &sSpeedMax) != Status::Success)
     {
         sSpeedMax = static_cast<uint8_t>(FAN_MODE_HIGH_UPPER_BOUND);
     }
@@ -182,8 +182,7 @@ CHIP_ERROR AppTask::InitFanControl()
         // boot-time FanMode writes may not loop back through the DM callback.
         AppInstance().HandleFanModeChange(sFanMode);
     }
-
-    if (sSupportsMultiSpeed)
+    else
     {
         uint8_t speedSettingCB = speedSettingNullable.IsNull() ? 0 : speedSettingNullable.Value();
         AppInstance().HandleSpeedSettingChange(speedSettingCB);
@@ -209,10 +208,7 @@ bool AppTask::ReadSupportsMultiSpeedFromFeatureMap()
 
 uint8_t AppTask::SpeedToPercent(uint8_t speed, uint8_t speedMax)
 {
-    if (speedMax == 0)
-    {
-        return 0;
-    }
+    VerifyOrReturnValue(speedMax != 0, 0);
     return static_cast<uint8_t>((static_cast<uint16_t>(speed) * 100) / speedMax);
 }
 
@@ -221,11 +217,7 @@ DataModel::Nullable<uint8_t> AppTask::GetSpeedSetting()
     DataModel::Nullable<uint8_t> speedSetting;
 
     Status status = Attributes::SpeedSetting::Get(kFanEndpoint, speedSetting);
-    if (status != Status::Success)
-    {
-        ChipLogError(NotSpecified, "GetSpeedSetting: failed to get SpeedSetting attribute: %d", to_underlying(status));
-    }
-
+    VerifyOrReturnValue(status == Status::Success, speedSetting);
     return speedSetting;
 }
 
@@ -234,10 +226,7 @@ DataModel::Nullable<Percent> AppTask::GetPercentSetting()
     DataModel::Nullable<Percent> percentSetting;
 
     Status status = Attributes::PercentSetting::Get(kFanEndpoint, percentSetting);
-    if (status != Status::Success)
-    {
-        ChipLogError(NotSpecified, "GetPercentSetting: failed to get PercentSetting attribute: %d", to_underlying(status));
-    }
+    VerifyOrReturnValue(status == Status::Success, percentSetting, ChipLogError(NotSpecified, "GetPercentSetting: failed to get PercentSetting attribute: %d", to_underlying(status)));
 
     return percentSetting;
 }
@@ -245,10 +234,7 @@ DataModel::Nullable<Percent> AppTask::GetPercentSetting()
 Status AppTask::SetPercentSetting(Percent aNewPercentSetting)
 {
     DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
-    if (!percentSettingNullable.IsNull() && percentSettingNullable.Value() == aNewPercentSetting)
-    {
-        return Status::Success;
-    }
+    VerifyOrReturnValue(!percentSettingNullable.IsNull() && percentSettingNullable.Value() == aNewPercentSetting, Status::Success);
 
     AttributeUpdateInfo * data = chip::Platform::New<AttributeUpdateInfo>();
     data->percentSetting       = aNewPercentSetting;
@@ -266,22 +252,13 @@ Status AppTask::SetPercentSetting(Percent aNewPercentSetting)
 
 Status AppTask::SetSpeedSetting(uint8_t aNewSpeedSetting)
 {
-    if (!sSupportsMultiSpeed)
-    {
-        return Status::Success;
-    }
+    VerifyOrReturnValue(sSupportsMultiSpeed, Status::Success);
 
     DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
-    if (!speedSettingNullable.IsNull() && speedSettingNullable.Value() == aNewSpeedSetting)
-    {
-        return Status::Success;
-    }
+    VerifyOrReturnValue(!speedSettingNullable.IsNull() && speedSettingNullable.Value() == aNewSpeedSetting, Status::Success);
 
     Status status = Attributes::SpeedSetting::Set(kFanEndpoint, aNewSpeedSetting);
-    if (status != Status::Success)
-    {
-        ChipLogError(NotSpecified, "SetSpeedSetting: failed to set SpeedSetting attribute: %d", to_underlying(status));
-    }
+    VerifyOrReturnValue(status == Status::Success, status, ChipLogError(NotSpecified, "SetSpeedSetting: failed to set SpeedSetting attribute: %d", to_underlying(status)));
 
     return status;
 }
@@ -311,18 +288,14 @@ void AppTask::SyncFanMode(FanModeEnum aNewFanMode)
 
 FanModeEnum AppTask::DeriveFanModeFromPercent(Percent percent)
 {
-    if (percent == 0)
-    {
-        return FanModeEnum::kOff;
-    }
-    if (percent <= SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax))
-    {
-        return FanModeEnum::kLow;
-    }
-    if (percent <= SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax))
-    {
-        return FanModeEnum::kMedium;
-    }
+    VerifyOrReturnValue(percent != 0, FanModeEnum::kOff);
+
+    const uint8_t lowPercentMax = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax);
+    VerifyOrReturnValue(percent > lowPercentMax, FanModeEnum::kLow);
+
+    const uint8_t mediumPercentMax = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax);
+    VerifyOrReturnValue(percent > mediumPercentMax, FanModeEnum::kMedium);
+
     return FanModeEnum::kHigh;
 }
 

--- a/examples/fan-control-app/silabs/src/AppTask.cpp
+++ b/examples/fan-control-app/silabs/src/AppTask.cpp
@@ -87,16 +87,6 @@ uint8_t sPercentCurrent      = 0;
 uint8_t sSpeedCurrent        = 0;
 bool sSupportsMultiSpeed     = false;
 
-bool ReadSupportsMultiSpeedFromFeatureMap()
-{
-    uint32_t featureMap = 0;
-    if (Attributes::FeatureMap::Get(kFanEndpoint, &featureMap) != Status::Success)
-    {
-        return false;
-    }
-    return (featureMap & to_underlying(Feature::kMultiSpeed)) != 0;
-}
-
 void UpdateFanControlLED()
 {
     sFanLED.Set(false);
@@ -163,7 +153,7 @@ CHIP_ERROR AppTask::InitFanControl()
     LinkAppLed(&sFanLED);
 
     PlatformMgr().LockChipStack();
-    sSupportsMultiSpeed = ReadSupportsMultiSpeedFromFeatureMap();
+    ReadSupportsMultiSpeedFromFeatureMap();
     if (Attributes::SpeedMax::Get(kFanEndpoint, &sSpeedMax) != Status::Success || sSpeedMax == 0)
     {
         sSpeedMax = static_cast<uint8_t>(FAN_MODE_HIGH_UPPER_BOUND);
@@ -186,19 +176,29 @@ CHIP_ERROR AppTask::InitFanControl()
     uint8_t percentSettingCB = percentSettingNullable.IsNull() ? 0 : percentSettingNullable.Value();
     AppInstance().HandlePercentSettingChange(percentSettingCB);
 
-    if (AppInstance().SupportsMultiSpeed())
+    if (sSupportsMultiSpeed)
     {
         uint8_t speedSettingCB = speedSettingNullable.IsNull() ? 0 : speedSettingNullable.Value();
         AppInstance().HandleSpeedSettingChange(speedSettingCB);
     }
-
+    // Startup runs before BaseApplication marks the app initialized, so
+    // boot-time FanMode writes may not loop back through the DM callback.
+    AppInstance().HandleFanModeChange(sFanMode);
     PostFanUiUpdateEvent();
 
     return CHIP_NO_ERROR;
 }
 
-bool AppTask::SupportsMultiSpeed() const
+bool AppTask::ReadSupportsMultiSpeedFromFeatureMap()
 {
+    uint32_t featureMap = 0;
+    if (Attributes::FeatureMap::Get(kFanEndpoint, &featureMap) != Status::Success)
+    {
+        sSupportsMultiSpeed = false;
+        return false;
+    }
+
+    sSupportsMultiSpeed = (featureMap & to_underlying(Feature::kMultiSpeed)) != 0;
     return sSupportsMultiSpeed;
 }
 
@@ -261,7 +261,7 @@ Status AppTask::SetPercentSetting(Percent aNewPercentSetting)
 
 Status AppTask::SetSpeedSetting(uint8_t aNewSpeedSetting)
 {
-    if (!SupportsMultiSpeed())
+    if (!sSupportsMultiSpeed)
     {
         return Status::Success;
     }
@@ -290,15 +290,18 @@ void AppTask::SyncFanMode(FanModeEnum aNewFanMode)
         return;
     }
 
-    sFanMode            = aNewFanMode;
     AttributeUpdateInfo * data = chip::Platform::New<AttributeUpdateInfo>();
     data->endPoint      = kFanEndpoint;
-    data->fanMode       = sFanMode;
+    data->fanMode       = aNewFanMode;
     data->isFanMode     = true;
     if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "SyncFanMode: failed to update FanMode attribute");
+        chip::Platform::Delete(data);
+        return;
     }
+
+    sFanMode = aNewFanMode;
 }
 
 FanModeEnum AppTask::DeriveFanModeFromPercent(Percent percent)
@@ -322,7 +325,7 @@ void AppTask::HandleFanModeChange(FanModeEnum aNewFanMode)
 {
     ChipLogDetail(NotSpecified, "HandleFanModeChange: %d", to_underlying(aNewFanMode));
 
-    if (SupportsMultiSpeed())
+    if (sSupportsMultiSpeed)
     {
         uint8_t speedSettingCurrent = GetSpeedSetting().ValueOr(101);
         uint8_t highSpeedSetting =
@@ -455,7 +458,7 @@ void AppTask::HandlePercentSettingChange(uint8_t aNewPercentSetting)
 
 void AppTask::HandleSpeedSettingChange(uint8_t aNewSpeedSetting)
 {
-    VerifyOrReturn(SupportsMultiSpeed());
+    VerifyOrReturn(sSupportsMultiSpeed);
     VerifyOrReturn(aNewSpeedSetting != sSpeedCurrent);
     VerifyOrReturn(sFanMode != FanModeEnum::kAuto);
     ChipLogDetail(NotSpecified, "HandleSpeedSettingChange: %d", aNewSpeedSetting);
@@ -518,7 +521,7 @@ Status AppTask::HandleStep(StepDirectionEnum aDirection, bool aWrap, bool aLowes
 
     uint8_t speedMin = aLowestOff ? kaLowestOffTrue : kaLowestOffFalse;
 
-    if (SupportsMultiSpeed())
+    if (sSupportsMultiSpeed)
     {
         DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
         uint8_t curSpeedSetting                         = speedSettingNullable.IsNull() ? speedMin : speedSettingNullable.Value();
@@ -644,7 +647,7 @@ void AppTask::DMPostAttributeChangeCallback(const ConcreteAttributePath & attrib
         break;
     }
     case Attributes::SpeedSetting::Id: {
-        if (AppInstance().SupportsMultiSpeed())
+        if (sSupportsMultiSpeed)
         {
             AppInstance().HandleSpeedSettingChange(*value);
         }
@@ -653,7 +656,7 @@ void AppTask::DMPostAttributeChangeCallback(const ConcreteAttributePath & attrib
     case Attributes::FanMode::Id: {
         sFanMode = *reinterpret_cast<FanModeEnum *>(value);
         // MultiSpeed: cluster keeps FanMode / PercentSetting / SpeedSetting consistent.
-        if (!AppInstance().SupportsMultiSpeed())
+        if (!sSupportsMultiSpeed)
         {
             AppInstance().HandleFanModeChange(sFanMode);
         }

--- a/examples/fan-control-app/silabs/src/AppTask.cpp
+++ b/examples/fan-control-app/silabs/src/AppTask.cpp
@@ -237,12 +237,12 @@ DataModel::Nullable<Percent> AppTask::GetPercentSetting()
     return percentSetting;
 }
 
-void AppTask::SetPercentSetting(Percent aNewPercentSetting)
+Status AppTask::SetPercentSetting(Percent aNewPercentSetting)
 {
     DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
     if (!percentSettingNullable.IsNull() && percentSettingNullable.Value() == aNewPercentSetting)
     {
-        return;
+        return Status::Success;
     }
 
     AttributeUpdateInfo * data = chip::Platform::New<AttributeUpdateInfo>();
@@ -252,17 +252,24 @@ void AppTask::SetPercentSetting(Percent aNewPercentSetting)
     if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "SetPercentSetting: failed to update PercentSetting attribute");
+        chip::Platform::Delete(data);
+        return Status::Failure;
     }
+
+    return Status::Success;
 }
 
-void AppTask::SetSpeedSetting(uint8_t aNewSpeedSetting)
+Status AppTask::SetSpeedSetting(uint8_t aNewSpeedSetting)
 {
-    VerifyOrReturn(SupportsMultiSpeed());
+    if (!SupportsMultiSpeed())
+    {
+        return Status::Success;
+    }
 
     DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
     if (!speedSettingNullable.IsNull() && speedSettingNullable.Value() == aNewSpeedSetting)
     {
-        return;
+        return Status::Success;
     }
 
     Status status = Attributes::SpeedSetting::Set(kFanEndpoint, aNewSpeedSetting);
@@ -270,6 +277,8 @@ void AppTask::SetSpeedSetting(uint8_t aNewSpeedSetting)
     {
         ChipLogError(NotSpecified, "SetSpeedSetting: failed to set SpeedSetting attribute: %d", to_underlying(status));
     }
+
+    return status;
 }
 
 void AppTask::SyncFanMode(FanModeEnum aNewFanMode)
@@ -428,26 +437,20 @@ void AppTask::HandlePercentSettingChange(uint8_t aNewPercentSetting)
     VerifyOrReturn(aNewPercentSetting != sPercentCurrent);
     VerifyOrReturn(sFanMode != FanModeEnum::kAuto);
     ChipLogDetail(NotSpecified, "HandlePercentSettingChange: %d", aNewPercentSetting);
-    sPercentCurrent = aNewPercentSetting;
 
     AppTask::AttributeUpdateInfo * data = chip::Platform::New<AppTask::AttributeUpdateInfo>();
     data->endPoint             = kFanEndpoint;
-    data->percentCurrent       = sPercentCurrent;
+    data->percentCurrent       = aNewPercentSetting;
     data->isPercentCurrent     = true;
 
     if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "HandlePercentSettingChange: failed to set PercentCurrent attribute");
+        chip::Platform::Delete(data);
+        return;
     }
 
-    if (!SupportsMultiSpeed())
-    {
-        FanModeEnum newFanMode = AppInstance().DeriveFanModeFromPercent(aNewPercentSetting);
-        if (newFanMode != sFanMode)
-        {
-            SyncFanMode(newFanMode);
-        }
-    }
+    sPercentCurrent = aNewPercentSetting;
 }
 
 void AppTask::HandleSpeedSettingChange(uint8_t aNewSpeedSetting)
@@ -456,17 +459,20 @@ void AppTask::HandleSpeedSettingChange(uint8_t aNewSpeedSetting)
     VerifyOrReturn(aNewSpeedSetting != sSpeedCurrent);
     VerifyOrReturn(sFanMode != FanModeEnum::kAuto);
     ChipLogDetail(NotSpecified, "HandleSpeedSettingChange: %d", aNewSpeedSetting);
-    sSpeedCurrent = aNewSpeedSetting;
 
     AppTask::AttributeUpdateInfo * data = chip::Platform::New<AppTask::AttributeUpdateInfo>();
     data->endPoint             = kFanEndpoint;
-    data->speedCurrent         = sSpeedCurrent;
+    data->speedCurrent         = aNewSpeedSetting;
     data->isSpeedCurrent       = true;
 
     if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "HandleSpeedSettingChange: failed to set SpeedCurrent attribute");
+        chip::Platform::Delete(data);
+        return;
     }
+
+    sSpeedCurrent = aNewSpeedSetting;
 }
 
 CHIP_ERROR AppTask::StartAppTask()
@@ -546,46 +552,42 @@ Status AppTask::HandleStep(StepDirectionEnum aDirection, bool aWrap, bool aLowes
         }
         }
 
-        SetSpeedSetting(curSpeedSetting);
+        return SetSpeedSetting(curSpeedSetting);
     }
-    else
+
+    DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
+    Percent curPercentSetting = percentSettingNullable.IsNull() ? static_cast<Percent>(speedMin) : percentSettingNullable.Value();
+
+    switch (aDirection)
     {
-        DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
-        Percent curPercentSetting = percentSettingNullable.IsNull() ? static_cast<Percent>(speedMin) : percentSettingNullable.Value();
-
-        switch (aDirection)
+    case StepDirectionEnum::kIncrease: {
+        if (curPercentSetting >= 100)
         {
-        case StepDirectionEnum::kIncrease: {
-            if (curPercentSetting >= 100)
-            {
-                curPercentSetting = aWrap ? static_cast<Percent>(speedMin) : 100;
-            }
-            else
-            {
-                curPercentSetting++;
-            }
-            break;
+            curPercentSetting = aWrap ? static_cast<Percent>(speedMin) : 100;
         }
-        case StepDirectionEnum::kDecrease: {
-            if (curPercentSetting <= speedMin)
-            {
-                curPercentSetting = aWrap ? 100 : static_cast<Percent>(speedMin);
-            }
-            else
-            {
-                curPercentSetting--;
-            }
-            break;
+        else
+        {
+            curPercentSetting++;
         }
-        default: {
-            break;
+        break;
+    }
+    case StepDirectionEnum::kDecrease: {
+        if (curPercentSetting <= speedMin)
+        {
+            curPercentSetting = aWrap ? 100 : static_cast<Percent>(speedMin);
         }
+        else
+        {
+            curPercentSetting--;
         }
-
-        SetPercentSetting(curPercentSetting);
+        break;
+    }
+    default: {
+        break;
+    }
     }
 
-    return Status::Success;
+    return SetPercentSetting(curPercentSetting);
 }
 
 void AppTask::UpdateClusterState(intptr_t arg)

--- a/examples/fan-control-app/silabs/src/AppTask.cpp
+++ b/examples/fan-control-app/silabs/src/AppTask.cpp
@@ -176,14 +176,19 @@ CHIP_ERROR AppTask::InitFanControl()
     uint8_t percentSettingCB = percentSettingNullable.IsNull() ? 0 : percentSettingNullable.Value();
     AppInstance().HandlePercentSettingChange(percentSettingCB);
 
+    if (!sSupportsMultiSpeed)
+    {
+        // Startup runs before BaseApplication marks the app initialized, so
+        // boot-time FanMode writes may not loop back through the DM callback.
+        AppInstance().HandleFanModeChange(sFanMode);
+    }
+
     if (sSupportsMultiSpeed)
     {
         uint8_t speedSettingCB = speedSettingNullable.IsNull() ? 0 : speedSettingNullable.Value();
         AppInstance().HandleSpeedSettingChange(speedSettingCB);
     }
-    // Startup runs before BaseApplication marks the app initialized, so
-    // boot-time FanMode writes may not loop back through the DM callback.
-    AppInstance().HandleFanModeChange(sFanMode);
+
     PostFanUiUpdateEvent();
 
     return CHIP_NO_ERROR;

--- a/examples/fan-control-app/silabs/src/AppTask.cpp
+++ b/examples/fan-control-app/silabs/src/AppTask.cpp
@@ -81,10 +81,11 @@ constexpr int kaLowestOffFalse = 1;
 
 LEDWidget sFanLED;
 
-FanModeEnum sFanMode      = FanModeEnum::kOff;
-uint8_t sSpeedMax         = 0;
-uint8_t sPercentCurrent   = 0;
-uint8_t sSpeedCurrent     = 0;
+FanModeEnum sFanMode         = FanModeEnum::kOff;
+uint8_t sSpeedMax            = 0;
+uint8_t sPercentCurrent      = 0;
+uint8_t sSpeedCurrent        = 0;
+bool sSupportsMultiSpeed     = false;
 
 uint8_t SpeedToPercent(uint8_t speed, uint8_t speedMax)
 {
@@ -93,6 +94,33 @@ uint8_t SpeedToPercent(uint8_t speed, uint8_t speedMax)
         return 0;
     }
     return static_cast<uint8_t>((static_cast<uint16_t>(speed) * 100) / speedMax);
+}
+
+bool SupportsMultiSpeed()
+{
+    uint32_t featureMap = 0;
+    if (Attributes::FeatureMap::Get(kFanEndpoint, &featureMap) != Status::Success)
+    {
+        return false;
+    }
+    return (featureMap & to_underlying(Feature::kMultiSpeed)) != 0;
+}
+
+FanModeEnum DeriveFanModeFromPercent(Percent percent)
+{
+    if (percent == 0)
+    {
+        return FanModeEnum::kOff;
+    }
+    if (percent <= SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax))
+    {
+        return FanModeEnum::kLow;
+    }
+    if (percent <= SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax))
+    {
+        return FanModeEnum::kMedium;
+    }
+    return FanModeEnum::kHigh;
 }
 
 DataModel::Nullable<uint8_t> GetSpeedSetting()
@@ -139,15 +167,154 @@ void SetPercentSetting(Percent aNewPercentSetting)
     }
 }
 
-void UpdateFanMode()
+void SetSpeedSetting(uint8_t aNewSpeedSetting)
 {
+    VerifyOrReturn(sSupportsMultiSpeed);
+
+    DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
+    if (!speedSettingNullable.IsNull() && speedSettingNullable.Value() == aNewSpeedSetting)
+    {
+        return;
+    }
+
+    Status status = Attributes::SpeedSetting::Set(kFanEndpoint, aNewSpeedSetting);
+    if (status != Status::Success)
+    {
+        ChipLogError(NotSpecified, "SetSpeedSetting: failed to set SpeedSetting attribute: %d", to_underlying(status));
+    }
+}
+
+void SyncFanMode(FanModeEnum aNewFanMode)
+{
+    FanModeEnum currentFanMode;
+    if (Attributes::FanMode::Get(kFanEndpoint, &currentFanMode) == Status::Success && currentFanMode == aNewFanMode)
+    {
+        sFanMode = aNewFanMode;
+        return;
+    }
+
+    sFanMode                   = aNewFanMode;
     AppTask::AttributeUpdateInfo * data = chip::Platform::New<AppTask::AttributeUpdateInfo>();
     data->endPoint             = kFanEndpoint;
     data->fanMode              = sFanMode;
     data->isFanMode            = true;
     if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
     {
-        ChipLogError(NotSpecified, "UpdateFanMode: failed to update FanMode attribute");
+        ChipLogError(NotSpecified, "SyncFanMode: failed to update FanMode attribute");
+    }
+}
+
+void ApplyFanModeMapping(FanModeEnum aNewFanMode)
+{
+    ChipLogDetail(NotSpecified, "ApplyFanModeMapping: %d", to_underlying(aNewFanMode));
+
+    if (sSupportsMultiSpeed)
+    {
+        uint8_t speedSettingCurrent = GetSpeedSetting().ValueOr(101);
+        uint8_t highSpeedSetting =
+            (sSpeedMax >= FAN_MODE_HIGH_LOWER_BOUND) ? static_cast<uint8_t>(FAN_MODE_HIGH_LOWER_BOUND) : sSpeedMax;
+
+        switch (aNewFanMode)
+        {
+        case FanModeEnum::kOff: {
+            if (speedSettingCurrent != 0)
+            {
+                SetSpeedSetting(0);
+            }
+            break;
+        }
+        case FanModeEnum::kLow: {
+            if (speedSettingCurrent < FAN_MODE_LOW_LOWER_BOUND || speedSettingCurrent > FAN_MODE_LOW_UPPER_BOUND)
+            {
+                SetSpeedSetting(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND));
+            }
+            break;
+        }
+        case FanModeEnum::kMedium: {
+            if (speedSettingCurrent < FAN_MODE_MEDIUM_LOWER_BOUND || speedSettingCurrent > FAN_MODE_MEDIUM_UPPER_BOUND)
+            {
+                SetSpeedSetting(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND));
+            }
+            break;
+        }
+        case FanModeEnum::kOn:
+        case FanModeEnum::kHigh: {
+            if (speedSettingCurrent < highSpeedSetting || speedSettingCurrent > sSpeedMax)
+            {
+                SetSpeedSetting(highSpeedSetting);
+            }
+            break;
+        }
+        case FanModeEnum::kSmart:
+        case FanModeEnum::kAuto: {
+            ChipLogProgress(NotSpecified, "ApplyFanModeMapping: Auto");
+            break;
+        }
+        case FanModeEnum::kUnknownEnumValue: {
+            ChipLogProgress(NotSpecified, "ApplyFanModeMapping: Unknown");
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    else
+    {
+        uint8_t percentSettingCurrent = GetPercentSetting().ValueOr(101);
+        const uint8_t lowPercentMin   = 1;
+        const uint8_t lowPercentMax   = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax);
+        const uint8_t mediumPercentMin =
+            SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND), sSpeedMax);
+        const uint8_t mediumPercentMax =
+            SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax);
+        const uint8_t highPercentMin =
+            SpeedToPercent(static_cast<uint8_t>((sSpeedMax >= FAN_MODE_HIGH_LOWER_BOUND) ? FAN_MODE_HIGH_LOWER_BOUND : sSpeedMax),
+                           sSpeedMax);
+        const uint8_t highPercentMax = 100;
+
+        switch (aNewFanMode)
+        {
+        case FanModeEnum::kOff: {
+            if (percentSettingCurrent != 0)
+            {
+                SetPercentSetting(0);
+            }
+            break;
+        }
+        case FanModeEnum::kLow: {
+            if (percentSettingCurrent < lowPercentMin || percentSettingCurrent > lowPercentMax)
+            {
+                SetPercentSetting(SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND), sSpeedMax));
+            }
+            break;
+        }
+        case FanModeEnum::kMedium: {
+            if (percentSettingCurrent < mediumPercentMin || percentSettingCurrent > mediumPercentMax)
+            {
+                SetPercentSetting(mediumPercentMin);
+            }
+            break;
+        }
+        case FanModeEnum::kOn:
+        case FanModeEnum::kHigh: {
+            if (percentSettingCurrent < highPercentMin || percentSettingCurrent > highPercentMax)
+            {
+                SetPercentSetting(highPercentMin);
+            }
+            break;
+        }
+        case FanModeEnum::kSmart:
+        case FanModeEnum::kAuto: {
+            ChipLogProgress(NotSpecified, "ApplyFanModeMapping: Auto");
+            break;
+        }
+        case FanModeEnum::kUnknownEnumValue: {
+            ChipLogProgress(NotSpecified, "ApplyFanModeMapping: Unknown");
+            break;
+        }
+        default:
+            break;
+        }
     }
 }
 
@@ -217,7 +384,11 @@ CHIP_ERROR AppTask::InitFanControl()
     LinkAppLed(&sFanLED);
 
     PlatformMgr().LockChipStack();
-    Attributes::SpeedMax::Get(kFanEndpoint, &sSpeedMax);
+    sSupportsMultiSpeed = SupportsMultiSpeed();
+    if (Attributes::SpeedMax::Get(kFanEndpoint, &sSpeedMax) != Status::Success || sSpeedMax == 0)
+    {
+        sSpeedMax = static_cast<uint8_t>(FAN_MODE_HIGH_LOWER_BOUND);
+    }
     FanModeEnum fanMode = sFanMode;
     Status fanModeStatus = Attributes::FanMode::Get(kFanEndpoint, &fanMode);
     DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
@@ -236,12 +407,12 @@ CHIP_ERROR AppTask::InitFanControl()
     uint8_t percentSettingCB = percentSettingNullable.IsNull() ? 0 : percentSettingNullable.Value();
     AppInstance().HandlePercentSettingChange(percentSettingCB);
 
-    uint8_t speedSettingCB = speedSettingNullable.IsNull() ? 0 : speedSettingNullable.Value();
-    AppInstance().HandleSpeedSettingChange(speedSettingCB);
+    if (sSupportsMultiSpeed)
+    {
+        uint8_t speedSettingCB = speedSettingNullable.IsNull() ? 0 : speedSettingNullable.Value();
+        AppInstance().HandleSpeedSettingChange(speedSettingCB);
+    }
 
-    // Startup runs before BaseApplication marks the app initialized, so
-    // boot-time FanMode writes may not loop back through the DM callback.
-    AppInstance().HandleFanModeChange(sFanMode);
     PostFanUiUpdateEvent();
 
     return CHIP_NO_ERROR;
@@ -249,58 +420,7 @@ CHIP_ERROR AppTask::InitFanControl()
 
 void AppTask::HandleFanModeChange(FanModeEnum aNewFanMode)
 {
-    ChipLogDetail(NotSpecified, "HandleFanModeChange: %d", to_underlying(aNewFanMode));
-    // If PercentSetting is null, use an out-of-bounds value to force an update.
-    uint8_t percentSettingCurrent = GetPercentSetting().ValueOr(101);
-    switch (aNewFanMode)
-    {
-    case FanModeEnum::kOff: {
-        if (percentSettingCurrent != 0)
-        {
-            SetPercentSetting(0);
-        }
-        break;
-    }
-    case FanModeEnum::kLow: {
-        const uint8_t lowPercentMin = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND), sSpeedMax);
-        const uint8_t lowPercentMax = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax);
-        if (percentSettingCurrent < lowPercentMin || percentSettingCurrent > lowPercentMax)
-        {
-            SetPercentSetting(lowPercentMin);
-        }
-        break;
-    }
-    case FanModeEnum::kMedium: {
-        const uint8_t mediumPercentMin = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND), sSpeedMax);
-        const uint8_t mediumPercentMax = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax);
-        if (percentSettingCurrent < mediumPercentMin || percentSettingCurrent > mediumPercentMax)
-        {
-            SetPercentSetting(mediumPercentMin);
-        }
-        break;
-    }
-    case FanModeEnum::kOn:
-    case FanModeEnum::kHigh: {
-        const uint8_t highPercentMin = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_HIGH_LOWER_BOUND), sSpeedMax);
-        const uint8_t highPercentMax = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_HIGH_UPPER_BOUND), sSpeedMax);
-        if (percentSettingCurrent < highPercentMin || percentSettingCurrent > highPercentMax)
-        {
-            SetPercentSetting(highPercentMin);
-        }
-        break;
-    }
-    case FanModeEnum::kSmart:
-    case FanModeEnum::kAuto: {
-        ChipLogProgress(NotSpecified, "HandleFanModeChange: Auto");
-        break;
-    }
-    case FanModeEnum::kUnknownEnumValue: {
-        ChipLogProgress(NotSpecified, "HandleFanModeChange: Unknown");
-        break;
-    }
-    default:
-        break;
-    }
+    ApplyFanModeMapping(aNewFanMode);
 }
 
 void AppTask::HandlePercentSettingChange(uint8_t aNewPercentSetting)
@@ -319,10 +439,20 @@ void AppTask::HandlePercentSettingChange(uint8_t aNewPercentSetting)
     {
         ChipLogError(NotSpecified, "HandlePercentSettingChange: failed to set PercentCurrent attribute");
     }
+
+    if (!sSupportsMultiSpeed)
+    {
+        FanModeEnum newFanMode = DeriveFanModeFromPercent(aNewPercentSetting);
+        if (newFanMode != sFanMode)
+        {
+            SyncFanMode(newFanMode);
+        }
+    }
 }
 
 void AppTask::HandleSpeedSettingChange(uint8_t aNewSpeedSetting)
 {
+    VerifyOrReturn(sSupportsMultiSpeed);
     VerifyOrReturn(aNewSpeedSetting != sSpeedCurrent);
     VerifyOrReturn(sFanMode != FanModeEnum::kAuto);
     ChipLogDetail(NotSpecified, "HandleSpeedSettingChange: %d", aNewSpeedSetting);
@@ -337,25 +467,6 @@ void AppTask::HandleSpeedSettingChange(uint8_t aNewSpeedSetting)
     {
         ChipLogError(NotSpecified, "HandleSpeedSettingChange: failed to set SpeedCurrent attribute");
     }
-
-    // Update the fan mode as per the current speed.
-    if (sSpeedCurrent == 0)
-    {
-        sFanMode = FanModeEnum::kOff;
-    }
-    else if (sSpeedCurrent <= FAN_MODE_LOW_UPPER_BOUND)
-    {
-        sFanMode = FanModeEnum::kLow;
-    }
-    else if (sSpeedCurrent <= FAN_MODE_MEDIUM_UPPER_BOUND)
-    {
-        sFanMode = FanModeEnum::kMedium;
-    }
-    else if (sSpeedCurrent <= FAN_MODE_HIGH_UPPER_BOUND)
-    {
-        sFanMode = FanModeEnum::kHigh;
-    }
-    UpdateFanMode();
 }
 
 CHIP_ERROR AppTask::StartAppTask()
@@ -399,55 +510,79 @@ Status AppTask::HandleStep(StepDirectionEnum aDirection, bool aWrap, bool aLowes
 
     VerifyOrReturnError(aDirection != StepDirectionEnum::kUnknownEnumValue, Status::InvalidCommand);
 
-    // if aLowestOff is true, Step command can reduce the fan speed to 0, else 1.
     uint8_t speedMin = aLowestOff ? kaLowestOffTrue : kaLowestOffFalse;
 
-    DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
-
-    uint8_t curSpeedSetting = speedSettingNullable.IsNull() ? speedMin : speedSettingNullable.Value();
-
-    // increase or decrease the fan speed by one step
-    switch (aDirection)
+    if (sSupportsMultiSpeed)
     {
-    case StepDirectionEnum::kIncrease: {
-        if (curSpeedSetting >= sSpeedMax)
-        {
-            curSpeedSetting = aWrap ? speedMin : sSpeedMax;
-        }
-        else
-        {
-            curSpeedSetting++;
-        }
-        break;
-    }
-    case StepDirectionEnum::kDecrease: {
-        if (curSpeedSetting <= speedMin)
-        {
-            curSpeedSetting = aWrap ? sSpeedMax : speedMin;
-        }
-        else
-        {
-            curSpeedSetting--;
-        }
-        break;
-    }
-    default: {
-        break;
-    }
-    }
+        DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
+        uint8_t curSpeedSetting                         = speedSettingNullable.IsNull() ? speedMin : speedSettingNullable.Value();
 
-    // Convert SpeedSetting to PercentSetting
-    uint8_t curPercentSetting = SpeedToPercent(curSpeedSetting, sSpeedMax);
+        switch (aDirection)
+        {
+        case StepDirectionEnum::kIncrease: {
+            if (curSpeedSetting >= sSpeedMax)
+            {
+                curSpeedSetting = aWrap ? speedMin : sSpeedMax;
+            }
+            else
+            {
+                curSpeedSetting++;
+            }
+            break;
+        }
+        case StepDirectionEnum::kDecrease: {
+            if (curSpeedSetting <= speedMin)
+            {
+                curSpeedSetting = aWrap ? sSpeedMax : speedMin;
+            }
+            else
+            {
+                curSpeedSetting--;
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+        }
 
-    AppTask::AttributeUpdateInfo * data = chip::Platform::New<AppTask::AttributeUpdateInfo>();
-    data->percentSetting       = curPercentSetting;
-    data->endPoint             = kFanEndpoint;
-    data->isPercentSetting     = true;
-
-    if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
+        SetSpeedSetting(curSpeedSetting);
+    }
+    else
     {
-        ChipLogError(NotSpecified, "AppTask::HandleStep: Failed to update PercentSetting attribute");
-        return Status::Failure;
+        DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
+        Percent curPercentSetting = percentSettingNullable.IsNull() ? static_cast<Percent>(speedMin) : percentSettingNullable.Value();
+
+        switch (aDirection)
+        {
+        case StepDirectionEnum::kIncrease: {
+            if (curPercentSetting >= 100)
+            {
+                curPercentSetting = aWrap ? static_cast<Percent>(speedMin) : 100;
+            }
+            else
+            {
+                curPercentSetting++;
+            }
+            break;
+        }
+        case StepDirectionEnum::kDecrease: {
+            if (curPercentSetting <= speedMin)
+            {
+                curPercentSetting = aWrap ? 100 : static_cast<Percent>(speedMin);
+            }
+            else
+            {
+                curPercentSetting--;
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+        }
+
+        SetPercentSetting(curPercentSetting);
     }
 
     return Status::Success;
@@ -507,12 +642,19 @@ void AppTask::DMPostAttributeChangeCallback(const ConcreteAttributePath & attrib
         break;
     }
     case Attributes::SpeedSetting::Id: {
-        AppInstance().HandleSpeedSettingChange(*value);
+        if (sSupportsMultiSpeed)
+        {
+            AppInstance().HandleSpeedSettingChange(*value);
+        }
         break;
     }
     case Attributes::FanMode::Id: {
         sFanMode = *reinterpret_cast<FanModeEnum *>(value);
-        AppInstance().HandleFanModeChange(sFanMode);
+        // MultiSpeed: cluster keeps FanMode / PercentSetting / SpeedSetting consistent.
+        if (!sSupportsMultiSpeed)
+        {
+            AppInstance().HandleFanModeChange(sFanMode);
+        }
         PostFanUiUpdateEvent();
         break;
     }

--- a/examples/fan-control-app/silabs/src/AppTask.cpp
+++ b/examples/fan-control-app/silabs/src/AppTask.cpp
@@ -176,16 +176,16 @@ CHIP_ERROR AppTask::InitFanControl()
     uint8_t percentSettingCB = percentSettingNullable.IsNull() ? 0 : percentSettingNullable.Value();
     AppInstance().HandlePercentSettingChange(percentSettingCB);
 
-    if (!sSupportsMultiSpeed)
+    if (sSupportsMultiSpeed)
+    {
+        uint8_t speedSettingCB = speedSettingNullable.IsNull() ? 0 : speedSettingNullable.Value();
+        AppInstance().HandleSpeedSettingChange(speedSettingCB);
+    }
+    else
     {
         // Startup runs before BaseApplication marks the app initialized, so
         // boot-time FanMode writes may not loop back through the DM callback.
         AppInstance().HandleFanModeChange(sFanMode);
-    }
-    else
-    {
-        uint8_t speedSettingCB = speedSettingNullable.IsNull() ? 0 : speedSettingNullable.Value();
-        AppInstance().HandleSpeedSettingChange(speedSettingCB);
     }
 
     PostFanUiUpdateEvent();
@@ -352,64 +352,63 @@ void AppTask::HandleFanModeChange(FanModeEnum aNewFanMode)
         default:
             break;
         }
+        return;
     }
-    else
-    {
-        uint8_t percentSettingCurrent = GetPercentSetting().ValueOr(101);
-        const uint8_t lowPercentMin   = 1;
-        const uint8_t lowPercentMax   = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax);
-        const uint8_t mediumPercentMin =
-            SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND), sSpeedMax);
-        const uint8_t mediumPercentMax =
-            SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax);
-        const uint8_t highPercentMin =
-            SpeedToPercent(static_cast<uint8_t>((sSpeedMax >= FAN_MODE_HIGH_LOWER_BOUND) ? FAN_MODE_HIGH_LOWER_BOUND : sSpeedMax),
-                           sSpeedMax);
-        const uint8_t highPercentMax = 100;
 
-        switch (aNewFanMode)
+    uint8_t percentSettingCurrent = GetPercentSetting().ValueOr(101);
+    const uint8_t lowPercentMin   = 1;
+    const uint8_t lowPercentMax   = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax);
+    const uint8_t mediumPercentMin =
+        SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND), sSpeedMax);
+    const uint8_t mediumPercentMax =
+        SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax);
+    const uint8_t highPercentMin =
+        SpeedToPercent(static_cast<uint8_t>((sSpeedMax >= FAN_MODE_HIGH_LOWER_BOUND) ? FAN_MODE_HIGH_LOWER_BOUND : sSpeedMax),
+                       sSpeedMax);
+    const uint8_t highPercentMax = 100;
+
+    switch (aNewFanMode)
+    {
+    case FanModeEnum::kOff: {
+        if (percentSettingCurrent != 0)
         {
-        case FanModeEnum::kOff: {
-            if (percentSettingCurrent != 0)
-            {
-                SetPercentSetting(0);
-            }
-            break;
+            SetPercentSetting(0);
         }
-        case FanModeEnum::kLow: {
-            if (percentSettingCurrent < lowPercentMin || percentSettingCurrent > lowPercentMax)
-            {
-                SetPercentSetting(SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND), sSpeedMax));
-            }
-            break;
+        break;
+    }
+    case FanModeEnum::kLow: {
+        if (percentSettingCurrent < lowPercentMin || percentSettingCurrent > lowPercentMax)
+        {
+            SetPercentSetting(SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND), sSpeedMax));
         }
-        case FanModeEnum::kMedium: {
-            if (percentSettingCurrent < mediumPercentMin || percentSettingCurrent > mediumPercentMax)
-            {
-                SetPercentSetting(mediumPercentMin);
-            }
-            break;
+        break;
+    }
+    case FanModeEnum::kMedium: {
+        if (percentSettingCurrent < mediumPercentMin || percentSettingCurrent > mediumPercentMax)
+        {
+            SetPercentSetting(mediumPercentMin);
         }
-        case FanModeEnum::kOn:
-        case FanModeEnum::kHigh: {
-            if (percentSettingCurrent < highPercentMin || percentSettingCurrent > highPercentMax)
-            {
-                SetPercentSetting(highPercentMin);
-            }
-            break;
+        break;
+    }
+    case FanModeEnum::kOn:
+    case FanModeEnum::kHigh: {
+        if (percentSettingCurrent < highPercentMin || percentSettingCurrent > highPercentMax)
+        {
+            SetPercentSetting(highPercentMin);
         }
-        case FanModeEnum::kSmart:
-        case FanModeEnum::kAuto: {
-            ChipLogProgress(NotSpecified, "HandleFanModeChange: Auto");
-            break;
-        }
-        case FanModeEnum::kUnknownEnumValue: {
-            ChipLogProgress(NotSpecified, "HandleFanModeChange: Unknown");
-            break;
-        }
-        default:
-            break;
-        }
+        break;
+    }
+    case FanModeEnum::kSmart:
+    case FanModeEnum::kAuto: {
+        ChipLogProgress(NotSpecified, "HandleFanModeChange: Auto");
+        break;
+    }
+    case FanModeEnum::kUnknownEnumValue: {
+        ChipLogProgress(NotSpecified, "HandleFanModeChange: Unknown");
+        break;
+    }
+    default:
+        break;
     }
 }
 
@@ -542,24 +541,18 @@ Status AppTask::HandleStep(StepDirectionEnum aDirection, bool aWrap, bool aLowes
     switch (aDirection)
     {
     case StepDirectionEnum::kIncrease: {
-        if (curPercentSetting >= 100)
+        curPercentSetting++;
+        if (curPercentSetting > 100)
         {
             curPercentSetting = aWrap ? static_cast<Percent>(speedMin) : 100;
-        }
-        else
-        {
-            curPercentSetting++;
         }
         break;
     }
     case StepDirectionEnum::kDecrease: {
-        if (curPercentSetting <= speedMin)
+        curPercentSetting--;
+        if (curPercentSetting < speedMin)
         {
             curPercentSetting = aWrap ? 100 : static_cast<Percent>(speedMin);
-        }
-        else
-        {
-            curPercentSetting--;
         }
         break;
     }


### PR DESCRIPTION
### Summary

This PR fixes the cascading attribute handling in Fan Control app.

The app was remapping FanMode, PercentSetting, and SpeedSetting in ways that fought the cluster’s own cascade logic, causing write/read mismatches and missing subscription reports.

**Problem**

- Writing PercentSetting=1 was read back as 10 because a speed→fan-mode→percent remap overwrote small percent values.
- FanMode descending to Off produced 3 FanMode reports but only 2 PercentSetting reports (3 != 2), failing the report-count check.

**Fix**
Refactor FanControlManager to support feature-gated, directional synchronization between FanMode, SpeedSetting, and PercentSetting.

- MultiSpeed enabled

  - Direct FanMode writes now update SpeedSetting only.
  - The Fan Control cluster derives PercentSetting from SpeedSetting.
  - SpeedSetting changes synchronize only FanMode and SpeedCurrent. They no longer remap values back to other settings, preventing circular updates.
  - Direct PercentSetting writes update only PercentCurrent.

- MultiSpeed disabled

  - Direct FanMode writes map to PercentSetting using percentage bands derived dynamically from the current SpeedMax value via SpeedToPercent().
  - This replaces the previous fixed thresholds (1–33%, 34–66%, and 67–100%), allowing the mapping to adapt to the configured maximum speed.

- Additional changes

  - SetSpeedSetting() now uses the synchronous Attributes::SpeedSetting::Set() API.
  - This ensures the application delegate is invoked before the cluster's FanMode callback, allowing the expected PercentSetting subscription report to be emitted when transitioning to Off.

### Related issues

[MATTER-6315](https://jira.silabs.com/browse/MATTER-6315)

### Testing

Build and flash fan-control app on BRD4338A.
Run TC-FAN-3.1 (TC_FAN_3_1.py) and ensure that the test-case passes.
