### PR TITLE
[SL-ONLY] : update github actions

### DIFF
--- a/.github/workflows/silabs-common-build.yaml
+++ b/.github/workflows/silabs-common-build.yaml
@@ -27,7 +27,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Checkout submodules & Bootstrap
               uses: ./.github/actions/checkout-submodules-and-bootstrap

--- a/.github/workflows/silabs-custom-thread-build.yaml
+++ b/.github/workflows/silabs-custom-thread-build.yaml
@@ -21,7 +21,7 @@ jobs:
             image: ghcr.io/project-chip/chip-build-efr32:206
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Checkout submodules & Bootstrap
               uses: ./.github/actions/checkout-submodules-and-bootstrap

--- a/.github/workflows/silabs-open-csa-prs.yaml
+++ b/.github/workflows/silabs-open-csa-prs.yaml
@@ -44,7 +44,7 @@ jobs:
               id: generate_token
               uses: actions/create-github-app-token@v3
               with:
-                  app-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
+                  client-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
                   private-key: ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}
             - name: Mask the generated token
               run: echo "::add-mask::${{ steps.generate_token.outputs.token }}"

--- a/.github/workflows/silabs-open-csa-prs.yaml
+++ b/.github/workflows/silabs-open-csa-prs.yaml
@@ -42,7 +42,7 @@ jobs:
         steps:
             - name: Generate token for the workflow
               id: generate_token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
                   private-key: ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/silabs-open-csa-prs.yaml
+++ b/.github/workflows/silabs-open-csa-prs.yaml
@@ -49,7 +49,7 @@ jobs:
             - name: Mask the generated token
               run: echo "::add-mask::${{ steps.generate_token.outputs.token }}"
 
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
               with:
                   ref: ${{ matrix.base_branch }}
                   persist-credentials: false
@@ -60,7 +60,7 @@ jobs:
                   git reset --hard ${{ matrix.local_branch }}
 
             - name: Create Pull Request
-              uses: peter-evans/create-pull-request@v7
+              uses: peter-evans/create-pull-request@v8
               with:
                   branch: ${{ matrix.pr_branch }}
                   base: ${{ matrix.base_branch }}

--- a/.github/workflows/silabs-require-admin-action-check.yaml
+++ b/.github/workflows/silabs-require-admin-action-check.yaml
@@ -26,7 +26,7 @@ jobs:
             'sl-require-admin-action') }}
         steps:
             - name: Add comment to PR
-              uses: actions/github-script@v8
+              uses: actions/github-script@v9
               with:
                   script: |
                       const prNumber = context.payload.pull_request.number;
@@ -65,7 +65,7 @@ jobs:
             'sl-require-admin-action'
         steps:
             - name: Add comment to PR
-              uses: actions/github-script@v8
+              uses: actions/github-script@v9
               with:
                   script: |
                       const prNumber = context.payload.pull_request.number;
@@ -88,7 +88,7 @@ jobs:
                       }
 
             - name: Re-add sl-require-admin-action label
-              uses: actions/github-script@v8
+              uses: actions/github-script@v9
               with:
                   script: |
                       const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/silabs-update-branches.yaml
+++ b/.github/workflows/silabs-update-branches.yaml
@@ -24,7 +24,7 @@ jobs:
               id: generate_token
               uses: actions/create-github-app-token@v3
               with:
-                  app-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
+                  client-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
                   private-key:
                       ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}
             - name: Mask the generated token

--- a/.github/workflows/silabs-update-branches.yaml
+++ b/.github/workflows/silabs-update-branches.yaml
@@ -22,7 +22,7 @@ jobs:
         steps:
             - name: Generate token for the workflow
               id: generate_token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
                   private-key:

--- a/.github/workflows/silabs-update-branches.yaml
+++ b/.github/workflows/silabs-update-branches.yaml
@@ -31,7 +31,7 @@ jobs:
               run: echo "::add-mask::${{ steps.generate_token.outputs.token }}"
 
             - name: Checkout matter_sdk::${{ matrix.local_branch }} branch
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   repository: SiliconLabsSoftware/matter_sdk
                   ref: ${{ matrix.local_branch }}

--- a/.github/workflows/silabs-zap-failure-regen.yaml
+++ b/.github/workflows/silabs-zap-failure-regen.yaml
@@ -26,7 +26,7 @@ jobs:
               id: generate_token
               uses: actions/create-github-app-token@v3
               with:
-                  app-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
+                  client-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
                   private-key:
                       ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}
             - name: Mask the generated token

--- a/.github/workflows/silabs-zap-failure-regen.yaml
+++ b/.github/workflows/silabs-zap-failure-regen.yaml
@@ -33,7 +33,7 @@ jobs:
               run: echo "::add-mask::${{ steps.generate_token.outputs.token }}"
 
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
               with:
                   ref: ${{ github.event.workflow_run.head_branch }}
                   fetch-depth: 0

--- a/.github/workflows/silabs-zap-failure-regen.yaml
+++ b/.github/workflows/silabs-zap-failure-regen.yaml
@@ -24,7 +24,7 @@ jobs:
         steps:
             - name: Generate token for the workflow
               id: generate_token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
                   private-key:

--- a/.github/workflows/sl-labeler.yml
+++ b/.github/workflows/sl-labeler.yml
@@ -17,7 +17,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
+          client-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
           private-key: ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}
       
       - name: Mask the generated token

--- a/.github/workflows/sl-labeler.yml
+++ b/.github/workflows/sl-labeler.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo "::add-mask::${{ steps.generate_token.outputs.token }}"
 
       - name: Check PR title for SL prefix and apply labels
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |

--- a/.github/workflows/sl-labeler.yml
+++ b/.github/workflows/sl-labeler.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Generate token for the workflow
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.SILABSSW_MATTER_CI_BOT_APP_ID }}
           private-key: ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
### Summary
Keep on seeing
`Node 20 is being deprecated. This workflow is running with Node 24 by default.`
https://github.com/SiliconLabsSoftware/matter_sdk/actions/runs/30388906724/job/90375115342?pr=1094
As the create-github-app-token is using v2 instead of v3, 
We do not use Dependabot for actions on matter_sdk as CSA generally handles it , but here we need to use it for SL-ONLY actions

Also using client-id instead of app-id
### Related issues
N/A

### Testing

CI logs,
https://github.com/SiliconLabsSoftware/matter_sdk/actions/runs/30389272344/job/90376333695?pr=1108