### PR TITLE
[SL-ONLY] Remove Dependencies of WF200 not in CSA

### DIFF
--- a/examples/base-platform-app/silabs/BUILD.gn
+++ b/examples/base-platform-app/silabs/BUILD.gn
@@ -92,10 +92,6 @@ if (wifi_soc) {
     sources = common_sources
     include_dirs =
         [ "${chip_root}/src/platform/silabs/efr32" ] + common_include_dirs
-
-    if (use_wf200) {
-      include_dirs += [ "${examples_plat_dir}/wf200" ]
-    }
     defines = common_defines
   }
 }

--- a/examples/fan-control-app/silabs/BUILD.gn
+++ b/examples/fan-control-app/silabs/BUILD.gn
@@ -104,7 +104,7 @@ if (wifi_soc) {
       "${examples_common_plat_dir}",
       "${examples_common_plat_dir}/freertos_config",
     ]
-    
+
     defines = []
     if (chip_enable_pw_rpc) {
       defines += [

--- a/examples/fan-control-app/silabs/BUILD.gn
+++ b/examples/fan-control-app/silabs/BUILD.gn
@@ -104,12 +104,7 @@ if (wifi_soc) {
       "${examples_common_plat_dir}",
       "${examples_common_plat_dir}/freertos_config",
     ]
-
-    if (use_wf200) {
-      # TODO efr32_sdk should not need a header from this location
-      include_dirs += [ "${examples_plat_dir}/wf200" ]
-    }
-
+    
     defines = []
     if (chip_enable_pw_rpc) {
       defines += [

--- a/examples/multi-sensor-app/silabs/BUILD.gn
+++ b/examples/multi-sensor-app/silabs/BUILD.gn
@@ -97,11 +97,6 @@ if (wifi_soc) {
       "${examples_common_plat_dir}",
       "${examples_common_plat_dir}/freertos_config",
     ]
-
-    if (use_wf200) {
-      # TODO efr32_sdk should not need a header from this location
-      include_dirs += [ "${examples_plat_dir}/wf200" ]
-    }
   }
 }
 

--- a/examples/onoff-plug-app/silabs/BUILD.gn
+++ b/examples/onoff-plug-app/silabs/BUILD.gn
@@ -90,11 +90,6 @@ if (wifi_soc) {
       "${examples_common_plat_dir}/freertos_config",
     ]
 
-    if (use_wf200) {
-      # TODO efr32_sdk should not need a header from this location
-      include_dirs += [ "${examples_plat_dir}/wf200" ]
-    }
-
     defines = []
     if (chip_enable_pw_rpc) {
       defines += [

--- a/examples/template/silabs/BUILD.gn
+++ b/examples/template/silabs/BUILD.gn
@@ -89,11 +89,6 @@ if (wifi_soc) {
       "${examples_common_plat_dir}/freertos_config",
     ]
 
-    if (use_wf200) {
-      # TODO efr32_sdk should not need a header from this location
-      include_dirs += [ "${examples_plat_dir}/wf200" ]
-    }
-
     defines = []
     if (chip_enable_pw_rpc) {
       defines += [

--- a/third_party/silabs/aws_ota_sdk/demos/ota/common/src/pal.c
+++ b/third_party/silabs/aws_ota_sdk/demos/ota/common/src/pal.c
@@ -34,10 +34,6 @@
 #ifdef EFR32MG24 //For efr32 NCP combos
 #include "btl_interface.h"
 #include "em_bus.h" // For CORE_CRITICAL_SECTION
-#if (defined(EFR32MG24) && defined(WF200_WIFI))
-#include "sl_wfx_host_api.h"
-#include "spi_multiplex.h"
-#endif // EFR32MG24 && WF200_WIFI
 #else
 #ifdef __cplusplus
 extern "C" {
@@ -142,13 +138,8 @@ int16_t otaPal_WriteBlock_efr32(OtaFileContext_t *const C,
                  writeBufOffset);
       writeBufOffset = 0;
 
-#if (defined(EFR32MG24) && defined(WF200_WIFI))
-      sl_wfx_host_pre_bootloader_spi_transfer();
-#endif
       CORE_CRITICAL_SECTION(err = bootloader_eraseWriteStorage(mSlotId, mWriteOffset, writeBuffer, kAlignmentBytes);)
-#if (defined(EFR32MG24) && defined(WF200_WIFI))
-      sl_wfx_host_post_bootloader_spi_transfer();
-#endif
+
       if (err) {
         SILABS_LOG("otaPal_WriteBlock bootloader_eraseWriteStorage FAILED: %ld", err);
         filerc = -1;
@@ -169,13 +160,8 @@ int16_t otaPal_WriteBlock_efr32(OtaFileContext_t *const C,
           writeBufOffset++;
         }
         SILABS_LOG("while loop final reminder (blockReadOffset == ulBlockSize)writeBufOffset %d", writeBufOffset);
-#if (defined(EFR32MG24) && defined(WF200_WIFI))
-        sl_wfx_host_pre_bootloader_spi_transfer();
-#endif
         CORE_CRITICAL_SECTION(err = bootloader_eraseWriteStorage(mSlotId, mWriteOffset, writeBuffer, kAlignmentBytes);)
-#if (defined(EFR32MG24) && defined(WF200_WIFI))
-        sl_wfx_host_post_bootloader_spi_transfer();
-#endif
+
         if (err) {
           SILABS_LOG("ERROR: In HandleFinalize bootloader_eraseWriteStorage() error %ld", err);
           return -1;
@@ -296,9 +282,6 @@ OtaPalStatus_t otaPal_ActivateNewImage_efr32(OtaFileContext_t *const C)
   int32_t err     = 0;
   SILABS_LOG("otaPal_ActivateNewImage OTAImageProcessorImpl::HandleApply()");
 
-#if (defined(EFR32MG24) && defined(WF200_WIFI))
-  sl_wfx_host_pre_bootloader_spi_transfer();
-#endif
   CORE_CRITICAL_SECTION(err = bootloader_verifyImage(mSlotId, NULL);)
   if (err != 0) {
     SILABS_LOG("otaPal_ActivateNewImage ERROR: bootloader_verifyImage() error %ld", err);


### PR DESCRIPTION
## WF200 SL-ONLY cleanup

Removed the remaining **SL-ONLY** WF200 leftovers.

Shared CSA platform changes are intentionally not included in this PR because they will be synced within the next week. The corresponding CSA branch changes are tracked in [project-chip/connectedhomeip#73218](https://github.com/project-chip/connectedhomeip/pull/73218).

### SL-UP verification

```bash
git log --all --regexp-ignore-case --grep='[SL-UP]' | grep -i -C 20 'wf200'
```

The SL-UP WF200 work in #126/#36628, #268, and #739 has already been upstreamed or integrated as part of [Matter 2.9.0-1.6](https://confluence.silabs.com/spaces/MATTER/pages/781980927/Matter+2.9.0-1.6).

No additional SL-UP action is required.

### SL-ONLY verification

```bash
git log --all --regexp-ignore-case --grep='[SL-ONLY]' | grep -i -C 20 'wf200'
```

Most SL-ONLY WF200 code had already been removed. The remaining stale references were:

- `use_wf200` include directories in SL-only applications
- The `WF200_WIFI` SPI mux and `sl_wfx_host_*` guards in the Matter-AWS `pal.c` implementation from #669

These leftovers are removed in this change.

### Changes

- `examples/base-platform-app/silabs/BUILD.gn` — remove dead `use_wf200` include
- `examples/fan-control-app/silabs/BUILD.gn` — remove dead `use_wf200` include
- `examples/multi-sensor-app/silabs/BUILD.gn` — remove dead `use_wf200` include
- `examples/onoff-plug-app/silabs/BUILD.gn` — remove dead `use_wf200` include
- `examples/template/silabs/BUILD.gn` — remove dead `use_wf200` include
- `third_party/silabs/aws_ota_sdk/demos/ota/common/src/pal.c` — remove `WF200_WIFI` and `sl_wfx_host_*` guards

### Build validation

Ran the full build set for the following boards to validate the change:

```bash
boards=(
  "BRD4338A"
  "BRD2605A"
  "BRD4343A"
  "BRD4342A"
  "BRD2708A"
  "BRD2911A"
  "BRD4186C"
  "BRD4187C"
  "BRD2703A"
  "BRD4316A"
  "BRD4317A"
  "BRD4319A"
  "BRD2704A"
  "BRD4318A"
  "BRD4116A"
  "BRD4117A"
  "BRD4118A"
  "BRD2608A"
)
```

Also ran the NCP build for:

```bash
ncp_boards=(
  "BRD4187C"
)
```