### PR TITLE
[CSA-CP]Bump Silabs doorlock devicetype revision to 4 (Auto-merged by…

### DIFF
--- a/examples/lock-app/silabs/data_model/lock-app.matter
+++ b/examples/lock-app/silabs/data_model/lock-app.matter
@@ -3268,7 +3268,7 @@ endpoint 0 {
 }
 endpoint 1 {
   device type ma_powersource = 17, version 1;
-  device type ma_doorlock = 10, version 3;
+  device type ma_doorlock = 10, version 4;
 
 
   server cluster Identify {

--- a/examples/lock-app/silabs/data_model/lock-app.zap
+++ b/examples/lock-app/silabs/data_model/lock-app.zap
@@ -4870,7 +4870,7 @@
         }
       ],
       "deviceVersions": [
-        3,
+        4,
         1
       ],
       "deviceIdentifiers": [


### PR DESCRIPTION
### Summary
Change the Silabs doorlock devicetype revision from 3 to 4.
- Update zapfile `examples/lock-app/silabs/data_model/lock-app.zap` with new value.
- Run generate.py to regen the .matter file examples/lock-app/silabs/data_model/lock-app.matter


### Related issues
[MATTER-6844](https://jira.silabs.com/browse/MATTER-6844)

### Testing
Run tc_idm_10_6 against Silabs Lock-app on EFR32MG24 device

```
[MatterTest] 07-27 21:14:12.244 INFO ===== EXECUTION FLAGS SUMMARY BEGIN =====
[MatterTest] 07-27 21:14:12.244 INFO Config values:
[MatterTest] 07-27 21:14:12.245 INFO   - admin_vendor_id: 65521
[MatterTest] 07-27 21:14:12.245 INFO   - app_pid: 0
[MatterTest] 07-27 21:14:12.245 INFO   - ble_controller: 0
[MatterTest] 07-27 21:14:12.246 INFO   - case_admin_subject: 112233
[MatterTest] 07-27 21:14:12.246 INFO   - commission_only: False
[MatterTest] 07-27 21:14:12.246 INFO   - commissioning_method: 'ble-thread'
[MatterTest] 07-27 21:14:12.247 INFO   - controller_cat_tags: [65537]
[MatterTest] 07-27 21:14:12.247 INFO   - controller_node_id: 112233
[MatterTest] 07-27 21:14:12.247 INFO   - debug: False
[MatterTest] 07-27 21:14:12.248 INFO   - discriminators: [3840]
[MatterTest] 07-27 21:14:12.248 INFO   - dut_node_ids: [305414945]
[MatterTest] 07-27 21:14:12.248 INFO   - endpoint: 0
[MatterTest] 07-27 21:14:12.248 INFO   - fabric_id: 1
[MatterTest] 07-27 21:14:12.249 INFO   - fail_on_skipped_tests: False
[MatterTest] 07-27 21:14:12.249 INFO   - legacy: False
[MatterTest] 07-27 21:14:12.249 INFO   - logs_path: '/tmp/matter_testing/logs'
[MatterTest] 07-27 21:14:12.250 INFO   - maximize_cert_chains: True
[MatterTest] 07-27 21:14:12.250 INFO   - no_wildcard_subscription: False
[MatterTest] 07-27 21:14:12.250 INFO   - paa_trust_store_path: '/home/ubuntu/connectedhomeip/credentials/development/paa-root-certs'
[MatterTest] 07-27 21:14:12.250 INFO   - root_of_trust_index: 1
[MatterTest] 07-27 21:14:12.251 INFO   - setup_passcodes: [20202021]
[MatterTest] 07-27 21:14:12.251 INFO   - storage_path: 'admin_storage.json'
[MatterTest] 07-27 21:14:12.251 INFO   - tests: ['test_TC_IDM_10_2', 'test_TC_IDM_10_6']
[MatterTest] 07-27 21:14:12.252 INFO   - thread_operational_dataset: 0x0e08000000000001000000030000134a0300001a35060004001fffe00208c1492e61d6e5dbda0708fd96a9c76d8c24730510d8a5288446db89cf7bb94fe0c369... (truncated, 111 bytes)
[MatterTest] 07-27 21:14:12.252 INFO   - timeout: 100000
[MatterTest] 07-27 21:14:12.252 INFO

Named args:
[MatterTest] 07-27 21:14:12.253 INFO   - certificate_authority_manager: 'ebee3eaa-89ff-11f1-b14e-1999747e30aa'
[MatterTest] 07-27 21:14:12.253 INFO   - default_controller: 'ebee3ea7-89ff-11f1-b14e-1999747e30aa'
[MatterTest] 07-27 21:14:12.253 INFO   - hooks: 'ebee3ea9-89ff-11f1-b14e-1999747e30aa'
[MatterTest] 07-27 21:14:12.253 INFO   - matter_stack: 'ebee3ea6-89ff-11f1-b14e-1999747e30aa'
[MatterTest] 07-27 21:14:12.254 INFO   - matter_test_config: 'ebee3ea8-89ff-11f1-b14e-1999747e30aa'
[MatterTest] 07-27 21:14:12.254 INFO ===== EXECUTION FLAGS SUMMARY END =====
[MatterTest] 07-27 21:14:12.255 INFO Summary for test class TC_DeviceConformance: Error 0, Executed 2, Failed 0, Passed 2, Requested 2, Skipped 0
```