### PR TITLE
[SL-ONLY] Buffering the packets until device is connected

### DIFF
--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -49,6 +49,10 @@ buildconfig_header("inet_buildconfig") {
     "INET_CONFIG_ENABLE_TCP_ENDPOINT=${chip_inet_config_enable_tcp_endpoint}",
     "INET_CONFIG_ENABLE_UDP_ENDPOINT=${chip_inet_config_enable_udp_endpoint}",
     "HAVE_LWIP_RAW_BIND_NETIF=true",
+
+    # [SL-ONLY] Queuing the UDP packets until the netif is up
+    "SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY=${sl_inet_config_udp_lwip_queue_until_netif_ready}",
+    "SL_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE=${sl_inet_config_udp_lwip_deferred_send_queue_size}",
   ]
 
   if (chip_inet_project_config_include != "") {
@@ -183,6 +187,7 @@ static_library("inet") {
     #  - UDPEndPointImplSockets.h
     sources += [
       "BasicPacketFilters.h",
+      "DeferredUdpSendRing.h",
       "EndpointQueueFilter.h",
       "UDPEndPoint.cpp",
       "UDPEndPoint.h",
@@ -192,6 +197,12 @@ static_library("inet") {
 
     if (!chip_system_config_use_network_framework) {
       sources += [ "UDPEndPointImpl${chip_system_config_inet}.cpp" ]
+      if (sl_inet_config_udp_lwip_queue_until_netif_ready) {
+        sources += [
+          "DeferredUdpSendQueueLwIP.cpp",
+          "DeferredUdpSendQueueLwIP.h",
+        ]
+      }
     }
   }
 

--- a/src/inet/DeferredUdpSendQueueLwIP.cpp
+++ b/src/inet/DeferredUdpSendQueueLwIP.cpp
@@ -1,0 +1,216 @@
+/*
+ *
+ *    Copyright (c) 2020-2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <inet/DeferredUdpSendQueueLwIP.h>
+
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+
+#include <inet/DeferredUdpSendRing.h>
+#include <inet/EndPointStateLwIP.h>
+#include <inet/IPAddress.h>
+#include <inet/IPPacketInfo.h>
+#include <inet/UDPEndPoint.h>
+#include <inet/UDPEndPointImplLwIP.h>
+
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+#include <lwip/err.h>
+#include <lwip/ip.h>
+#include <lwip/netif.h>
+
+#include <platform/LockTracker.h>
+
+#include <utility>
+
+namespace chip {
+namespace Inet {
+
+namespace {
+
+#ifndef NETIF_FOREACH
+#define NETIF_FOREACH(netif) for ((netif) = netif_list; (netif) != nullptr; (netif) = (netif)->next)
+#endif
+
+constexpr size_t kDeferredQueueCapacity = SL_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE;
+static_assert(kDeferredQueueCapacity > 0, "SL_INET_CONFIG_UDP_LWIP_DEFERRED_SEND_QUEUE_SIZE must be > 0");
+
+struct DeferredUdpSlot
+{
+    UDPEndPointHandle epHandle;
+    IPPacketInfo pktInfo;
+    System::PacketBufferHandle msg;
+};
+
+using DeferredUdpRing = DeferredUdpSendRing<DeferredUdpSlot, kDeferredQueueCapacity>;
+
+DeferredUdpRing gDeferredRing;
+
+bool IsNetifUsable(struct netif * netif)
+{
+    return netif != nullptr && netif_is_up(netif) && netif_is_link_up(netif);
+}
+
+bool NetifHasPreferredIpv6Address(struct netif * netif)
+{
+    VerifyOrReturnValue(netif != nullptr, false);
+    for (u8_t idx = 0; idx < LWIP_IPV6_NUM_ADDRESSES; ++idx)
+    {
+        if (ip6_addr_ispreferred(netif_ip6_addr_state(netif, idx)))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool IsNetifReadyForOutboundUdp(struct netif * netif, const IPAddress & dest)
+{
+    VerifyOrReturnValue(IsNetifUsable(netif), false);
+    if (dest.IsIPv6())
+    {
+        return NetifHasPreferredIpv6Address(netif);
+    }
+#if INET_CONFIG_ENABLE_IPV4
+    if (dest.IsIPv4())
+    {
+        return !ip4_addr_isany(netif_ip4_addr(netif));
+    }
+#endif // INET_CONFIG_ENABLE_IPV4
+    return false;
+}
+
+bool IsOutboundNetifReadyForUdp(const IPPacketInfo & pktInfo)
+{
+    const InterfaceId & intfId = pktInfo.Interface;
+    const IPAddress & dest     = pktInfo.DestAddress;
+
+    if (intfId.IsPresent())
+    {
+        return IsNetifReadyForOutboundUdp(intfId.GetPlatformInterface(), dest);
+    }
+
+    if (IsNetifReadyForOutboundUdp(netif_default, dest))
+    {
+        return true;
+    }
+
+    struct netif * netif = nullptr;
+    NETIF_FOREACH(netif)
+    {
+        if (IsNetifReadyForOutboundUdp(netif, dest))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+} // namespace
+
+CHIP_ERROR DeferredUdpSendQueueLwIP::ProbeDefer(const IPPacketInfo & pktInfo, bool & outShouldDefer)
+{
+    outShouldDefer = false;
+    err_t probeErr = EndPointStateLwIP::RunOnTCPIPRet([&]() -> err_t {
+        outShouldDefer = !IsOutboundNetifReadyForUdp(pktInfo);
+        return ERR_OK;
+    });
+    VerifyOrReturnError(probeErr == ERR_OK, chip::System::MapErrorLwIP(probeErr));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeferredUdpSendQueueLwIP::Enqueue(UDPEndPointImplLwIP * self, const IPPacketInfo * pktInfo,
+                                             System::PacketBufferHandle && msg)
+{
+    DeferredUdpSlot slot;
+    slot.epHandle = UDPEndPointHandle(static_cast<UDPEndPoint *>(self));
+    slot.pktInfo  = *pktInfo;
+    slot.msg      = std::move(msg);
+
+    ChipLogDetail(Inet, "UDP send deferred (waiting for netif)");
+    if (gDeferredRing.IsFull())
+    {
+        ChipLogDetail(Inet, "Deferred UDP queue full: dropping head");
+    }
+    gDeferredRing.PushBack(std::move(slot));
+    return CHIP_NO_ERROR;
+}
+
+void DeferredUdpSendQueueLwIP::PurgeForEndpoint(UDPEndPointImplLwIP * self)
+{
+    UDPEndPoint * asBase = static_cast<UDPEndPoint *>(self);
+    const size_t n       = gDeferredRing.ActiveCount();
+    for (size_t i = 0; i < n; ++i)
+    {
+        DeferredUdpSlot slot = gDeferredRing.PopFront();
+        if (!slot.epHandle.IsNull() && slot.epHandle == *asBase)
+        {
+            continue;
+        }
+        gDeferredRing.PushBack(std::move(slot));
+    }
+}
+
+void DeferredUdpSendQueueLwIP::Flush()
+{
+    assertChipStackLockedByCurrentThread();
+
+    DeferredUdpRing pending{};
+    SwapDeferredUdpSendRings(gDeferredRing, pending);
+
+    while (!pending.Empty())
+    {
+        DeferredUdpSlot slot = pending.PopFront();
+
+        // Probe each deferred slot independently. A prior ProbeDefer in SendMsgImpl only covered
+        // the current outgoing pktInfo, while pending entries may target other interfaces/routes.
+        // Also, link/address state can legitimately change between calls.
+        bool ready     = false;
+        err_t probeErr = EndPointStateLwIP::RunOnTCPIPRet([&]() -> err_t {
+            ready = IsOutboundNetifReadyForUdp(slot.pktInfo);
+            return ERR_OK;
+        });
+        if (probeErr != ERR_OK)
+        {
+            ChipLogError(Inet, "DeferredUdpSendQueueLwIP::Flush: RunOnTCPIPRet failed: %d", static_cast<int>(probeErr));
+            gDeferredRing.PushBack(std::move(slot));
+            while (!pending.Empty())
+            {
+                gDeferredRing.PushBack(pending.PopFront());
+            }
+            return;
+        }
+
+        if (!ready)
+        {
+            gDeferredRing.PushBack(std::move(slot));
+            continue;
+        }
+
+        if (!slot.epHandle.IsNull())
+        {
+            auto * impl = static_cast<UDPEndPointImplLwIP *>(slot.epHandle.operator->());
+            (void) impl->FlushOneDeferred(&slot.pktInfo, std::move(slot.msg));
+        }
+    }
+}
+
+} // namespace Inet
+} // namespace chip
+
+#endif // SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY

--- a/src/inet/DeferredUdpSendQueueLwIP.h
+++ b/src/inet/DeferredUdpSendQueueLwIP.h
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2020-2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * Outbound UDP send deferral for LwIP (bounded FIFO, fixed storage).
+ * Keeps queue mechanics out of UDPEndPointImplLwIP.cpp.
+ */
+
+#pragma once
+
+#include <inet/InetConfig.h>
+
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+
+#include <lib/core/CHIPError.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace Inet {
+
+struct IPPacketInfo;
+class UDPEndPointImplLwIP;
+
+class DeferredUdpSendQueueLwIP
+{
+public:
+    /**
+     * If the netif is not ready for this destination, set outShouldDefer true so the send should be
+     * queued. Returns a mapped CHIP error if the TCPIP thread bridge fails.
+     */
+    static CHIP_ERROR ProbeDefer(const IPPacketInfo & pktInfo, bool & outShouldDefer);
+
+    static CHIP_ERROR Enqueue(UDPEndPointImplLwIP * self, const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg);
+
+    static void PurgeForEndpoint(UDPEndPointImplLwIP * self);
+
+    static void Flush();
+};
+
+} // namespace Inet
+} // namespace chip
+
+#endif // SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY

--- a/src/inet/DeferredUdpSendRing.h
+++ b/src/inet/DeferredUdpSendRing.h
@@ -1,0 +1,103 @@
+/*
+ *
+ *    Copyright (c) 2020-2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * Bounded FIFO queue with fixed-capacity storage indexed in a circle.
+ *
+ * This is one data structure, not two: logical behavior is a queue (enqueue at
+ * the back, dequeue from the front). `head` and `count` map that queue onto a
+ * fixed `FixedBuffer` by wrapping indices modulo `Capacity`, which is the
+ * usual ring-buffer indexing trick for a fixed array.
+ *
+ * `PushBack` / `PopFront` are the standard names for enqueue/dequeue at the
+ * two ends of that FIFO. A low-level ring API might expose only head/tail
+ * indices; here we expose the queue operations callers need.
+ *
+ * After `PopFront`, the vacated cell is assigned `Slot{}` so the slot in the
+ * array is empty until reused. That is optional for some `Slot` types once
+ * moved-from, but it keeps array cells in a known state and matches types whose
+ * moved-from state still holds resources until reassigned or destroyed.
+ *
+ * `PopFront` returns `Slot` by value: the returned object is constructed from
+ * the slot contents (move), then returned to the caller (NRVO or move). It is
+ * not a reference into ring storage; the caller owns the returned `Slot`.
+ *
+ * Storage mechanics are in this header so host unit tests can cover them
+ * without LwIP.
+ */
+
+#pragma once
+
+#include <lib/support/FixedBuffer.h>
+
+#include <cstddef>
+#include <utility>
+
+namespace chip {
+namespace Inet {
+
+template <typename Slot, size_t Capacity>
+struct DeferredUdpSendRing
+{
+    static_assert(Capacity > 0, "DeferredUdpSendRing capacity must be > 0");
+
+    chip::FixedBuffer<Slot, Capacity> slots{};
+    size_t head  = 0;
+    size_t count = 0;
+
+    bool Empty() const { return count == 0; }
+    bool IsFull() const { return count == Capacity; }
+    size_t ActiveCount() const { return count; }
+
+    // Enqueue at the logical tail (may drop oldest entry when full).
+    void PushBack(Slot && slot)
+    {
+        if (IsFull())
+        {
+            slots[head] = Slot{};
+            head        = (head + 1) % Capacity;
+            --count;
+        }
+        const size_t idx = (head + count) % Capacity;
+        slots[idx]       = std::move(slot);
+        ++count;
+    }
+
+    // Dequeue from the logical head; returned value is owned by the caller.
+    Slot PopFront()
+    {
+        Slot out    = std::move(slots[head]);
+        slots[head] = Slot{};
+        head        = (head + 1) % Capacity;
+        --count;
+        return out;
+    }
+};
+
+template <typename Slot, size_t Capacity>
+void SwapDeferredUdpSendRings(DeferredUdpSendRing<Slot, Capacity> & a, DeferredUdpSendRing<Slot, Capacity> & b)
+{
+    std::swap(a.head, b.head);
+    std::swap(a.count, b.count);
+    for (size_t i = 0; i < Capacity; ++i)
+    {
+        std::swap(a.slots[i], b.slots[i]);
+    }
+}
+
+} // namespace Inet
+} // namespace chip

--- a/src/inet/EndPointStateLwIP.h
+++ b/src/inet/EndPointStateLwIP.h
@@ -33,11 +33,18 @@ struct tcp_pcb;
 namespace chip {
 namespace Inet {
 
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+class DeferredUdpSendQueueLwIP;
+#endif
+
 /**
  * Definitions shared by all LwIP EndPoint classes.
  */
 class DLL_EXPORT EndPointStateLwIP
 {
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    friend class DeferredUdpSendQueueLwIP;
+#endif
 protected:
     EndPointStateLwIP() : mLwIPEndPointType(LwIPEndPointType::Unknown) {}
 

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -23,6 +23,10 @@
 
 #include <inet/UDPEndPointImplLwIP.h>
 
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#include <inet/DeferredUdpSendQueueLwIP.h>
+#endif
+
 #if INET_CONFIG_ENABLE_IPV4
 #include <lwip/igmp.h>
 #endif // INET_CONFIG_ENABLE_IPV4
@@ -151,7 +155,6 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
     }
 
     CHIP_ERROR res = CHIP_NO_ERROR;
-    err_t lwipErr  = ERR_VAL;
 
     // Make sure we have the appropriate type of PCB based on the destination address.
     res = GetPCB(destAddr.Type());
@@ -159,6 +162,30 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
     {
         return res;
     }
+
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    // Defer if the netif is not ready for this destination; otherwise drain earlier deferrals first.
+    // Flush still re-evaluates readiness per deferred entry because the queue may contain packets for
+    // different interfaces/destinations than pktInfo, and netif state can change between probes.
+    bool shouldDefer         = false;
+    CHIP_ERROR deferProbeErr = DeferredUdpSendQueueLwIP::ProbeDefer(*pktInfo, shouldDefer);
+    VerifyOrReturnError(deferProbeErr == CHIP_NO_ERROR, deferProbeErr);
+    if (shouldDefer)
+    {
+        return DeferredUdpSendQueueLwIP::Enqueue(this, pktInfo, std::move(msg));
+    }
+    DeferredUdpSendQueueLwIP::Flush();
+#endif // SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+
+    return PerformLwIPUdpSend(pktInfo, std::move(msg));
+}
+
+CHIP_ERROR UDPEndPointImplLwIP::PerformLwIPUdpSend(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
+{
+    assertChipStackLockedByCurrentThread();
+
+    err_t lwipErr              = ERR_OK;
+    const IPAddress & destAddr = pktInfo->DestAddress;
 
     // Send the message to the specified address/port.
     // If an outbound interface has been specified, call a specific version of the UDP sendto()
@@ -192,17 +219,46 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
 
     ip_addr_copy(mUDP->local_ip, boundAddr);
 
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    if (lwipErr == ERR_RTE)
+    {
+        ChipLogDetail(Inet, "UDP send deferred (no route yet, ERR_RTE)");
+        return DeferredUdpSendQueueLwIP::Enqueue(this, pktInfo, std::move(msg));
+    }
+#endif // SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+
     if (lwipErr != ERR_OK)
     {
-        res = chip::System::MapErrorLwIP(lwipErr);
+        return chip::System::MapErrorLwIP(lwipErr);
     }
-
-    return res;
+    return CHIP_NO_ERROR;
 }
+
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+CHIP_ERROR UDPEndPointImplLwIP::FlushOneDeferred(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
+{
+    if (mState == State::kClosed || mUDP == nullptr)
+    {
+        return CHIP_NO_ERROR;
+    }
+    return PerformLwIPUdpSend(pktInfo, std::move(msg));
+}
+
+void UDPEndPointImplLwIP::FlushDeferredSendQueue()
+{
+    DeferredUdpSendQueueLwIP::Flush();
+}
+#else
+void UDPEndPointImplLwIP::FlushDeferredSendQueue() {}
+#endif // SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 
 void UDPEndPointImplLwIP::CloseImpl()
 {
     assertChipStackLockedByCurrentThread();
+
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    DeferredUdpSendQueueLwIP::PurgeForEndpoint(this);
+#endif
 
     // Since UDP PCB is released synchronously here, but UDP endpoint itself might have to wait
     // for destruction asynchronously, there could be more allocated UDP endpoints than UDP PCBs.

--- a/src/inet/UDPEndPointImplLwIP.h
+++ b/src/inet/UDPEndPointImplLwIP.h
@@ -30,8 +30,16 @@
 namespace chip {
 namespace Inet {
 
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+class DeferredUdpSendQueueLwIP;
+#endif
+
 class UDPEndPointImplLwIP : public UDPEndPoint, public EndPointStateLwIP
 {
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    friend class DeferredUdpSendQueueLwIP;
+#endif
+
 public:
     UDPEndPointImplLwIP(EndPointManager<UDPEndPoint> & endPointManager) : UDPEndPoint(endPointManager), mUDP(nullptr) {}
 
@@ -54,6 +62,12 @@ public:
      */
     static void SetQueueFilter(EndpointQueueFilter * queueFilter) { sQueueFilter = queueFilter; }
 
+    /**
+     * Drain outbound UDP datagrams deferred while no operational LwIP netif was available.
+     * Must be called on the Matter chip thread. Safe to call when deferral is disabled (no-op).
+     */
+    static void FlushDeferredSendQueue();
+
 private:
     // UDPEndPoint overrides.
 #if INET_CONFIG_ENABLE_IPV4
@@ -65,6 +79,11 @@ private:
     CHIP_ERROR ListenImpl() override;
     CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg) override;
     void CloseImpl() override;
+
+    CHIP_ERROR PerformLwIPUdpSend(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
+#if SL_INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    CHIP_ERROR FlushOneDeferred(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
+#endif
 
     static struct netif * FindNetifFromInterfaceId(InterfaceId aInterfaceId);
     static CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId);

--- a/src/inet/inet.gni
+++ b/src/inet/inet.gni
@@ -24,6 +24,12 @@ declare_args() {
   # Enable UDP endpoint.
   chip_inet_config_enable_udp_endpoint = true
 
+  # [SL-ONLY]: defer outbound UDP until a netif is link-up (DeferredUdpSendQueueLwIP).
+  sl_inet_config_udp_lwip_queue_until_netif_ready = false
+
+  # [SL-ONLY]: queue size for the UDP DeferredUdpSendQueueLwIP
+  sl_inet_config_udp_lwip_deferred_send_queue_size = 0
+
   # Enable TCP endpoint.
   chip_inet_config_enable_tcp_endpoint = true
 

--- a/src/inet/tests/BUILD.gn
+++ b/src/inet/tests/BUILD.gn
@@ -76,6 +76,7 @@ if (chip_build_tests) {
     ]
     test_sources = [
       "TestBasicPacketFilters.cpp",
+      "TestDeferredUdpSendRing.cpp",
       "TestInetAddress.cpp",
       "TestInetErrorStr.cpp",
     ]

--- a/src/inet/tests/TestDeferredUdpSendRing.cpp
+++ b/src/inet/tests/TestDeferredUdpSendRing.cpp
@@ -1,0 +1,151 @@
+/*
+ *
+ *    Copyright (c) 2020-2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * Unit tests for @ref chip::Inet::DeferredUdpSendRing, the FIFO backing
+ * DeferredUdpSendQueueLwIP. LwIP-specific ProbeDefer/Flush behavior is not
+ * covered here.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <inet/DeferredUdpSendRing.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Inet;
+
+struct IntSlot
+{
+    int value = -1;
+    IntSlot() = default;
+    explicit IntSlot(int v) : value(v) {}
+};
+
+using Ring3 = DeferredUdpSendRing<IntSlot, 3>;
+
+TEST(DeferredUdpSendRingTest, StartsEmpty)
+{
+    Ring3 r;
+    EXPECT_TRUE(r.Empty());
+    EXPECT_EQ(r.ActiveCount(), 0u);
+    EXPECT_FALSE(r.IsFull());
+}
+
+TEST(DeferredUdpSendRingTest, PushPopSingle)
+{
+    Ring3 r;
+    r.PushBack(IntSlot{ 42 });
+    EXPECT_FALSE(r.Empty());
+    EXPECT_EQ(r.ActiveCount(), 1u);
+    IntSlot out = r.PopFront();
+    EXPECT_EQ(out.value, 42);
+    EXPECT_TRUE(r.Empty());
+}
+
+// PopFront returns a by-value Slot owned by the caller, not a view into ring
+// storage; it must remain valid after later ring operations.
+TEST(DeferredUdpSendRingTest, PopFrontReturnSurvivesLaterRingUse)
+{
+    Ring3 r;
+    r.PushBack(IntSlot{ 5 });
+    IntSlot first = r.PopFront();
+    r.PushBack(IntSlot{ 6 });
+    EXPECT_EQ(first.value, 5);
+    EXPECT_EQ(r.PopFront().value, 6);
+    EXPECT_TRUE(r.Empty());
+}
+
+TEST(DeferredUdpSendRingTest, FifoOrderUpToCapacity)
+{
+    Ring3 r;
+    r.PushBack(IntSlot{ 1 });
+    r.PushBack(IntSlot{ 2 });
+    r.PushBack(IntSlot{ 3 });
+    EXPECT_TRUE(r.IsFull());
+    EXPECT_EQ(r.ActiveCount(), 3u);
+    EXPECT_EQ(r.PopFront().value, 1);
+    EXPECT_EQ(r.PopFront().value, 2);
+    EXPECT_EQ(r.PopFront().value, 3);
+    EXPECT_TRUE(r.Empty());
+}
+
+TEST(DeferredUdpSendRingTest, OverflowDropsOldest)
+{
+    Ring3 r;
+    r.PushBack(IntSlot{ 1 });
+    r.PushBack(IntSlot{ 2 });
+    r.PushBack(IntSlot{ 3 });
+    r.PushBack(IntSlot{ 4 });
+    EXPECT_TRUE(r.IsFull());
+    EXPECT_EQ(r.ActiveCount(), 3u);
+    EXPECT_EQ(r.PopFront().value, 2);
+    EXPECT_EQ(r.PopFront().value, 3);
+    EXPECT_EQ(r.PopFront().value, 4);
+    EXPECT_TRUE(r.Empty());
+}
+
+TEST(DeferredUdpSendRingTest, RepeatedOverflowKeepsFifo)
+{
+    Ring3 r;
+    for (int i = 0; i < 10; ++i)
+    {
+        r.PushBack(IntSlot{ i });
+    }
+    EXPECT_EQ(r.ActiveCount(), 3u);
+    EXPECT_EQ(r.PopFront().value, 7);
+    EXPECT_EQ(r.PopFront().value, 8);
+    EXPECT_EQ(r.PopFront().value, 9);
+}
+
+TEST(DeferredUdpSendRingTest, SwapExchangesRings)
+{
+    Ring3 a;
+    Ring3 b;
+    a.PushBack(IntSlot{ 1 });
+    a.PushBack(IntSlot{ 2 });
+    b.PushBack(IntSlot{ 9 });
+
+    SwapDeferredUdpSendRings(a, b);
+
+    EXPECT_EQ(a.ActiveCount(), 1u);
+    EXPECT_EQ(b.ActiveCount(), 2u);
+    EXPECT_EQ(a.PopFront().value, 9);
+    EXPECT_EQ(b.PopFront().value, 1);
+    EXPECT_EQ(b.PopFront().value, 2);
+}
+
+TEST(DeferredUdpSendRingTest, SwapEmptyWithFull)
+{
+    Ring3 a;
+    Ring3 b;
+    b.PushBack(IntSlot{ 10 });
+    b.PushBack(IntSlot{ 11 });
+    b.PushBack(IntSlot{ 12 });
+
+    SwapDeferredUdpSendRings(a, b);
+
+    EXPECT_TRUE(b.Empty());
+    EXPECT_EQ(a.ActiveCount(), 3u);
+    EXPECT_EQ(a.PopFront().value, 10);
+    EXPECT_EQ(a.PopFront().value, 11);
+    EXPECT_EQ(a.PopFront().value, 12);
+    EXPECT_TRUE(a.Empty());
+}
+
+} // namespace


### PR DESCRIPTION
### Summary
For the LIT device we are trying to disconnect from the AP and reconnect when we want to send any attribute update or while reporting data of subscription.
For the reporting data, that will be on the idle mode duration we can connect a bit early i.e., a part of different PR. but while posting attribute change the matter stack sends the packet unaware about the low layer transport is offline.

To fix this, we are buffering the packets on the LwIP layer and flushing them once we are reconnected.
This have CSA code modification of the UDPEndpointLwIPImpl.cpp and .h files but it won't affect/conflicts in the future since the changes are moved a different file all together.

Unit test is added for the Queue impl to ensure we don't see any issues


Cherry-pick for the PR: https://github.com/SiliconLabsSoftware/matter_sdk/pull/929

### Related issues
NA

### Testing
Tested with 917SoC