### PR TITLE
[SL-TEMP] Revert "[SL-TEMP]Remove sli_zigbee_af_print_internal_var_arg until si…

### DIFF
--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -323,7 +323,6 @@ extern "C" void LwIPLog(const char * aFormat, ...)
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-#if 0 // [SL-TEMP] sli_zigbee_af_print_internal_var_arg requires sisdk 2026.6 or later.
 #if defined(SL_COMPONENT_CATALOG_PRESENT) &&                                                                                       \
     (defined(SL_CATALOG_ZIGBEE_ZCL_CLI_PRESENT) || defined(SL_CATALOG_ZIGBEE_DEBUG_PRINT_PRESENT))
 #include "zcl-debug-print.h"
@@ -379,7 +378,6 @@ extern "C" void sli_zigbee_af_print_internal_var_arg(uint16_t area, uint32_t log
 }
 #endif // defined(SL_COMPONENT_CATALOG_PRESENT) && (defined(SL_CATALOG_ZIGBEE_ZCL_CLI_PRESENT) ||
        // defined(SL_CATALOG_ZIGBEE_DEBUG_PRINT_PRESENT))
-#endif // 0 - [SL-TEMP] sli_zigbee_af_print_internal_var_arg requires sisdk 2026.6 or later.
 
 /**
  * Platform logging function for OpenThread


### PR DESCRIPTION
…sdk 2026.6 is pickup (https://github.com/SiliconLabsSoftware/matter_sdk/pull/1056)"

This reverts commit https://github.com/SiliconLabsSoftware/matter_sdk/commit/ec8be6d37590b5869088fa0053f378a220897942.

Summary
revert SL-TEMP as 2026.6 is now supported on matter_sdk/main

Related issues
n/a

Testing
CI