### PR TITLE
[SL-ONLY] : llvm fixes (#970) (#1101)

### DIFF
--- a/examples/onoff-plug-app/silabs/src/AppTask.cpp
+++ b/examples/onoff-plug-app/silabs/src/AppTask.cpp
@@ -56,6 +56,7 @@
 #define APP_ONOFF_BUTTON 1
 
 using namespace chip;
+using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::DeviceLayer;
 using namespace chip::DeviceLayer::Silabs;
@@ -198,7 +199,7 @@ void AppTask::ButtonEventHandler(uint8_t button, uint8_t btnAction)
     }
 }
 
-void AppTask::DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
+void AppTask::DMPostAttributeChangeCallback(const ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                             uint8_t * value)
 {
     ClusterId clusterId     = attributePath.mClusterId;
@@ -230,7 +231,7 @@ void AppTask::DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePa
                         ChipLogValueMEI(attributeId), type, value != nullptr ? static_cast<unsigned>(*value) : 0u, size);
         break;
 
-    case Identify::Id:
+    case Clusters::Identify::Id:
         if (value != nullptr && size == sizeof(uint8_t))
         {
             ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u",


### PR DESCRIPTION
CP of [SL-UP] : llvm fixes (#970) #1101 

llvm fixes

### Summary
Missed this while upstreaming #970  to CSA as onoff plug is SL-ONLY

### Related issues

Issue: https://github.com/SiliconLabsSoftware/matter_extension/actions/runs/30280850725/job/90027153660

### Testing

Tested ./slc/build.sh slc/apps/onoff_plug_app/thread/matter_thread_soc_onoff_plug_app_series_2_internal_freertos.slcw brd4337a --output_suffix llvm --with toolchain_llvm  locally on matter_extension
