### PR TITLE
[SL-ONLY] Adding the backport to the release_2.10-1.6.1 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -60,6 +60,18 @@ pull_request_rules:
               labels:
                   - backport-v1.6.1-branch
 
+    - name: Backport to release_2.10-1.6.1
+      conditions:
+          - merged
+          - base=main
+          - label="request-backport-release_2.10-1.6.1"
+      actions:
+          backport:
+              branches:
+                  - release_2.10-1.6.1
+              labels:
+                  - backport-release_2.10-1.6.1
+
     - name: Backport to v1.6.1-mve-branch
       conditions:
           - merged
@@ -127,6 +139,7 @@ pull_request_rules:
       conditions:
           - or:
                 - label="backport-v1.6.1-branch"
+                - label="backport-release_2.10-1.6.1"
                 - label="backport-v1.6-branch"
                 - label="backport-v1.5-branch"
                 - label="backport-v1.4.2-branch"


### PR DESCRIPTION
### Summary
Adds Mergify support to cherry-pick merged main PRs onto the Silabs release_2.10-1.6.1 branch.

### Related issues
NA

### Testing
Manual verification of the .mergify.yml structure.