### PR TITLE
[SL-ONLY] MATTER-6651: Validate APIs in CI (#1087)

### DIFF
--- a/.github/silabs-apis.yaml
+++ b/.github/silabs-apis.yaml
@@ -1,0 +1,405 @@
+# CI validation baseline for Silabs APIs.
+# When adding/changing an API, update this file and the Confluence page.
+# https://confluence.silabs.com/spaces/MATTER/pages/873669145/CRTP+Override+APIs+by+App
+apps:
+  air-quality-sensor-app:
+    classes:
+      AppTask:
+        header: examples/air-quality-sensor-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: InitAirQualitySensor
+          signature: CHIP_ERROR InitAirQualitySensor()
+        - name: GetAirQualityValue
+          signature: CHIP_ERROR GetAirQualityValue(int32_t &air_quality)
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: SensorTimerEventHandler
+          signature: static void SensorTimerEventHandler(void *arg)
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+  base-platform-app:
+    classes:
+      AppTask:
+        header: examples/base-platform-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: ApplicationEventHandler
+          signature: static void ApplicationEventHandler(AppEvent *aEvent)
+        - name: OnEnterActiveMode
+          signature: void OnEnterActiveMode()override
+          ifdef: CHIP_CONFIG_ENABLE_ICD_SERVER
+        - name: OnEnterIdleMode
+          signature: void OnEnterIdleMode()override
+          ifdef: CHIP_CONFIG_ENABLE_ICD_SERVER
+        - name: OnTransitionToIdle
+          signature: void OnTransitionToIdle()override
+          ifdef: CHIP_CONFIG_ENABLE_ICD_SERVER
+        - name: OnICDModeChange
+          signature: void OnICDModeChange()override
+          ifdef: CHIP_CONFIG_ENABLE_ICD_SERVER
+  closure-app:
+    classes:
+      AppTask:
+        header: examples/closure-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: ClosureButtonActionEventHandler
+          signature: static void ClosureButtonActionEventHandler(AppEvent *aEvent)
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+        - name: DMClosureControlClusterAttributeChangedCallback
+          signature: void DMClosureControlClusterAttributeChangedCallback(const chip::app::ConcreteAttributePath &attributePath)
+        - name: DMClosureDimensionClusterAttributeChangedCallback
+          signature: void DMClosureDimensionClusterAttributeChangedCallback(const chip::app::ConcreteAttributePath &attributePath)
+      ClosureManager:
+        header: examples/closure-app/silabs/include/ClosureManagerImpl.h
+        apis:
+        - name: Init
+          signature: void Init()override
+        - name: OnCalibrateCommand
+          signature: chip::Protocols::InteractionModel::Status OnCalibrateCommand()override
+        - name: OnMoveToCommand
+          signature: chip::Protocols::InteractionModel::Status OnMoveToCommand(const chip::Optional<chip::app::Clusters::ClosureControl::TargetPositionEnum>position,
+            const chip::Optional<bool>latch, const chip::Optional<chip::app::Clusters::Globals::ThreeLevelAutoEnum>speed)override
+        - name: OnStopCommand
+          signature: chip::Protocols::InteractionModel::Status OnStopCommand()override
+        - name: OnSetTargetCommand
+          signature: chip::Protocols::InteractionModel::Status OnSetTargetCommand(const chip::Optional<chip::Percent100ths>&position,
+            const chip::Optional<bool>&latch, const chip::Optional<chip::app::Clusters::Globals::ThreeLevelAutoEnum>&speed,
+            const chip::EndpointId endpointId)override
+        - name: OnStepCommand
+          signature: chip::Protocols::InteractionModel::Status OnStepCommand(const chip::app::Clusters::ClosureDimension::StepDirectionEnum
+            &direction, const uint16_t &numberOfSteps, const chip::Optional<chip::app::Clusters::Globals::ThreeLevelAutoEnum>&speed,
+            const chip::EndpointId &endpointId)override
+        - name: HandleClosureActionComplete
+          signature: void HandleClosureActionComplete(Action_t action)
+        - name: HandleClosureMotionAction
+          signature: void HandleClosureMotionAction()
+        - name: HandleClosureUnlatchAction
+          signature: void HandleClosureUnlatchAction()
+        - name: GetPanelNextPosition
+          signature: bool GetPanelNextPosition(const chip::app::Clusters::ClosureDimension::GenericDimensionStateStruct &currentState,
+            const chip::app::Clusters::ClosureDimension::GenericDimensionStateStruct &targetState, chip::app::DataModel::Nullable<chip::Percent100ths>&nextPosition)
+        - name: HandlePanelSetTargetAction
+          signature: void HandlePanelSetTargetAction(chip::EndpointId endpointId)
+        - name: HandlePanelUnlatchAction
+          signature: void HandlePanelUnlatchAction(chip::EndpointId endpointId)
+        - name: HandlePanelStepAction
+          signature: void HandlePanelStepAction(chip::EndpointId endpointId)
+  evse-app:
+    classes:
+      AppTask:
+        header: examples/evse-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: ApplicationInit
+          signature: void ApplicationInit()
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: EnergyManagementActionEventHandler
+          signature: static void EnergyManagementActionEventHandler(AppEvent *aEvent)
+  fan-control-app:
+    classes:
+      AppTask:
+        header: examples/fan-control-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: InitFanControl
+          signature: CHIP_ERROR InitFanControl()
+        - name: HandleStep
+          signature: Status HandleStep(StepDirectionEnum aDirection, bool aWrap, bool aLowestOff)override
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: FanUiUpdateEventHandler
+          signature: static void FanUiUpdateEventHandler(AppEvent *aEvent)
+        - name: HandleFanModeChange
+          signature: void HandleFanModeChange(FanModeEnum aNewFanMode)
+        - name: HandlePercentSettingChange
+          signature: void HandlePercentSettingChange(uint8_t aNewPercentSetting)
+        - name: HandleSpeedSettingChange
+          signature: void HandleSpeedSettingChange(uint8_t aNewSpeedSetting)
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+  light-switch-app:
+    classes:
+      AppTask:
+        header: examples/light-switch-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: InitLightSwitch
+          signature: CHIP_ERROR InitLightSwitch(chip::EndpointId lightSwitchEndpoint, chip::EndpointId genericSwitchEndpoint)
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: AppEventHandler
+          signature: static void AppEventHandler(AppEvent *aEvent)
+        - name: InitBindingHandler
+          signature: static void InitBindingHandler(intptr_t arg)
+        - name: LightSwitchChangedHandler
+          signature: static void LightSwitchChangedHandler(const chip::app::Clusters::Binding::TableEntry &binding, chip::OperationalDeviceProxy
+            *peer_device, void *context)
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+  lighting-app:
+    classes:
+      AppTask:
+        header: examples/lighting-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: InitLight
+          signature: CHIP_ERROR InitLight()
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: OnTriggerOffWithEffect
+          signature: static void OnTriggerOffWithEffect(OnOffEffect *effect)
+        - name: LightActionEventHandler
+          signature: static void LightActionEventHandler(AppEvent *aEvent)
+        - name: LightTimerEventHandler
+          signature: static void LightTimerEventHandler(void *timerCbArg)
+        - name: LightControlEventHandler
+          signature: static void LightControlEventHandler(AppEvent *aEvent)
+          ifdef: SL_MATTER_RGB_LED_ENABLED
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+  lock-app:
+    classes:
+      AppTask:
+        header: examples/lock-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: InitLock
+          signature: CHIP_ERROR InitLock()
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: LockButtonActionHandler
+          signature: static void LockButtonActionHandler(AppEvent *aEvent)
+        - name: UnlatchCallback
+          signature: static void UnlatchCallback(void *argument)
+        - name: ActuatorMovementEventHandler
+          signature: static void ActuatorMovementEventHandler(AppEvent *aEvent)
+        - name: LockActionEventHandler
+          signature: static void LockActionEventHandler(AppEvent *aEvent)
+        - name: LockRequestEventHandler
+          signature: static void LockRequestEventHandler(AppEvent *aEvent)
+        - name: HandleLockRequestOnAppTask
+          signature: void HandleLockRequestOnAppTask(const AppTask::LockRequest &request)
+        - name: UnlockAfterUnlatch
+          signature: static void UnlockAfterUnlatch(intptr_t context)
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+        - name: DMDoorLockOnDoorLockCommand
+          signature: bool DMDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const chip::app::DataModel::Nullable<chip::FabricIndex>&fabricIdx,
+            const chip::app::DataModel::Nullable<chip::NodeId>&nodeId, const chip::Optional<chip::ByteSpan>&pinCode, chip::app::Clusters::DoorLock::OperationErrorEnum
+            &err)
+        - name: DMDoorLockOnDoorUnlockCommand
+          signature: bool DMDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const chip::app::DataModel::Nullable<chip::FabricIndex>&fabricIdx,
+            const chip::app::DataModel::Nullable<chip::NodeId>&nodeId, const chip::Optional<chip::ByteSpan>&pinCode, chip::app::Clusters::DoorLock::OperationErrorEnum
+            &err)
+        - name: DMDoorLockOnDoorUnboltCommand
+          signature: bool DMDoorLockOnDoorUnboltCommand(chip::EndpointId endpointId, const chip::app::DataModel::Nullable<chip::FabricIndex>&fabricIdx,
+            const chip::app::DataModel::Nullable<chip::NodeId>&nodeId, const chip::Optional<chip::ByteSpan>&pinCode, chip::app::Clusters::DoorLock::OperationErrorEnum
+            &err)
+        - name: DMDoorLockGetCredential
+          signature: bool DMDoorLockGetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, CredentialTypeEnum
+            credentialType, EmberAfPluginDoorLockCredentialInfo &credential)
+        - name: DMDoorLockSetCredential
+          signature: bool DMDoorLockSetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, chip::FabricIndex
+            creator, chip::FabricIndex modifier, DlCredentialStatus credentialStatus, CredentialTypeEnum credentialType, const
+            chip::ByteSpan &credentialData)
+        - name: DMDoorLockGetUser
+          signature: bool DMDoorLockGetUser(chip::EndpointId endpointId, uint16_t userIndex, EmberAfPluginDoorLockUserInfo
+            &user)
+        - name: DMDoorLockSetUser
+          signature: bool DMDoorLockSetUser(chip::EndpointId endpointId, uint16_t userIndex, chip::FabricIndex creator, chip::FabricIndex
+            modifier, const chip::CharSpan &userName, uint32_t uniqueId, UserStatusEnum userStatus, UserTypeEnum usertype,
+            CredentialRuleEnum credentialRule, const CredentialStruct *credentials, size_t totalCredentials)
+        - name: DMDoorLockGetWeekDaySchedule
+          signature: DlStatus DMDoorLockGetWeekDaySchedule(chip::EndpointId endpointId, uint8_t weekdayIndex, uint16_t userIndex,
+            EmberAfPluginDoorLockWeekDaySchedule &schedule)
+        - name: DMDoorLockSetWeekDaySchedule
+          signature: DlStatus DMDoorLockSetWeekDaySchedule(chip::EndpointId endpointId, uint8_t weekdayIndex, uint16_t userIndex,
+            DlScheduleStatus status, DaysMaskMap daysMask, uint8_t startHour, uint8_t startMinute, uint8_t endHour, uint8_t
+            endMinute)
+        - name: DMDoorLockGetYearDaySchedule
+          signature: DlStatus DMDoorLockGetYearDaySchedule(chip::EndpointId endpointId, uint8_t yearDayIndex, uint16_t userIndex,
+            EmberAfPluginDoorLockYearDaySchedule &schedule)
+        - name: DMDoorLockSetYearDaySchedule
+          signature: DlStatus DMDoorLockSetYearDaySchedule(chip::EndpointId endpointId, uint8_t yearDayIndex, uint16_t userIndex,
+            DlScheduleStatus status, uint32_t localStartTime, uint32_t localEndTime)
+        - name: DMDoorLockGetHolidaySchedule
+          signature: DlStatus DMDoorLockGetHolidaySchedule(chip::EndpointId endpointId, uint8_t holidayIndex, EmberAfPluginDoorLockHolidaySchedule
+            &holidaySchedule)
+        - name: DMDoorLockSetHolidaySchedule
+          signature: DlStatus DMDoorLockSetHolidaySchedule(chip::EndpointId endpointId, uint8_t holidayIndex, DlScheduleStatus
+            status, uint32_t localStartTime, uint32_t localEndTime, OperatingModeEnum operatingMode)
+        - name: DMDoorLockOnAutoRelock
+          signature: void DMDoorLockOnAutoRelock(chip::EndpointId endpointId)
+  multi-sensor-app:
+    classes:
+      AppTask:
+        header: examples/multi-sensor-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: InitSensorManager
+          signature: CHIP_ERROR InitSensorManager()
+        - name: GetTemperatureAndHumidity
+          signature: CHIP_ERROR GetTemperatureAndHumidity(int16_t &temperature, uint16_t &humidity)
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: ProcessButtonEvent
+          signature: static void ProcessButtonEvent(AppEvent *aEvent)
+        - name: TriggerSensorAction
+          signature: static void TriggerSensorAction(chip::System::Layer *aLayer, void *aAppState)
+        - name: OccupancyAttributeUpdateEvent
+          signature: static void OccupancyAttributeUpdateEvent(AppEvent *aEvent)
+        - name: SensorAttributeUpdateEvent
+          signature: static void SensorAttributeUpdateEvent(AppEvent *aEvent)
+        - name: OnAttributeChanged
+          signature: void OnAttributeChanged(const chip::app::ConcreteAttributePath &path, chip::app::DataModel::AttributeChangeType
+            type)override
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+  onoff-plug-app:
+    classes:
+      AppTask:
+        header: examples/onoff-plug-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: InitPlug
+          signature: CHIP_ERROR InitPlug()
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: OnOffActionEventHandler
+          signature: static void OnOffActionEventHandler(AppEvent *aEvent)
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+  oven-app:
+    classes:
+      AppTask:
+        header: examples/oven-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: OvenButtonHandler
+          signature: static void OvenButtonHandler(AppEvent *aEvent)
+        - name: OvenActionHandler
+          signature: static void OvenActionHandler(AppEvent *aEvent)
+        - name: ConnectivityEventHandler
+          signature: static void ConnectivityEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg)
+        - name: InitBindingHandler
+          signature: static void InitBindingHandler(intptr_t arg)
+        - name: CookTopBindingPropagateState
+          signature: static void CookTopBindingPropagateState(chip::EndpointId cookTopEndpoint, bool cookTopOn)
+        - name: BoundDeviceChangedHandler
+          signature: static void BoundDeviceChangedHandler(const chip::app::Clusters::Binding::TableEntry &binding, chip::OperationalDeviceProxy
+            *peerDevice, void *context)
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+        - name: OnAttributeChanged
+          signature: void OnAttributeChanged(const chip::app::ConcreteAttributePath &path, chip::app::DataModel::AttributeChangeType
+            type)override
+        - name: DMOvenModeClusterInitCallback
+          signature: void DMOvenModeClusterInitCallback(chip::EndpointId endpointId)
+        - name: DMOvenModeClusterShutdownCallback
+          signature: void DMOvenModeClusterShutdownCallback(chip::EndpointId endpointId, MatterClusterShutdownType shutdownType)
+        - name: InitOven
+          signature: CHIP_ERROR InitOven()
+        - name: OnOffAttributeChangeHandler
+          signature: void OnOffAttributeChangeHandler(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t
+            *value, uint16_t size)
+        - name: IsTransitionBlocked
+          signature: bool IsTransitionBlocked(uint8_t fromMode, uint8_t toMode)override
+  rangehood-app:
+    classes:
+      AppTask:
+        header: examples/rangehood-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: InitRangeHood
+          signature: CHIP_ERROR InitRangeHood()
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: ActionTriggerHandler
+          signature: static void ActionTriggerHandler(AppEvent *aEvent)
+        - name: FanControlButtonHandler
+          signature: static void FanControlButtonHandler(AppEvent *aEvent)
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+  refrigerator-app:
+    classes:
+      AppTask:
+        header: examples/refrigerator-app/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: InitRefrigerator
+          signature: CHIP_ERROR InitRefrigerator()
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+        - name: CabinetModeClusterInit
+          signature: void CabinetModeClusterInit(chip::EndpointId endpointId)
+        - name: Init
+          signature: CHIP_ERROR Init()override
+        - name: HandleChangeToMode
+          signature: void HandleChangeToMode(uint8_t newMode, chip::app::Clusters::ModeBase::Commands::ChangeToModeResponse::Type
+            &response)override
+        - name: GetModeLabelByIndex
+          signature: CHIP_ERROR GetModeLabelByIndex(uint8_t modeIndex, chip::MutableCharSpan &label)override
+        - name: GetModeValueByIndex
+          signature: CHIP_ERROR GetModeValueByIndex(uint8_t modeIndex, uint8_t &value)override
+        - name: GetModeTagsByIndex
+          signature: CHIP_ERROR GetModeTagsByIndex(uint8_t modeIndex, chip::app::DataModel::List<chip::app::Clusters::detail::Structs::ModeTagStruct::Type>&tags)override
+  thermostat:
+    classes:
+      AppTask:
+        header: examples/thermostat/silabs/include/AppTaskImpl.h
+        apis:
+        - name: AppInit
+          signature: CHIP_ERROR AppInit()override
+        - name: InitThermostat
+          signature: CHIP_ERROR InitThermostat()
+        - name: InitSensor
+          signature: CHIP_ERROR InitSensor()
+        - name: GetTemperature
+          signature: CHIP_ERROR GetTemperature(int16_t &temperature)
+        - name: ButtonEventHandler
+          signature: static void ButtonEventHandler(uint8_t button, uint8_t btnAction)
+        - name: SensorTimerEventHandler
+          signature: static void SensorTimerEventHandler(void *arg)
+        - name: TemperatureUpdateEventHandler
+          signature: static void TemperatureUpdateEventHandler(AppEvent *aEvent)
+        - name: DMPostAttributeChangeCallback
+          signature: void DMPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+            uint16_t size, uint8_t *value)
+        - name: DMThermostatClusterInit
+          signature: void DMThermostatClusterInit(chip::EndpointId endpoint)

