### PR TITLE
[SL-UP][SL-ONLY] MATTER-6633 : Update the Comment

### DIFF
--- a/examples/air-quality-sensor-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/air-quality-sensor-app/silabs/include/CHIPProjectConfig.h
@@ -109,5 +109,5 @@
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 
-// Temporary setting to use CustomerAppTask for apps which are not upgraded to new architecture
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/base-platform-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/base-platform-app/silabs/include/CHIPProjectConfig.h
@@ -111,7 +111,7 @@
  */
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 
-// Temporary setting to use CustomerAppTask for apps which are not upgraded to new architecture
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
 
 // Setting to prevent required Data Model implementation in AppTask

--- a/examples/closure-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/closure-app/silabs/include/CHIPProjectConfig.h
@@ -101,5 +101,5 @@
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 
-// This is a temporary setting to use the CustomerAppTask for the apps which are not upgraded to the new architecture.
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/evse-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/evse-app/silabs/include/CHIPProjectConfig.h
@@ -101,7 +101,7 @@
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 
-// Temporary setting to use CustomerAppTask for apps which are not upgraded to new architecture
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
 
 // Setting to prevent required Data Model implementation in AppTask

--- a/examples/fan-control-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/fan-control-app/silabs/include/CHIPProjectConfig.h
@@ -101,5 +101,5 @@
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 
-// This is a temporary setting to use the CustomerAppTask for the apps which are not upgraded to the new architecture.
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/light-switch-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/light-switch-app/silabs/include/CHIPProjectConfig.h
@@ -101,5 +101,5 @@
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 
-// Temporary setting to use CustomerAppTask for apps which are not upgraded to new architecture
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/lighting-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/silabs/include/CHIPProjectConfig.h
@@ -107,5 +107,5 @@
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 
-// This is a temporary setting to use the CustomerAppTask for the apps which are not upgraded to the new architecture.
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/lock-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/lock-app/silabs/include/CHIPProjectConfig.h
@@ -143,5 +143,5 @@ static constexpr uint8_t kNumCredentialTypes         = 6;
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 #endif
 
-// Route BaseApplication data-model posts and Rpc button path through CustomerAppTask / AppTaskImpl (CRTP).
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/multi-sensor-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/multi-sensor-app/silabs/include/CHIPProjectConfig.h
@@ -123,5 +123,5 @@
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 
-// Temporary setting to use CustomerAppTask for apps which are not upgraded to new architecture
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/onoff-plug-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/onoff-plug-app/silabs/include/CHIPProjectConfig.h
@@ -129,5 +129,5 @@
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 
-// Temporary setting to use CustomerAppTask for apps which are not upgraded to new architecture
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/oven-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/oven-app/silabs/include/CHIPProjectConfig.h
@@ -101,5 +101,5 @@
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 
-// Temporary setting to use CustomerAppTask for apps which are not upgraded to new architecture
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/platform/silabs/Rpc.cpp
+++ b/examples/platform/silabs/Rpc.cpp
@@ -94,7 +94,7 @@ public:
         CustomerAppTask::ButtonEventHandler(request.idx /* PB 0 or PB 1 */, request.pushed);
 #else
         AppTask::GetAppTask().ButtonEventHandler(request.idx /* PB 0 or PB 1 */, request.pushed);
-#endif
+#endif // defined(CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK)
         return pw::OkStatus();
     }
 };

--- a/examples/rangehood-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/rangehood-app/silabs/include/CHIPProjectConfig.h
@@ -101,4 +101,5 @@
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/refrigerator-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/refrigerator-app/silabs/include/CHIPProjectConfig.h
@@ -110,5 +110,5 @@
 
 #define CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY 1
 
-// Temporary setting to use CustomerAppTask for apps which are not upgraded to new architecture
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK

--- a/examples/thermostat/silabs/include/CHIPProjectConfig.h
+++ b/examples/thermostat/silabs/include/CHIPProjectConfig.h
@@ -109,5 +109,5 @@
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
 
-// This is a temporary setting to use the CustomerAppTask for the apps which are not upgraded to the new architecture.
+// Route shared platform callbacks through CustomerAppTask
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK


### PR DESCRIPTION
### Summary
As the CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK is no longer temporary, updating the comment to reflect the latest. 
Also, we cannot remove CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK as not all apps are refactoed ( like widnow, wake-on-matter) 

### Related issues

[MATTER-6633](https://jira.silabs.com/browse/MATTER-6633)

### Testing

Commnet change only.