### PR TITLE
[SL-ONLY] [SL-UP] Add WifiSleepManager and WifiInterface changes for LIT Wifi sleepy device

### DIFF
--- a/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
+++ b/examples/platform/silabs/wifi/icd/ApplicationSleepManager.cpp
@@ -134,13 +134,13 @@ bool ApplicationSleepManager::ProcessVendorIdExceptions(chip::VendorId vendorId)
 void ApplicationSleepManager::OnEnterActiveMode()
 {
     mIsInActiveMode = true;
-    TEMPORARY_RETURN_IGNORED mWifiSleepManager->VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kGenericEvent);
+    TEMPORARY_RETURN_IGNORED mWifiSleepManager->VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kActiveMode);
 }
 
 void ApplicationSleepManager::OnEnterIdleMode()
 {
     mIsInActiveMode = false;
-    TEMPORARY_RETURN_IGNORED mWifiSleepManager->VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kGenericEvent);
+    TEMPORARY_RETURN_IGNORED mWifiSleepManager->VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kIdleMode);
 }
 
 void ApplicationSleepManager::OnTransitionToIdle()

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -31,6 +31,10 @@
 #include <app/icd/server/ICDServerConfig.h>
 #include <cmsis_os2.h>
 #include <inet/IPAddress.h>
+#include <inet/InetConfig.h>
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+#include <inet/UDPEndPointImplLwIP.h>
+#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -539,6 +543,7 @@ CHIP_ERROR WifiInterfaceImpl::InitWiFiStack(void)
     // Create the message queue
     sWifiEventQueue = osMessageQueueNew(kWfxQueueSize, sizeof(WifiPlatformEvent), nullptr);
     VerifyOrReturnError(sWifiEventQueue != nullptr, CHIP_ERROR_NO_MEMORY);
+
 #ifndef SL_MBEDTLS_USE_TINYCRYPT
     // PSA Crypto initialization
     VerifyOrReturnError(psa_crypto_init() == PSA_SUCCESS, CHIP_ERROR_INTERNAL,
@@ -561,17 +566,7 @@ void WifiInterfaceImpl::ProcessEvent(WifiPlatformEvent event)
     case WifiPlatformEvent::kStationDisconnect: {
         ChipLogDetail(DeviceLayer, "WifiPlatformEvent::kStationDisconnect");
         TriggerPlatformWifiDisconnection();
-
-        wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationReady)
-            .Clear(WifiInterface::WifiState::kStationConnecting)
-            .Clear(WifiInterface::WifiState::kStationConnected);
-
-        // TODO: Implement disconnect notify
-        ResetConnectivityNotificationFlags();
-#if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
-        NotifyIPv4Change(false);
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
-        NotifyIPv6Change(false);
+        ClearWifiDisconnectedState();
     }
     break;
 
@@ -586,6 +581,10 @@ void WifiInterfaceImpl::ProcessEvent(WifiPlatformEvent event)
         TEMPORARY_RETURN_IGNORED chip::DeviceLayer::Silabs::WifiSleepManager::GetInstance().RequestHighPerformanceWithTransition();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
         InitiateScan();
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+        // Remove High performance request that might have been added during the connect/retry process
+        TEMPORARY_RETURN_IGNORED chip::DeviceLayer::Silabs::WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
         PostWifiPlatformEvent(WifiPlatformEvent::kStationStartJoin);
         break;
 
@@ -617,6 +616,17 @@ void WifiInterfaceImpl::NotifySuccessfulConnection(void)
     ChipLogProgress(DeviceLayer, "SLAAC OK: linklocal addr: %s", addrStr);
     NotifyIPv6Change(true);
     NotifyConnectivity();
+
+#if INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
+    {
+        CHIP_ERROR flushErr =
+            chip::DeviceLayer::SystemLayer().ScheduleLambda([]() { chip::Inet::UDPEndPointImplLwIP::FlushDeferredSendQueue(); });
+        if (flushErr != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "ScheduleLambda(FlushDeferredSendQueue) failed: %" CHIP_ERROR_FORMAT, flushErr.Format());
+        }
+    }
+#endif // INET_CONFIG_UDP_LWIP_QUEUE_UNTIL_NETIF_READY
 }
 
 sl_status_t WifiInterfaceImpl::JoinWifiNetwork(void)