--- a/.github/workflows/silabs-validate-apis.yaml
+++ b/.github/workflows/silabs-validate-apis.yaml
@@ -1,0 +1,35 @@
+name: Validate Silabs APIs
+
+on:
+    pull_request:
+        branches:
+            - main
+            - "release_*"
+        paths:
+            - "examples/*/silabs/include/*Impl.h"
+            - ".github/silabs-apis.yaml"
+            - "scripts/tools/silabs/validate_apis.py"
+    workflow_dispatch:
+
+concurrency:
+    group: silabs-validate-apis-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    validate-apis:
+        name: Validate APIs
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+
+            - name: Set up Python
+              uses: actions/setup-python@v7
+              with:
+                  python-version: "3.11"
+
+            - name: Install dependencies
+              run: python -m pip install pyyaml
+
+            - name: Validate APIs against manifest
+              run: python3 scripts/tools/silabs/validate_apis.py

--- a/.github/workflows/silabs-validate-apis.yaml
+++ b/.github/workflows/silabs-validate-apis.yaml
@@ -15,6 +15,9 @@ concurrency:
     group: silabs-validate-apis-${{ github.ref }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     validate-apis:
         name: Validate APIs

--- a/scripts/tools/silabs/validate_apis.py
+++ b/scripts/tools/silabs/validate_apis.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""@brief Validate Silabs APIs against a committed manifest.
+
+Parses public APIs from AppTaskImpl.h (and ClosureManagerImpl.h
+for closure app) and compares API names and signatures to .github/silabs-apis.yaml.
+Fails when headers and manifest drift (missing, extra, or changed APIs).
+
+Use --bootstrap once to regenerate the manifest from current headers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import yaml
+
+DEFAULT_MANIFEST = ".github/silabs-apis.yaml"
+MANIFEST_HEADER_COMMENT = (
+    "# CI validation baseline for Silabs APIs.\n"
+    "# When adding/changing an API, update this file and the Confluence page.\n"
+    "# https://confluence.silabs.com/spaces/MATTER/pages/873669145/CRTP+Override+APIs+by+App\n"
+)
+
+
+@dataclass(frozen=True)
+class ApiEntry:
+    name: str
+    signature: str
+    ifdef: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ClassConfig:
+    header: str
+    apis: Tuple[ApiEntry, ...]
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    classes: Dict[str, ClassConfig]
+
+
+@dataclass(frozen=True)
+class ParsedApi:
+    name: str
+    signature: str
+    ifdef: Optional[str] = None
+
+
+def strip_comments(text: str) -> str:
+    result: List[str] = []
+    i = 0
+    while i < len(text):
+        if text[i: i + 2] == "//":
+            while i < len(text) and text[i] != "\n":
+                i += 1
+        elif text[i: i + 2] == "/*":
+            end = text.find("*/", i + 2)
+            if end < 0:
+                break
+            i = end + 2
+        else:
+            result.append(text[i])
+            i += 1
+    return "".join(result)
+
+
+def collapse_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def normalize_signature(signature: str) -> str:
+    signature = collapse_whitespace(signature)
+    signature = re.sub(r"\)\s*override\b", ") override", signature)
+    signature = re.sub(r"\boverride\s*const\b", "override const", signature)
+    signature = re.sub(r"\s*\*\s*", " *", signature)
+    signature = re.sub(r"\s*&\s*", " &", signature)
+    signature = re.sub(r">\s*([A-Za-z_])", r"> \1", signature)
+    signature = re.sub(r",\s*([A-Za-z_])", r", \1", signature)
+    signature = re.sub(r"\s*<\s*", "<", signature)
+    signature = re.sub(r"\s*>\s*", ">", signature)
+    signature = re.sub(r"\s*,\s*", ", ", signature)
+    signature = re.sub(r"\s*\(\s*", "(", signature)
+    signature = re.sub(r"\s*\)\s*", ")", signature)
+    return signature
+
+
+def remove_brace_bodies(text: str) -> str:
+    result: List[str] = []
+    i = 0
+    while i < len(text):
+        if text[i] == "{":
+            depth = 1
+            i += 1
+            while i < len(text) and depth > 0:
+                if text[i] == "{":
+                    depth += 1
+                elif text[i] == "}":
+                    depth -= 1
+                i += 1
+            result.append(";")
+        else:
+            result.append(text[i])
+            i += 1
+    return "".join(result)
+
+
+def extract_access_section(text: str, access: str) -> str:
+    pattern = re.compile(rf"\b{access}\s*:")
+    match = pattern.search(text)
+    if not match:
+        return ""
+    start = match.end()
+    next_access = re.search(r"\b(public|private|protected)\s*:", text[start:])
+    if next_access:
+        return text[start: start + next_access.start()]
+    return text[start:]
+
+
+def ifdef_macro_from_directive(directive: str) -> Optional[str]:
+    directive = collapse_whitespace(directive)
+    defined_match = re.search(r"defined\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)", directive)
+    if defined_match:
+        return defined_match.group(1)
+    simple_match = re.match(r"([A-Za-z_][A-Za-z0-9_]*)", directive)
+    if simple_match:
+        return simple_match.group(1)
+    return None
+
+
+def split_preprocessor_sections(text: str) -> List[Tuple[Optional[str], str]]:
+    sections: List[Tuple[Optional[str], str]] = []
+    ifdef_stack: List[Optional[str]] = [None]
+    current: List[str] = []
+    lines = text.splitlines(keepends=True)
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if stripped.startswith("#ifdef "):
+            if current:
+                sections.append((ifdef_stack[-1], "".join(current)))
+                current = []
+            directive = stripped[7:].strip()
+            ifdef_stack.append(ifdef_macro_from_directive(directive))
+        elif stripped.startswith("#ifndef "):
+            if current:
+                sections.append((ifdef_stack[-1], "".join(current)))
+                current = []
+            directive = stripped[8:].strip()
+            ifdef_stack.append(ifdef_macro_from_directive(directive))
+        elif stripped.startswith("#if"):
+            if current:
+                sections.append((ifdef_stack[-1], "".join(current)))
+                current = []
+            directive = stripped[3:].strip()
+            ifdef_stack.append(ifdef_macro_from_directive(directive))
+        elif stripped.startswith("#endif"):
+            if current:
+                sections.append((ifdef_stack[-1], "".join(current)))
+                current = []
+            if len(ifdef_stack) > 1:
+                ifdef_stack.pop()
+        else:
+            current.append(line)
+        i += 1
+    if current:
+        sections.append((ifdef_stack[-1], "".join(current)))
+    return sections
+
+
+def find_matching_paren(text: str, open_index: int) -> int:
+    depth = 0
+    for i in range(open_index, len(text)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+    return -1
+
+
+def parse_method_declaration(decl: str) -> Optional[ParsedApi]:
+    decl = collapse_whitespace(decl.strip().rstrip(";"))
+    if not decl or decl.startswith("#"):
+        return None
+
+    is_static = False
+    if decl.startswith("static "):
+        is_static = True
+        decl = decl[len("static "):]
+
+    paren_index = decl.find("(")
+    if paren_index < 0:
+        return None
+    close_index = find_matching_paren(decl, paren_index)
+    if close_index < 0:
+        return None
+
+    before_paren = decl[:paren_index].strip()
+    name_match = re.search(r"([A-Za-z_][A-Za-z0-9_]*)\s*$", before_paren)
+    if not name_match:
+        return None
+    name = name_match.group(1)
+    return_type = before_paren[: name_match.start()].strip()
+    params = decl[paren_index: close_index + 1]
+    trailing = decl[close_index + 1:].strip()
+    trailing = re.sub(r"\boverride\b", "override", trailing)
+    trailing = re.sub(r"\bconst\b", "const", trailing)
+    trailing = collapse_whitespace(trailing)
+
+    signature_parts = []
+    if is_static:
+        signature_parts.append("static")
+    signature_parts.append(f"{return_type} {name}{params}")
+    if trailing:
+        signature_parts.append(trailing)
+    signature = normalize_signature(" ".join(signature_parts))
+    return ParsedApi(name=name, signature=signature)
+
+
+def extract_methods_from_section(section_text: str, active_ifdef: Optional[str]) -> List[ParsedApi]:
+    cleaned = strip_comments(section_text)
+    without_bodies = remove_brace_bodies(cleaned)
+    declarations = [part.strip() for part in without_bodies.split(";") if part.strip()]
+    methods: List[ParsedApi] = []
+    for decl in declarations:
+        parsed = parse_method_declaration(decl)
+        if parsed is None:
+            continue
+        methods.append(ParsedApi(name=parsed.name, signature=parsed.signature, ifdef=active_ifdef))
+    return methods
+
+
+def parse_impl_header(path: Path) -> List[ParsedApi]:
+    text = path.read_text(encoding="utf-8")
+    public_section = extract_access_section(text, "public")
+    if not public_section:
+        return []
+
+    public_section_no_comments = strip_comments(public_section)
+    methods: List[ParsedApi] = []
+    for ifdef, block in split_preprocessor_sections(public_section_no_comments):
+        methods.extend(extract_methods_from_section(block, ifdef))
+    return methods
+
+
+def app_name_from_header(header_path: str) -> str:
+    parts = Path(header_path).parts
+    examples_index = parts.index("examples")
+    return parts[examples_index + 1]
+
+
+def discover_impl_headers(repo_root: Path) -> Dict[str, Dict[str, str]]:
+    apps: Dict[str, Dict[str, str]] = {}
+    pattern = str(repo_root / "examples" / "*" / "silabs" / "include" / "AppTaskImpl.h")
+    for header in sorted(glob.glob(pattern)):
+        rel_header = os.path.relpath(header, repo_root)
+        app = app_name_from_header(rel_header)
+        apps.setdefault(app, {})["AppTask"] = rel_header
+
+    closure_manager = repo_root / "examples" / "closure-app" / "silabs" / "include" / "ClosureManagerImpl.h"
+    if closure_manager.is_file():
+        rel_header = os.path.relpath(closure_manager, repo_root)
+        apps.setdefault("closure-app", {})["ClosureManager"] = rel_header
+    return apps
+
+
+def load_manifest(path: Path) -> Dict[str, AppConfig]:
+    with path.open(encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+
+    apps: Dict[str, AppConfig] = {}
+    for app_name, app_data in (data.get("apps") or {}).items():
+        classes: Dict[str, ClassConfig] = {}
+        for class_name, class_data in (app_data.get("classes") or {}).items():
+            apis = tuple(
+                ApiEntry(
+                    name=api["name"],
+                    signature=api["signature"],
+                    ifdef=api.get("ifdef"),
+                )
+                for api in class_data.get("apis", [])
+            )
+            classes[class_name] = ClassConfig(header=class_data["header"], apis=apis)
+        apps[app_name] = AppConfig(classes=classes)
+    return apps
+
+
+def manifest_to_dict(apps: Dict[str, AppConfig]) -> dict:
+    manifest_apps = {}
+    for app_name in sorted(apps):
+        classes = {}
+        for class_name in sorted(apps[app_name].classes):
+            class_config = apps[app_name].classes[class_name]
+            apis = []
+            for api in class_config.apis:
+                entry = {"name": api.name, "signature": api.signature}
+                if api.ifdef:
+                    entry["ifdef"] = api.ifdef
+                apis.append(entry)
+            classes[class_name] = {"header": class_config.header, "apis": apis}
+        manifest_apps[app_name] = {"classes": classes}
+    return {"apps": manifest_apps}
+
+
+def write_manifest(path: Path, apps: Dict[str, AppConfig]) -> None:
+    content = MANIFEST_HEADER_COMMENT + yaml.safe_dump(
+        manifest_to_dict(apps),
+        sort_keys=False,
+        default_flow_style=False,
+        width=120,
+    )
+    path.write_text(content, encoding="utf-8")
+
+
+def bootstrap_manifest(repo_root: Path, manifest_path: Path) -> Dict[str, AppConfig]:
+    discovered = discover_impl_headers(repo_root)
+    apps: Dict[str, AppConfig] = {}
+    for app_name in sorted(discovered):
+        classes: Dict[str, ClassConfig] = {}
+        for class_name in sorted(discovered[app_name]):
+            header = discovered[app_name][class_name]
+            header_path = repo_root / header
+            parsed = parse_impl_header(header_path)
+            apis = tuple(
+                ApiEntry(name=api.name, signature=api.signature, ifdef=api.ifdef)
+                for api in parsed
+            )
+            classes[class_name] = ClassConfig(header=header, apis=apis)
+        apps[app_name] = AppConfig(classes=classes)
+    write_manifest(manifest_path, apps)
+    return apps
+
+
+def compare_apis(
+    header_path: str,
+    expected: Tuple[ApiEntry, ...],
+    actual: List[ParsedApi],
+) -> List[str]:
+    errors: List[str] = []
+    actual_by_name = {api.name: api for api in actual}
+    expected_names = {api.name for api in expected}
+
+    for api in expected:
+        if api.name not in actual_by_name:
+            errors.append(f"{header_path}: missing API '{api.name}' from header")
+            continue
+        actual_api = actual_by_name[api.name]
+        if normalize_signature(api.signature) != normalize_signature(actual_api.signature):
+            errors.append(
+                f"{header_path}: signature mismatch for '{api.name}':\n"
+                f"  manifest: {api.signature}\n"
+                f"  header:   {actual_api.signature}"
+            )
+        if api.ifdef and actual_api.ifdef and api.ifdef != actual_api.ifdef:
+            errors.append(
+                f"{header_path}: ifdef mismatch for '{api.name}': "
+                f"manifest={api.ifdef}, header={actual_api.ifdef}"
+            )
+
+    for api in actual:
+        if api.name not in expected_names:
+            errors.append(
+                f"{header_path}: unexpected API '{api.name}' not listed in manifest "
+                f"(signature: {api.signature})"
+            )
+    return errors
+
+
+def validate_manifest(repo_root: Path, manifest_path: Path) -> List[str]:
+    errors: List[str] = []
+    if not manifest_path.is_file():
+        return [f"Manifest not found: {manifest_path}"]
+
+    manifest = load_manifest(manifest_path)
+    discovered = discover_impl_headers(repo_root)
+
+    for app_name in sorted(discovered):
+        if app_name not in manifest:
+            errors.append(f"App '{app_name}' has AppTaskImpl.h but is missing from manifest")
+            continue
+        for class_name, header in sorted(discovered[app_name].items()):
+            if class_name not in manifest[app_name].classes:
+                errors.append(f"App '{app_name}' class '{class_name}' missing from manifest")
+                continue
+            class_config = manifest[app_name].classes[class_name]
+            if class_config.header != header:
+                errors.append(
+                    f"App '{app_name}' class '{class_name}': manifest header "
+                    f"'{class_config.header}' != discovered '{header}'"
+                )
+            header_path = repo_root / header
+            if not header_path.is_file():
+                errors.append(f"Header not found: {header}")
+                continue
+            actual = parse_impl_header(header_path)
+            errors.extend(compare_apis(header, class_config.apis, actual))
+
+    for app_name in sorted(manifest):
+        if app_name not in discovered:
+            errors.append(f"Manifest app '{app_name}' has no discovered AppTaskImpl.h")
+
+    return errors
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--bootstrap",
+        action="store_true",
+        help="Generate manifest from current headers (initial setup only)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[3]
+    manifest = (repo_root / DEFAULT_MANIFEST).resolve()
+
+    if args.bootstrap:
+        bootstrap_manifest(repo_root, manifest)
+        print(f"Wrote manifest to {manifest}")
+        return 0
+
+    errors = validate_manifest(repo_root, manifest)
+    if errors:
+        print("API validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("API validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**TODO**
CI will fail until all app refactor upstream complete 
disable manually in github UI, re-enable once all apps are merged

### Summary
cherry-pick of https://github.com/SiliconLabsSoftware/matter_sdk/pull/1087

Add CI validation for CRTP APIs so API contract changes require explicit manifest update in the same PR. 

Add the following files:
- `silabs-crtp-apis.yaml`
   - manifest file holding each apps public APIs and signatures
   - used to map against AppTaskImpl.h APIs in `validate_crtp_apis.py`
   - generated using `--bootstrap` arg on first setup
   - CI will fail if this is not updated along with API updates
- `silabs-validate-apis.yaml`
   - CI workflow to run API validation check
   - calls `validate_crtp_apis.py`
   - runs on PRs that touch `*Impl.h`
- `validate_crtp_apis.py`
   - script to compare `AppTaskImpl.h` (and `ClosureManager`) APIs against manifest file
   - parses public methods from `AppTaskImpl.h` (and `ClosureManagerImpl.h`)
   - compares these against methods in the manifest file 
   - fails on missing, extra, or mismatch API signature


### Related issues
MATTER-6651

### Testing
locally test script against:
- adding new api that is not in manifest
- deleting api that exists in manifest
- changing method signature compared to manifest

temporary testing of each of the above in CI as well
https://github.com/SiliconLabsSoftware/matter_sdk/actions/runs/29934630457/job/88972898365