@@ -652,11 +662,6 @@ sl_status_t WifiInterfaceImpl::JoinWifiNetwork(void)
 
     if (status == SL_STATUS_OK)
     {
-#if CHIP_CONFIG_ENABLE_ICD_SERVER
-        // Remove High performance request that might have been added during the connect/retry process
-        TEMPORARY_RETURN_IGNORED chip::DeviceLayer::Silabs::WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
-#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
-
         WifiPlatformEvent event = WifiPlatformEvent::kStationConnect;
         PostWifiPlatformEvent(event);
         return status;
@@ -805,7 +810,93 @@ sl_status_t WifiInterfaceImpl::TriggerPlatformWifiDisconnection()
     return SL_STATUS_OK;
 }
 
+void WifiInterfaceImpl::ClearWifiDisconnectedState()
+{
+    wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationReady)
+        .Clear(WifiInterface::WifiState::kStationConnecting)
+        .Clear(WifiInterface::WifiState::kStationConnected);
+
+    ResetConnectivityNotificationFlags();
+#if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
+    NotifyIPv4Change(false);
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
+    NotifyIPv6Change(false);
+}
+
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+namespace {
+osTimerId_t sLitPrecheckInReconnectTimer       = nullptr;
+constexpr uint32_t kLitPrecheckInMarginSeconds = 10;
+
+void OnLitPrecheckInReconnectOsTimer(void *)
+{
+    WifiInterfaceImpl & self = WifiInterfaceImpl::GetInstance();
+    VerifyOrReturn(self.IsWifiProvisioned() && !self.IsStationConnected());
+
+    ChipLogProgress(DeviceLayer, "LIT precheck-in: reconnecting Wi-Fi before ICD traffic");
+    VerifyOrReturn(self.ConfigureLITConnect() == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "LIT precheck-in reconnect failed"));
+}
+} // namespace
+
+CHIP_ERROR WifiInterfaceImpl::InitLitPrecheckInReconnectTimer()
+{
+    VerifyOrReturnError(sLitPrecheckInReconnectTimer == nullptr, CHIP_NO_ERROR);
+
+    sLitPrecheckInReconnectTimer = osTimerNew(OnLitPrecheckInReconnectOsTimer, osTimerOnce, nullptr, nullptr);
+    VerifyOrReturnError(sLitPrecheckInReconnectTimer != nullptr, CHIP_ERROR_INTERNAL,
+                        ChipLogDetail(DeviceLayer, "LIT precheck-in osTimerNew failed"));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WifiInterfaceImpl::ConfigureLITConnect()
+{
+    ResetConnectionRetryInterval();
+
+    VerifyOrReturnError(IsWifiProvisioned(), CHIP_NO_ERROR);
+
+    VerifyOrReturnError(!IsStationConnected(), CHIP_NO_ERROR);
+
+    if (!wfx_rsi.dev_state.Has(WifiInterface::WifiState::kStationConnecting))
+    {
+        return ConnectToAccessPoint();
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WifiInterfaceImpl::ConfigureLITDisconnect()
+{
+    CancelConnectionAttempt();
+    wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnected);
+    TriggerPlatformWifiDisconnection();
+    return CHIP_NO_ERROR;
+}
+
+void WifiInterfaceImpl::CancelLitPrecheckInReconnectTimer()
+{
+    VerifyOrReturn(sLitPrecheckInReconnectTimer != nullptr);
+    (void) osTimerStop(sLitPrecheckInReconnectTimer);
+}
+
+void WifiInterfaceImpl::StartLitPrecheckInReconnectTimer()
+{
+    VerifyOrReturn(sLitPrecheckInReconnectTimer != nullptr);
+    const uint32_t idleSec            = chip::ICDConfigurationData::GetInstance().GetModeBasedIdleModeDuration().count();
+    const uint32_t activeThresholdSec = chip::ICDConfigurationData::GetInstance().GetActiveModeThreshold().count() / 1000;
+    const uint32_t delaySec =
+        (idleSec > kLitPrecheckInMarginSeconds) ? (idleSec - activeThresholdSec - kLitPrecheckInMarginSeconds) : 1u;
+    const uint32_t delayMs = delaySec * 1000u;
+
+    (void) osTimerStop(sLitPrecheckInReconnectTimer);
+    if (osTimerStart(sLitPrecheckInReconnectTimer, pdMS_TO_TICKS(delayMs)) != osOK)
+    {
+        ChipLogDetail(DeviceLayer, "LIT precheck-in osTimerStart failed (delay ms=%u)", static_cast<unsigned>(delayMs));
+    }
+}
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+
 CHIP_ERROR WifiInterfaceImpl::ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration configuration, uint32_t listenInterval)
 {
     // Power save configuration is already set, nothing to do

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.h
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.h
@@ -74,8 +74,16 @@ public:
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     CHIP_ERROR ConfigureBroadcastFilter(bool enableBroadcastFilter) override;
     CHIP_ERROR ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration configuration, uint32_t listenInterval) override;
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+    CHIP_ERROR ConfigureLITConnect() override;
+    CHIP_ERROR ConfigureLITDisconnect() override;
+    void CancelLitPrecheckInReconnectTimer() override;
+    void StartLitPrecheckInReconnectTimer() override;
+    CHIP_ERROR InitLitPrecheckInReconnectTimer() override;
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
+public:
     /**
      * @brief Processes the wifi platform events for the SiWx platform
      *
@@ -91,6 +99,9 @@ protected:
      *                     SL_STATUS_FAILURE, otherwise
      */
     sl_status_t TriggerPlatformWifiDisconnection();
+
+    /** Software state after link down (used by kStationDisconnect and by synchronous disconnect paths). */
+    void ClearWifiDisconnectedState();
     /**
      * @brief Posts an event to the Wi-Fi task
      *
@@ -155,7 +166,6 @@ private:
 
     bool mHasNotifiedWifiConnectivity = false;
     bool mUseQuickJoin                = false;
-
     static WifiInterfaceImpl mInstance;
 };
 

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -129,7 +129,7 @@ void WifiInterface::NotifyWifiTaskInitialized(void)
     // TODO: We should move this to the init function and not the notification function
     // Creating a timer which will be used to retry connection with AP
     mRetryTimer = osTimerNew(RetryConnectionTimerHandler, osTimerOnce, NULL, NULL);
-    VerifyOrReturn(mRetryTimer != NULL);
+    VerifyOrReturn(mRetryTimer != nullptr);
 
     evt.header.id     = to_underlying(WifiEvent::kStartUp);
     evt.header.length = sizeof evt;
@@ -165,19 +165,20 @@ void WifiInterface::ScheduleConnectionAttempt()
             ChipLogError(DeviceLayer, "ConnectToAccessPoint() failed.");
         }
 
-#if CHIP_CONFIG_ENABLE_ICD_SERVER
-        //  Remove High performance request before giving up due to a timer start error to save battery life
-        TEMPORARY_RETURN_IGNORED Silabs::WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
-#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
         return;
     }
 
-#if CHIP_CONFIG_ENABLE_ICD_SERVER
-    TEMPORARY_RETURN_IGNORED Silabs::WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
-#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
-
     ChipLogProgress(DeviceLayer, "ScheduleConnectionAttempt : Next attempt after %d Seconds", retryInterval);
     retryInterval += retryInterval;
+}
+
+void WifiInterface::CancelConnectionAttempt()
+{
+    if (osTimerIsRunning(mRetryTimer))
+    {
+        osTimerStop(mRetryTimer);
+        mRetryTimer = nullptr;
+    }
 }
 
 void WifiInterface::ResetConnectionRetryInterval()

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -177,7 +177,6 @@ void WifiInterface::CancelConnectionAttempt()
     if (osTimerIsRunning(mRetryTimer))
     {
         osTimerStop(mRetryTimer);
-        mRetryTimer = nullptr;
     }
 }
 

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -390,6 +390,11 @@ protected:
      */
     void ScheduleConnectionAttempt();
 
+    /**
+     * @brief Function cancels the on-going reconnection attempts
+     */
+    void CancelConnectionAttempt();
+
     bool mHasNotifiedIPv6 = false;
 #if CHIP_DEVICE_CONFIG_ENABLE_IPV4
     bool mHasNotifiedIPv4 = false;

--- a/src/platform/silabs/wifi/icd/PowerSaveInterface.h
+++ b/src/platform/silabs/wifi/icd/PowerSaveInterface.h
@@ -68,6 +68,37 @@ public:
      */
     virtual CHIP_ERROR ConfigureBroadcastFilter(bool enableBroadcastFilter) { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
 
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+
+    /**
+     * @brief Reconnect after Long Idle Time (LIT) sleep disconnect (ICD active mode / reporting window).
+     *        Platform implementations start join without periodic backoff used for unintended disconnects.
+     */
+    virtual CHIP_ERROR ConfigureLITConnect() { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+
+    /**
+     * @brief Intentional STA disconnect for LIT disconnect sleep (CHIP_CONFIG_ENABLE_ICD_LIT).
+     *        Suppresses automatic reconnect until ConfigureLITConnect(); disconnect is processed on the Wi-Fi task.
+     */
+    virtual CHIP_ERROR ConfigureLITDisconnect() { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+
+    /**
+     * @brief Stops the LIT precheck-in reconnect timer (e.g. when entering active mode before LIT connect).
+     */
+    virtual void CancelLitPrecheckInReconnectTimer() {}
+
+    /**
+     * @brief Schedules Wi-Fi reconnect before the ICD traffic window after LIT disconnect sleep is configured.
+     */
+    virtual void StartLitPrecheckInReconnectTimer() {}
+
+    /**
+     * @brief Creates OS resources for LIT precheck-in reconnect scheduling. Called during WifiSleepManager::Init.
+     *
+     * @return CHIP_NO_ERROR on success, CHIP_ERROR_INTERNAL if timer creation fails.
+     */
+    virtual CHIP_ERROR InitLitPrecheckInReconnectTimer() { return CHIP_NO_ERROR; }
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
 protected:
     // Default power save configuration is High Performance as the device starts in high power mode and low power modes need to be
     // explicitly configured

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -36,7 +36,25 @@ CHIP_ERROR WifiSleepManager::Init(PowerSaveInterface * platformInterface, WifiSt
     mPowerSaveInterface = platformInterface;
     mWifiStateProvider  = wifiStateProvider;
 
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+    ReturnErrorOnFailure(mPowerSaveInterface->InitLitPrecheckInReconnectTimer());
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+
     return VerifyAndTransitionToLowPowerMode(PowerEvent::kGenericEvent);
+}
+
+void WifiSleepManager::HandleCommissioningSessionStarted()
+{
+    VerifyOrReturn(!mIsCommissioningInProgress);
+    mIsCommissioningInProgress = true;
+    TEMPORARY_RETURN_IGNORED WifiSleepManager::GetInstance().RequestHighPerformanceWithTransition();
+}
+
+void WifiSleepManager::HandleCommissioningSessionStopped()
+{
+    VerifyOrReturn(mIsCommissioningInProgress);
+    mIsCommissioningInProgress = false;
+    TEMPORARY_RETURN_IGNORED WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
 }
 
 CHIP_ERROR WifiSleepManager::RequestHighPerformance(bool triggerTransition)
@@ -74,15 +92,18 @@ CHIP_ERROR WifiSleepManager::HandlePowerEvent(PowerEvent event)
     {
     case PowerEvent::kCommissioningComplete:
         ChipLogProgress(AppServer, "WifiSleepManager: Handling Commissioning Complete Event");
-        mIsCommissioningInProgress = false;
 
         // TODO: Remove High Performance Req during commissioning when sleep issues are resolved
-        TEMPORARY_RETURN_IGNORED WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
+        HandleCommissioningSessionStopped();
         break;
 
     case PowerEvent::kConnectivityChange:
     case PowerEvent::kGenericEvent:
-        // No additional processing needed for these events at the moment
+    case PowerEvent::kActiveMode:
+        mActiveMode = true;
+        break;
+    case PowerEvent::kIdleMode:
+        mActiveMode = false;
         break;
 
     default:
@@ -99,6 +120,14 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode(PowerEvent event)
     VerifyOrDieWithMsg(mPowerSaveInterface != nullptr, DeviceLayer, "PowerSaveInterface is not initialized");
 
     ReturnErrorOnFailure(HandlePowerEvent(event));
+
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+    if (event == PowerEvent::kActiveMode)
+    {
+        mPowerSaveInterface->CancelLitPrecheckInReconnectTimer();
+        ReturnErrorOnFailure(ConfigureLITConnect());
+    }
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
 
     if (mHighPerformanceRequestCounter > 0)
     {
@@ -119,7 +148,14 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode(PowerEvent event)
 
     if (mCallback && mCallback->CanGoToLIBasedSleep())
     {
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+        if (!mActiveMode)
+        {
+            return ConfigureLITDisconnect();
+        }
+#else  // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
         return ConfigureLIBasedSleep();
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
     }
 
     return ConfigureDTIMBasedSleep();
@@ -166,6 +202,26 @@ CHIP_ERROR WifiSleepManager::ConfigureLIBasedSleep()
 
     return CHIP_NO_ERROR;
 }
+
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+CHIP_ERROR WifiSleepManager::ConfigureLITDisconnect()
+{
+    ReturnLogErrorOnFailure(mPowerSaveInterface->ConfigureLITDisconnect());
+    ReturnLogErrorOnFailure(mPowerSaveInterface->ConfigureBroadcastFilter(true));
+    ReturnLogErrorOnFailure(
+        mPowerSaveInterface->ConfigurePowerSave(PowerSaveInterface::PowerSaveConfiguration::kDeepSleep,
+                                                chip::ICDConfigurationData::GetInstance().GetSlowPollingInterval().count()));
+
+    mPowerSaveInterface->StartLitPrecheckInReconnectTimer();
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WifiSleepManager::ConfigureLITConnect()
+{
+    ReturnErrorOnFailure(mPowerSaveInterface->ConfigureLITConnect());
+    return CHIP_NO_ERROR;
+}
+#endif
 
 } // namespace Silabs
 } // namespace DeviceLayer

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -99,6 +99,8 @@ CHIP_ERROR WifiSleepManager::HandlePowerEvent(PowerEvent event)
 
     case PowerEvent::kConnectivityChange:
     case PowerEvent::kGenericEvent:
+        // Preserve mActiveMode; HP cycles and connectivity use these events.
+        break;
     case PowerEvent::kActiveMode:
         mActiveMode = true;
         break;

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.h
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.h
@@ -42,6 +42,8 @@ public:
         kGenericEvent          = 0,
         kCommissioningComplete = 1,
         kConnectivityChange    = 2,
+        kActiveMode            = 3,
+        kIdleMode              = 4,
     };
 
     /**
@@ -57,8 +59,8 @@ public:
          * @brief Function informs the WifiSleepManager in which Low Power mode the device can go to.
          *        The two supported sleep modes are DTIM based sleep and LI based sleep.
          *
-         *        When the function is called, the WifiSleepManager is about to go to sleep and using this function to make decision
-         *        as too wether it can go LI based sleep, lowest power mode, or DTIM based sleep.
+         *        When the function is called, the WifiSleepManager is about to go to sleep and uses this to choose LI sleep
+         *        (or LIT disconnect sleep when CHIP_CONFIG_ENABLE_ICD_LIT is enabled) versus DTIM based sleep.
          *
          *        DTIM based sleep requires the Wi-Fi devices to be synced with the DTIM beacon.
          *        In this mode, the broadcast filter is disabled and the device will process multicast and
@@ -89,29 +91,8 @@ public:
      */
     CHIP_ERROR Init(PowerSaveInterface * platformInterface, WifiStateProvider * wifiStateProvider);
 
-    inline void HandleCommissioningSessionStarted()
-    {
-        bool wasCommissioningInProgress = mIsCommissioningInProgress;
-        mIsCommissioningInProgress      = true;
-
-        if (!wasCommissioningInProgress)
-        {
-            // TODO: Remove High Performance Req during commissioning when sleep issues are resolved
-            TEMPORARY_RETURN_IGNORED WifiSleepManager::GetInstance().RequestHighPerformanceWithTransition();
-        }
-    }
-
-    inline void HandleCommissioningSessionStopped()
-    {
-        bool wasCommissioningInProgress = mIsCommissioningInProgress;
-        mIsCommissioningInProgress      = false;
-
-        if (wasCommissioningInProgress)
-        {
-            // TODO: Remove High Performance Req during commissioning when sleep issues are resolved
-            TEMPORARY_RETURN_IGNORED WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
-        }
-    }
+    void HandleCommissioningSessionStarted();
+    void HandleCommissioningSessionStopped();
 
     /**
      * @brief Set the Application Callback
@@ -171,7 +152,7 @@ public:
      *        1. If there are high performance requests, configure high performance mode.
      *        2. If commissioning is in progress, configure DTIM based sleep.
      *        3. If no commissioning is in progress and the device is unprovisioned, configure deep sleep.
-     *        4. If the application callback allows, configure LI based sleep; otherwise, configure DTIM based sleep.
+     *        4. If the application callback allows, configure LI sleep or LIT disconnect sleep (GN); otherwise, DTIM based sleep.
      *
      * @param event PowerEvent triggering the Verify and transition to low power mode processing
      *
@@ -231,6 +212,15 @@ private:
      */
     CHIP_ERROR ConfigureLIBasedSleep();
 
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+    /**
+     * @brief LIT path: intentional STA disconnect only (see PowerSaveInterface::ConfigureLITDisconnect).
+     */
+    CHIP_ERROR ConfigureLITDisconnect();
+
+    CHIP_ERROR ConfigureLITConnect();
+    #endif // CHIP_CONFIG_ENABLE_ICD_LIT
+
     /**
      * @brief Increments the HighPerformance request counter and triggers the transition to High Performance if requested.
      *
@@ -248,6 +238,7 @@ private:
     WifiStateProvider * mWifiStateProvider   = nullptr;
     bool mIsCommissioningInProgress          = false;
     uint8_t mHighPerformanceRequestCounter   = 0;
+    bool mActiveMode                         = false;
 
     ApplicationCallback * mCallback = nullptr;
 };

--- a/src/platform/silabs/wifi/icd/tests/TestWifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/tests/TestWifiSleepManager.cpp
@@ -33,6 +33,13 @@ public:
         mConfigureBroadcastFilterCalled = false;
         mIsWifiProvisioned              = false;
         mBroadcastFilterEnabled         = false;
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+        mConfigureLITConnectCalled    = false;
+        mConfigureLITDisconnectCalled = false;
+        mCancelLitPrecheckInTimerCalled = false;
+        mStartLitPrecheckInTimerCalled  = false;
+        mInitLitPrecheckInTimerCalled = false;
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
     }
 
     // Getters to check if methods were called
@@ -57,6 +64,43 @@ public:
         return wasEnabled;
     }
 
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+    bool WasConfigureLITConnectCalled()
+    {
+        bool wasCalled             = mConfigureLITConnectCalled;
+        mConfigureLITConnectCalled = false;
+        return wasCalled;
+    }
+
+    bool WasConfigureLITDisconnectCalled()
+    {
+        bool wasCalled                = mConfigureLITDisconnectCalled;
+        mConfigureLITDisconnectCalled = false;
+        return wasCalled;
+    }
+
+    bool WasCancelLitPrecheckTimerCalled()
+    {
+        bool wasCalled                  = mCancelLitPrecheckInTimerCalled;
+        mCancelLitPrecheckInTimerCalled = false;
+        return wasCalled;
+    }
+
+    bool WasStartLitPrecheckTimerCalled()
+    {
+        bool wasCalled                 = mStartLitPrecheckInTimerCalled;
+        mStartLitPrecheckInTimerCalled = false;
+        return wasCalled;
+    }
+
+    bool WasInitLitPrecheckInTimerCalled()
+    {
+        bool wasCalled                = mInitLitPrecheckInTimerCalled;
+        mInitLitPrecheckInTimerCalled = false;
+        return wasCalled;
+    }
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+
     PowerSaveConfiguration GetLastPowerSaveConfiguration() const { return mLastPowerSaveConfiguration; }
 
     // Setter for IsWifiProvisioned
@@ -76,6 +120,30 @@ public:
         return CHIP_NO_ERROR;
     }
 
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+    CHIP_ERROR ConfigureLITConnect() override
+    {
+        mConfigureLITConnectCalled = true;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR ConfigureLITDisconnect() override
+    {
+        mConfigureLITDisconnectCalled = true;
+        return CHIP_NO_ERROR;
+    }
+
+    void CancelLitPrecheckInReconnectTimer() override { mCancelLitPrecheckInTimerCalled = true; }
+
+    void StartLitPrecheckInReconnectTimer() override { mStartLitPrecheckInTimerCalled = true; }
+
+    CHIP_ERROR InitLitPrecheckInReconnectTimer() override
+    {
+        mInitLitPrecheckInTimerCalled = true;
+        return CHIP_NO_ERROR;
+    }
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+
     bool IsWifiProvisioned() override { return mIsWifiProvisioned; }
 
     bool IsStationConnected() override { return false; }
@@ -90,6 +158,19 @@ private:
     bool mBroadcastFilterEnabled         = false;
     PowerSaveConfiguration mLastPowerSaveConfiguration;
     bool mIsWifiProvisioned = false;
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+    bool mConfigureLITConnectCalled    = false;
+    bool mConfigureLITDisconnectCalled = false;
+    bool mCancelLitPrecheckInTimerCalled = false;
+    bool mStartLitPrecheckInTimerCalled  = false;
+    bool mInitLitPrecheckInTimerCalled = false;
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+};
+
+class AlwaysLiSleepCallback : public WifiSleepManager::ApplicationCallback
+{
+public:
+    bool CanGoToLIBasedSleep() override { return true; }
 };
 
 } // namespace
@@ -102,10 +183,21 @@ protected:
         EXPECT_EQ(WifiSleepManager::GetInstance().Init(&mMock, &mMock), CHIP_NO_ERROR);
         EXPECT_TRUE(mMock.WasConfigurePowerSaveCalled());
         EXPECT_EQ(mMock.GetLastPowerSaveConfiguration(), PowerSaveInterface::PowerSaveConfiguration::kDeepSleep);
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+        EXPECT_TRUE(mMock.WasInitLitPrecheckInTimerCalled());
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
     }
-    void TearDown() { mMock.Reset(); }
+    void TearDown()
+    {
+        WifiSleepManager::GetInstance().SetApplicationCallback(nullptr);
+        mMock.Reset();
+    }
 
     static TestMock mMock;
+
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+    AlwaysLiSleepCallback mLiSleepCallback;
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
 };
 
 TestMock TestWifiSleepManager::mMock;
@@ -114,14 +206,16 @@ TEST_F(TestWifiSleepManager, TestInitFailureNullPowerSaveInterface)
 {
     TestMock mock;
     EXPECT_EQ(WifiSleepManager::GetInstance().Init(nullptr, &mock), CHIP_ERROR_INVALID_ARGUMENT);
-    EXPECT_FALSE(mMock.WasConfigurePowerSaveCalled());
+    EXPECT_FALSE(mock.WasConfigurePowerSaveCalled());
+    ASSERT_EQ(WifiSleepManager::GetInstance().Init(&mMock, &mMock), CHIP_NO_ERROR);
 }
 
 TEST_F(TestWifiSleepManager, TestInitFailureNullWifiStateProvider)
 {
     TestMock mock;
     EXPECT_EQ(WifiSleepManager::GetInstance().Init(&mock, nullptr), CHIP_ERROR_INVALID_ARGUMENT);
-    EXPECT_FALSE(mMock.WasConfigurePowerSaveCalled());
+    EXPECT_FALSE(mock.WasConfigurePowerSaveCalled());
+    ASSERT_EQ(WifiSleepManager::GetInstance().Init(&mMock, &mMock), CHIP_NO_ERROR);
 }
 
 TEST_F(TestWifiSleepManager, TestRequestHighPerformanceMaxCounter)
@@ -212,3 +306,38 @@ TEST_F(TestWifiSleepManager, TestRequestHighPerformanceWithoutProvisioning)
     EXPECT_EQ(WifiSleepManager::GetInstance().RequestHighPerformanceWithoutTransition(), CHIP_NO_ERROR);
     EXPECT_EQ(mMock.GetLastPowerSaveConfiguration(), config);
 }
+
+#if defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)
+
+TEST_F(TestWifiSleepManager, TestLitIdleModeSelectsLITDisconnectWhenCallbackAllowsLiSleep)
+{
+    mMock.SetIsWifiProvisioned(true);
+    WifiSleepManager::GetInstance().SetApplicationCallback(&mLiSleepCallback);
+
+    EXPECT_EQ(WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kIdleMode),
+              CHIP_NO_ERROR);
+
+    EXPECT_TRUE(mMock.WasConfigureLITDisconnectCalled());
+    EXPECT_TRUE(mMock.WasConfigureBroadcastFilterCalled());
+    EXPECT_TRUE(mMock.WasBroadcastFilterEnabled());
+    EXPECT_EQ(mMock.GetLastPowerSaveConfiguration(), PowerSaveInterface::PowerSaveConfiguration::kDeepSleep);
+    EXPECT_TRUE(mMock.WasConfigurePowerSaveCalled());
+    EXPECT_TRUE(mMock.WasStartLitPrecheckTimerCalled());
+}
+
+TEST_F(TestWifiSleepManager, TestLitActiveModeRunsLITConnectThenDTIMWhenProvisioned)
+{
+    mMock.SetIsWifiProvisioned(true);
+    WifiSleepManager::GetInstance().SetApplicationCallback(&mLiSleepCallback);
+
+    EXPECT_EQ(WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kActiveMode),
+              CHIP_NO_ERROR);
+
+    EXPECT_TRUE(mMock.WasCancelLitPrecheckTimerCalled());
+    EXPECT_TRUE(mMock.WasConfigureLITConnectCalled());
+    EXPECT_EQ(mMock.GetLastPowerSaveConfiguration(), PowerSaveInterface::PowerSaveConfiguration::kConnectedSleep);
+    EXPECT_TRUE(mMock.WasConfigureBroadcastFilterCalled());
+    EXPECT_FALSE(mMock.WasBroadcastFilterEnabled());
+}
+
+#endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)

--- a/src/platform/silabs/wifi/icd/tests/TestWifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/tests/TestWifiSleepManager.cpp
@@ -340,4 +340,23 @@ TEST_F(TestWifiSleepManager, TestLitActiveModeRunsLITConnectThenDTIMWhenProvisio
     EXPECT_FALSE(mMock.WasBroadcastFilterEnabled());
 }
 
+TEST_F(TestWifiSleepManager, TestLitIdleModePreservedAcrossHighPerformanceCycle)
+{
+    mMock.SetIsWifiProvisioned(true);
+    WifiSleepManager::GetInstance().SetApplicationCallback(&mLiSleepCallback);
+
+    EXPECT_EQ(WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kIdleMode),
+              CHIP_NO_ERROR);
+    EXPECT_TRUE(mMock.WasConfigureLITDisconnectCalled());
+    EXPECT_EQ(mMock.GetLastPowerSaveConfiguration(), PowerSaveInterface::PowerSaveConfiguration::kDeepSleep);
+
+    // HP request/remove uses kGenericEvent; that must not flip mActiveMode to true.
+    EXPECT_EQ(WifiSleepManager::GetInstance().RequestHighPerformanceWithTransition(), CHIP_NO_ERROR);
+    EXPECT_EQ(mMock.GetLastPowerSaveConfiguration(), PowerSaveInterface::PowerSaveConfiguration::kHighPerformance);
+
+    EXPECT_EQ(WifiSleepManager::GetInstance().RemoveHighPerformanceRequest(), CHIP_NO_ERROR);
+    EXPECT_TRUE(mMock.WasConfigureLITDisconnectCalled());
+    EXPECT_EQ(mMock.GetLastPowerSaveConfiguration(), PowerSaveInterface::PowerSaveConfiguration::kDeepSleep);
+}
+
 #endif // defined(CHIP_CONFIG_ENABLE_ICD_LIT) && (CHIP_CONFIG_ENABLE_ICD_LIT == 1)


### PR DESCRIPTION
### Summary
This pull request implements Silicon Labs Wi-Fi ICD sleep handling for Long Idle Time (LIT) when CHIP_CONFIG_ENABLE_ICD_LIT is enabled. It uses the ICD active vs idle into WifiSleepManager so the stack can choose LIT disconnect sleep (intentional STA disconnect) during idle windows, while active mode brings Wi-Fi back for Matter/ICD traffic.

It also includes a pre-check timer which is used to ensure that our device joins back before sending the ICD traffic, giving a buffer of 10sec, since sometimes WPA3 join takes around 8sec to connect.

Using the LwIP buffering PR: https://github.com/SiliconLabsSoftware/matter_sdk/pull/1114
for the attribute update or if the device is not connected back buffering the packets and flushing it once the device re-connects to the AP.

Cherry-pick of the PR: https://github.com/SiliconLabsSoftware/matter_sdk/pull/928

### Related issues
NA

### Testing
Tested with the 917SoC, LIT sleep is working as expected with subscriptions