### PR TITLE
[SL-ONLY] Fan control cascading updates fix (#1081)

### DIFF
--- a/.github/silabs-apis.yaml
+++ b/.github/silabs-apis.yaml
@@ -126,6 +126,8 @@ apps:
           signature: static void FanUiUpdateEventHandler(AppEvent *aEvent)
         - name: HandleFanModeChange
           signature: void HandleFanModeChange(FanModeEnum aNewFanMode)
+        - name: DeriveFanModeFromPercent
+          signature: FanModeEnum DeriveFanModeFromPercent(Percent percent)
         - name: HandlePercentSettingChange
           signature: void HandlePercentSettingChange(uint8_t aNewPercentSetting)
         - name: HandleSpeedSettingChange

--- a/examples/fan-control-app/silabs/include/AppTask.h
+++ b/examples/fan-control-app/silabs/include/AppTask.h
@@ -39,6 +39,7 @@ public:
     // Bring frequently-used cluster types into class scope. Available to derived classes
     // (e.g. AppTaskImpl, CustomerAppTask) without re-qualification.
     using FanModeEnum       = chip::app::Clusters::FanControl::FanModeEnum;
+    using Percent           = chip::Percent;
     using StepDirectionEnum = chip::app::Clusters::FanControl::StepDirectionEnum;
     using Status            = chip::Protocols::InteractionModel::Status;
 
@@ -103,20 +104,55 @@ public:
     static void FanUiUpdateEventHandler(AppEvent * aEvent);
 
     /**
-     * @brief Reconcile PercentSetting whenever FanMode changes so the new mode lands
-     *        inside its configured speed band. Invoked from DMPostAttributeChangeCallback.
+     * @brief Reconcile PercentSetting or SpeedSetting when FanMode changes, depending on
+     *        MultiSpeed feature support. Invoked from DMPostAttributeChangeCallback when
+     *        MultiSpeed is disabled.
      */
     void HandleFanModeChange(FanModeEnum aNewFanMode);
 
     /**
      * @brief Mirror PercentSetting writes onto PercentCurrent (when not in Auto and not a no-op).
+     *        FanMode is updated by the cluster on PercentSetting writes; the app does not re-derive it.
      */
     void HandlePercentSettingChange(uint8_t aNewPercentSetting);
 
     /**
-     * @brief Mirror SpeedSetting writes onto SpeedCurrent and refresh FanMode from the new speed.
+     * @brief Derive FanMode from a PercentSetting value using SpeedMax-derived bands.
+     *        Optional customer override hook; default handlers rely on cluster FanMode updates.
+     */
+    FanModeEnum DeriveFanModeFromPercent(Percent percent);
+
+    /**
+     * @brief Mirror SpeedSetting writes onto SpeedCurrent when MultiSpeed is enabled.
      */
     void HandleSpeedSettingChange(uint8_t aNewSpeedSetting);
+
+    /**
+     * @brief Read MultiSpeed support from the FanControl FeatureMap and refresh the
+     *        sSupportsMultiSpeed cache. Call during InitFanControl() (including custom
+     *        overrides) with the chip stack locked. Exposed for customer code; not overridable.
+     */
+    bool ReadSupportsMultiSpeedFromFeatureMap();
+
+    /**
+     * @brief Convert a discrete speed step into a percent using SpeedMax.
+     */
+    static uint8_t SpeedToPercent(uint8_t speed, uint8_t speedMax);
+
+    chip::app::DataModel::Nullable<uint8_t> GetSpeedSetting();
+    chip::app::DataModel::Nullable<Percent> GetPercentSetting();
+
+    /**
+     * @brief Write SpeedSetting synchronously on the Matter thread. No-op when MultiSpeed is
+     *        disabled. Exposed for customer code; not overridable.
+     */
+    Status SetSpeedSetting(uint8_t aNewSpeedSetting);
+
+    /**
+     * @brief Schedule a PercentSetting write on the Matter thread. Exposed for customer code;
+     *        not overridable.
+     */
+    Status SetPercentSetting(Percent aNewPercentSetting);
 
     /**
      * @brief PlatformMgr().ScheduleWork() callback that flushes pending FanControl attribute writes
@@ -132,4 +168,10 @@ public:
 protected:
     /** Override of `BaseApplication::AppInit()`. */
     CHIP_ERROR AppInit() override;
+
+    /**
+     * @brief Write FanMode when it differs from the data model. Used by default attribute
+     *        handlers; exposed for customer overrides that reuse SDK sync behavior.
+     */
+    void SyncFanMode(FanModeEnum aNewFanMode);
 };

--- a/examples/fan-control-app/silabs/include/AppTaskImpl.h
+++ b/examples/fan-control-app/silabs/include/AppTaskImpl.h
@@ -35,6 +35,8 @@ template <typename Derived>
 class AppTaskImpl : public AppTask
 {
 public:
+    using Percent = AppTask::Percent;
+
     // Common AppTask bring up
     CHIP_ERROR AppInit() override { CRTP_OPTIONAL_DISPATCH(AppTaskImpl, Derived, AppInitImpl); }
 
@@ -69,6 +71,12 @@ public:
     void HandlePercentSettingChange(uint8_t aNewPercentSetting)
     {
         CRTP_OPTIONAL_VOID_DISPATCH(AppTaskImpl, Derived, HandlePercentSettingChangeImpl, aNewPercentSetting);
+    }
+
+    // Derive FanMode from PercentSetting
+    FanModeEnum DeriveFanModeFromPercent(Percent percent)
+    {
+        CRTP_OPTIONAL_DISPATCH_ARGS(AppTaskImpl, Derived, DeriveFanModeFromPercentImpl, percent);
     }
 
     // Handle SpeedSetting attribute changes
@@ -106,6 +114,8 @@ private:
     {
         AppTask::HandlePercentSettingChange(aNewPercentSetting);
     }
+
+    FanModeEnum DeriveFanModeFromPercentImpl(Percent percent) { return AppTask::DeriveFanModeFromPercent(percent); }
 
     void HandleSpeedSettingChangeImpl(uint8_t aNewSpeedSetting) { AppTask::HandleSpeedSettingChange(aNewSpeedSetting); }
 

--- a/examples/fan-control-app/silabs/src/AppTask.cpp
+++ b/examples/fan-control-app/silabs/src/AppTask.cpp
@@ -81,75 +81,11 @@ constexpr int kaLowestOffFalse = 1;
 
 LEDWidget sFanLED;
 
-FanModeEnum sFanMode      = FanModeEnum::kOff;
-uint8_t sSpeedMax         = 0;
-uint8_t sPercentCurrent   = 0;
-uint8_t sSpeedCurrent     = 0;
-
-uint8_t SpeedToPercent(uint8_t speed, uint8_t speedMax)
-{
-    if (speedMax == 0)
-    {
-        return 0;
-    }
-    return static_cast<uint8_t>((static_cast<uint16_t>(speed) * 100) / speedMax);
-}
-
-DataModel::Nullable<uint8_t> GetSpeedSetting()
-{
-    DataModel::Nullable<uint8_t> speedSetting;
-
-    Status status = Attributes::SpeedSetting::Get(kFanEndpoint, speedSetting);
-    if (status != Status::Success)
-    {
-        ChipLogError(NotSpecified, "GetSpeedSetting: failed to get SpeedSetting attribute: %d", to_underlying(status));
-    }
-
-    return speedSetting;
-}
-
-DataModel::Nullable<Percent> GetPercentSetting()
-{
-    DataModel::Nullable<Percent> percentSetting;
-
-    Status status = Attributes::PercentSetting::Get(kFanEndpoint, percentSetting);
-    if (status != Status::Success)
-    {
-        ChipLogError(NotSpecified, "GetPercentSetting: failed to get PercentSetting attribute: %d", to_underlying(status));
-    }
-
-    return percentSetting;
-}
-
-void SetPercentSetting(Percent aNewPercentSetting)
-{
-    DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
-    if (!percentSettingNullable.IsNull() && percentSettingNullable.Value() == aNewPercentSetting)
-    {
-        return;
-    }
-
-    AppTask::AttributeUpdateInfo * data = chip::Platform::New<AppTask::AttributeUpdateInfo>();
-    data->percentSetting       = aNewPercentSetting;
-    data->endPoint             = kFanEndpoint;
-    data->isPercentSetting     = true;
-    if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "SetPercentSetting: failed to update PercentSetting attribute");
-    }
-}
-
-void UpdateFanMode()
-{
-    AppTask::AttributeUpdateInfo * data = chip::Platform::New<AppTask::AttributeUpdateInfo>();
-    data->endPoint             = kFanEndpoint;
-    data->fanMode              = sFanMode;
-    data->isFanMode            = true;
-    if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "UpdateFanMode: failed to update FanMode attribute");
-    }
-}
+FanModeEnum sFanMode         = FanModeEnum::kOff;
+uint8_t sSpeedMax            = 0;
+uint8_t sPercentCurrent      = 0;
+uint8_t sSpeedCurrent        = 0;
+bool sSupportsMultiSpeed     = false;
 
 void UpdateFanControlLED()
 {
@@ -217,7 +153,11 @@ CHIP_ERROR AppTask::InitFanControl()
     LinkAppLed(&sFanLED);
 
     PlatformMgr().LockChipStack();
-    Attributes::SpeedMax::Get(kFanEndpoint, &sSpeedMax);
+    ReadSupportsMultiSpeedFromFeatureMap();
+    if (Attributes::SpeedMax::Get(kFanEndpoint, &sSpeedMax) != Status::Success)
+    {
+        sSpeedMax = static_cast<uint8_t>(FAN_MODE_HIGH_UPPER_BOUND);
+    }
     FanModeEnum fanMode = sFanMode;
     Status fanModeStatus = Attributes::FanMode::Get(kFanEndpoint, &fanMode);
     DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
@@ -236,22 +176,197 @@ CHIP_ERROR AppTask::InitFanControl()
     uint8_t percentSettingCB = percentSettingNullable.IsNull() ? 0 : percentSettingNullable.Value();
     AppInstance().HandlePercentSettingChange(percentSettingCB);
 
-    uint8_t speedSettingCB = speedSettingNullable.IsNull() ? 0 : speedSettingNullable.Value();
-    AppInstance().HandleSpeedSettingChange(speedSettingCB);
+    if (sSupportsMultiSpeed)
+    {
+        uint8_t speedSettingCB = speedSettingNullable.IsNull() ? 0 : speedSettingNullable.Value();
+        AppInstance().HandleSpeedSettingChange(speedSettingCB);
+    }
+    else
+    {
+        // Startup runs before BaseApplication marks the app initialized, so
+        // boot-time FanMode writes may not loop back through the DM callback.
+        AppInstance().HandleFanModeChange(sFanMode);
+    }
 
-    // Startup runs before BaseApplication marks the app initialized, so
-    // boot-time FanMode writes may not loop back through the DM callback.
-    AppInstance().HandleFanModeChange(sFanMode);
     PostFanUiUpdateEvent();
 
     return CHIP_NO_ERROR;
 }
 
+bool AppTask::ReadSupportsMultiSpeedFromFeatureMap()
+{
+    uint32_t featureMap = 0;
+    if (Attributes::FeatureMap::Get(kFanEndpoint, &featureMap) != Status::Success)
+    {
+        sSupportsMultiSpeed = false;
+        return false;
+    }
+
+    sSupportsMultiSpeed = (featureMap & to_underlying(Feature::kMultiSpeed)) != 0;
+    return sSupportsMultiSpeed;
+}
+
+uint8_t AppTask::SpeedToPercent(uint8_t speed, uint8_t speedMax)
+{
+    VerifyOrReturnValue(speedMax != 0, 0);
+    return static_cast<uint8_t>((static_cast<uint16_t>(speed) * 100) / speedMax);
+}
+
+DataModel::Nullable<uint8_t> AppTask::GetSpeedSetting()
+{
+    DataModel::Nullable<uint8_t> speedSetting;
+
+    Status status = Attributes::SpeedSetting::Get(kFanEndpoint, speedSetting);
+    VerifyOrReturnValue(status == Status::Success, speedSetting);
+    return speedSetting;
+}
+
+DataModel::Nullable<Percent> AppTask::GetPercentSetting()
+{
+    DataModel::Nullable<Percent> percentSetting;
+
+    Status status = Attributes::PercentSetting::Get(kFanEndpoint, percentSetting);
+    VerifyOrReturnValue(status == Status::Success, percentSetting, ChipLogError(NotSpecified, "GetPercentSetting: failed to get PercentSetting attribute: %d", to_underlying(status)));
+
+    return percentSetting;
+}
+
+Status AppTask::SetPercentSetting(Percent aNewPercentSetting)
+{
+    DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
+    VerifyOrReturnValue(!percentSettingNullable.IsNull() && percentSettingNullable.Value() == aNewPercentSetting, Status::Success);
+
+    AttributeUpdateInfo * data = chip::Platform::New<AttributeUpdateInfo>();
+    data->percentSetting       = aNewPercentSetting;
+    data->endPoint             = kFanEndpoint;
+    data->isPercentSetting     = true;
+    if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "SetPercentSetting: failed to update PercentSetting attribute");
+        chip::Platform::Delete(data);
+        return Status::Failure;
+    }
+
+    return Status::Success;
+}
+
+Status AppTask::SetSpeedSetting(uint8_t aNewSpeedSetting)
+{
+    VerifyOrReturnValue(sSupportsMultiSpeed, Status::Success);
+
+    DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
+    VerifyOrReturnValue(!speedSettingNullable.IsNull() && speedSettingNullable.Value() == aNewSpeedSetting, Status::Success);
+
+    Status status = Attributes::SpeedSetting::Set(kFanEndpoint, aNewSpeedSetting);
+    VerifyOrReturnValue(status == Status::Success, status, ChipLogError(NotSpecified, "SetSpeedSetting: failed to set SpeedSetting attribute: %d", to_underlying(status)));
+
+    return status;
+}
+
+void AppTask::SyncFanMode(FanModeEnum aNewFanMode)
+{
+    FanModeEnum currentFanMode;
+    if (Attributes::FanMode::Get(kFanEndpoint, &currentFanMode) == Status::Success && currentFanMode == aNewFanMode)
+    {
+        sFanMode = aNewFanMode;
+        return;
+    }
+
+    AttributeUpdateInfo * data = chip::Platform::New<AttributeUpdateInfo>();
+    data->endPoint      = kFanEndpoint;
+    data->fanMode       = aNewFanMode;
+    data->isFanMode     = true;
+    if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "SyncFanMode: failed to update FanMode attribute");
+        chip::Platform::Delete(data);
+        return;
+    }
+
+    sFanMode = aNewFanMode;
+}
+
+FanModeEnum AppTask::DeriveFanModeFromPercent(Percent percent)
+{
+    VerifyOrReturnValue(percent != 0, FanModeEnum::kOff);
+
+    const uint8_t lowPercentMax = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax);
+    VerifyOrReturnValue(percent > lowPercentMax, FanModeEnum::kLow);
+
+    const uint8_t mediumPercentMax = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax);
+    VerifyOrReturnValue(percent > mediumPercentMax, FanModeEnum::kMedium);
+
+    return FanModeEnum::kHigh;
+}
+
 void AppTask::HandleFanModeChange(FanModeEnum aNewFanMode)
 {
     ChipLogDetail(NotSpecified, "HandleFanModeChange: %d", to_underlying(aNewFanMode));
-    // If PercentSetting is null, use an out-of-bounds value to force an update.
+
+    if (sSupportsMultiSpeed)
+    {
+        uint8_t speedSettingCurrent = GetSpeedSetting().ValueOr(101);
+        uint8_t highSpeedSetting =
+            (sSpeedMax >= FAN_MODE_HIGH_LOWER_BOUND) ? static_cast<uint8_t>(FAN_MODE_HIGH_LOWER_BOUND) : sSpeedMax;
+
+        switch (aNewFanMode)
+        {
+        case FanModeEnum::kOff: {
+            if (speedSettingCurrent != 0)
+            {
+                SetSpeedSetting(0);
+            }
+            break;
+        }
+        case FanModeEnum::kLow: {
+            if (speedSettingCurrent < FAN_MODE_LOW_LOWER_BOUND || speedSettingCurrent > FAN_MODE_LOW_UPPER_BOUND)
+            {
+                SetSpeedSetting(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND));
+            }
+            break;
+        }
+        case FanModeEnum::kMedium: {
+            if (speedSettingCurrent < FAN_MODE_MEDIUM_LOWER_BOUND || speedSettingCurrent > FAN_MODE_MEDIUM_UPPER_BOUND)
+            {
+                SetSpeedSetting(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND));
+            }
+            break;
+        }
+        case FanModeEnum::kOn:
+        case FanModeEnum::kHigh: {
+            if (speedSettingCurrent < highSpeedSetting || speedSettingCurrent > sSpeedMax)
+            {
+                SetSpeedSetting(highSpeedSetting);
+            }
+            break;
+        }
+        case FanModeEnum::kSmart:
+        case FanModeEnum::kAuto: {
+            ChipLogProgress(NotSpecified, "HandleFanModeChange: Auto");
+            break;
+        }
+        case FanModeEnum::kUnknownEnumValue: {
+            ChipLogProgress(NotSpecified, "HandleFanModeChange: Unknown");
+            break;
+        }
+        default:
+            break;
+        }
+        return;
+    }
+
     uint8_t percentSettingCurrent = GetPercentSetting().ValueOr(101);
+    const uint8_t lowPercentMin   = 1;
+    const uint8_t lowPercentMax   = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax);
+    const uint8_t mediumPercentMin =
+        SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND), sSpeedMax);
+    const uint8_t mediumPercentMax =
+        SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax);
+    const uint8_t highPercentMin =
+        SpeedToPercent(static_cast<uint8_t>((sSpeedMax >= FAN_MODE_HIGH_LOWER_BOUND) ? FAN_MODE_HIGH_LOWER_BOUND : sSpeedMax),
+                       sSpeedMax);
+    const uint8_t highPercentMax = 100;
+
     switch (aNewFanMode)
     {
     case FanModeEnum::kOff: {
@@ -262,17 +377,13 @@ void AppTask::HandleFanModeChange(FanModeEnum aNewFanMode)
         break;
     }
     case FanModeEnum::kLow: {
-        const uint8_t lowPercentMin = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND), sSpeedMax);
-        const uint8_t lowPercentMax = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_UPPER_BOUND), sSpeedMax);
         if (percentSettingCurrent < lowPercentMin || percentSettingCurrent > lowPercentMax)
         {
-            SetPercentSetting(lowPercentMin);
+            SetPercentSetting(SpeedToPercent(static_cast<uint8_t>(FAN_MODE_LOW_LOWER_BOUND), sSpeedMax));
         }
         break;
     }
     case FanModeEnum::kMedium: {
-        const uint8_t mediumPercentMin = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_LOWER_BOUND), sSpeedMax);
-        const uint8_t mediumPercentMax = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_MEDIUM_UPPER_BOUND), sSpeedMax);
         if (percentSettingCurrent < mediumPercentMin || percentSettingCurrent > mediumPercentMax)
         {
             SetPercentSetting(mediumPercentMin);
@@ -281,8 +392,6 @@ void AppTask::HandleFanModeChange(FanModeEnum aNewFanMode)
     }
     case FanModeEnum::kOn:
     case FanModeEnum::kHigh: {
-        const uint8_t highPercentMin = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_HIGH_LOWER_BOUND), sSpeedMax);
-        const uint8_t highPercentMax = SpeedToPercent(static_cast<uint8_t>(FAN_MODE_HIGH_UPPER_BOUND), sSpeedMax);
         if (percentSettingCurrent < highPercentMin || percentSettingCurrent > highPercentMax)
         {
             SetPercentSetting(highPercentMin);
@@ -308,54 +417,42 @@ void AppTask::HandlePercentSettingChange(uint8_t aNewPercentSetting)
     VerifyOrReturn(aNewPercentSetting != sPercentCurrent);
     VerifyOrReturn(sFanMode != FanModeEnum::kAuto);
     ChipLogDetail(NotSpecified, "HandlePercentSettingChange: %d", aNewPercentSetting);
-    sPercentCurrent = aNewPercentSetting;
 
     AppTask::AttributeUpdateInfo * data = chip::Platform::New<AppTask::AttributeUpdateInfo>();
     data->endPoint             = kFanEndpoint;
-    data->percentCurrent       = sPercentCurrent;
+    data->percentCurrent       = aNewPercentSetting;
     data->isPercentCurrent     = true;
 
     if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "HandlePercentSettingChange: failed to set PercentCurrent attribute");
+        chip::Platform::Delete(data);
+        return;
     }
+
+    sPercentCurrent = aNewPercentSetting;
 }
 
 void AppTask::HandleSpeedSettingChange(uint8_t aNewSpeedSetting)
 {
+    VerifyOrReturn(sSupportsMultiSpeed);
     VerifyOrReturn(aNewSpeedSetting != sSpeedCurrent);
     VerifyOrReturn(sFanMode != FanModeEnum::kAuto);
     ChipLogDetail(NotSpecified, "HandleSpeedSettingChange: %d", aNewSpeedSetting);
-    sSpeedCurrent = aNewSpeedSetting;
 
     AppTask::AttributeUpdateInfo * data = chip::Platform::New<AppTask::AttributeUpdateInfo>();
     data->endPoint             = kFanEndpoint;
-    data->speedCurrent         = sSpeedCurrent;
+    data->speedCurrent         = aNewSpeedSetting;
     data->isSpeedCurrent       = true;
 
     if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "HandleSpeedSettingChange: failed to set SpeedCurrent attribute");
+        chip::Platform::Delete(data);
+        return;
     }
 
-    // Update the fan mode as per the current speed.
-    if (sSpeedCurrent == 0)
-    {
-        sFanMode = FanModeEnum::kOff;
-    }
-    else if (sSpeedCurrent <= FAN_MODE_LOW_UPPER_BOUND)
-    {
-        sFanMode = FanModeEnum::kLow;
-    }
-    else if (sSpeedCurrent <= FAN_MODE_MEDIUM_UPPER_BOUND)
-    {
-        sFanMode = FanModeEnum::kMedium;
-    }
-    else if (sSpeedCurrent <= FAN_MODE_HIGH_UPPER_BOUND)
-    {
-        sFanMode = FanModeEnum::kHigh;
-    }
-    UpdateFanMode();
+    sSpeedCurrent = aNewSpeedSetting;
 }
 
 CHIP_ERROR AppTask::StartAppTask()
@@ -399,35 +496,63 @@ Status AppTask::HandleStep(StepDirectionEnum aDirection, bool aWrap, bool aLowes
 
     VerifyOrReturnError(aDirection != StepDirectionEnum::kUnknownEnumValue, Status::InvalidCommand);
 
-    // if aLowestOff is true, Step command can reduce the fan speed to 0, else 1.
     uint8_t speedMin = aLowestOff ? kaLowestOffTrue : kaLowestOffFalse;
 
-    DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
+    if (sSupportsMultiSpeed)
+    {
+        DataModel::Nullable<uint8_t> speedSettingNullable = GetSpeedSetting();
+        uint8_t curSpeedSetting                         = speedSettingNullable.IsNull() ? speedMin : speedSettingNullable.Value();
 
-    uint8_t curSpeedSetting = speedSettingNullable.IsNull() ? speedMin : speedSettingNullable.Value();
+        switch (aDirection)
+        {
+        case StepDirectionEnum::kIncrease: {
+            if (curSpeedSetting >= sSpeedMax)
+            {
+                curSpeedSetting = aWrap ? speedMin : sSpeedMax;
+            }
+            else
+            {
+                curSpeedSetting++;
+            }
+            break;
+        }
+        case StepDirectionEnum::kDecrease: {
+            if (curSpeedSetting <= speedMin)
+            {
+                curSpeedSetting = aWrap ? sSpeedMax : speedMin;
+            }
+            else
+            {
+                curSpeedSetting--;
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+        }
 
-    // increase or decrease the fan speed by one step
+        return SetSpeedSetting(curSpeedSetting);
+    }
+
+    DataModel::Nullable<Percent> percentSettingNullable = GetPercentSetting();
+    Percent curPercentSetting = percentSettingNullable.IsNull() ? static_cast<Percent>(speedMin) : percentSettingNullable.Value();
+
     switch (aDirection)
     {
     case StepDirectionEnum::kIncrease: {
-        if (curSpeedSetting >= sSpeedMax)
+        curPercentSetting++;
+        if (curPercentSetting > 100)
         {
-            curSpeedSetting = aWrap ? speedMin : sSpeedMax;
-        }
-        else
-        {
-            curSpeedSetting++;
+            curPercentSetting = aWrap ? static_cast<Percent>(speedMin) : 100;
         }
         break;
     }
     case StepDirectionEnum::kDecrease: {
-        if (curSpeedSetting <= speedMin)
+        curPercentSetting--;
+        if (curPercentSetting < speedMin)
         {
-            curSpeedSetting = aWrap ? sSpeedMax : speedMin;
-        }
-        else
-        {
-            curSpeedSetting--;
+            curPercentSetting = aWrap ? 100 : static_cast<Percent>(speedMin);
         }
         break;
     }
@@ -436,21 +561,7 @@ Status AppTask::HandleStep(StepDirectionEnum aDirection, bool aWrap, bool aLowes
     }
     }
 
-    // Convert SpeedSetting to PercentSetting
-    uint8_t curPercentSetting = SpeedToPercent(curSpeedSetting, sSpeedMax);
-
-    AppTask::AttributeUpdateInfo * data = chip::Platform::New<AppTask::AttributeUpdateInfo>();
-    data->percentSetting       = curPercentSetting;
-    data->endPoint             = kFanEndpoint;
-    data->isPercentSetting     = true;
-
-    if (PlatformMgr().ScheduleWork(&CustomerAppTask::UpdateClusterState, reinterpret_cast<intptr_t>(data)) != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "AppTask::HandleStep: Failed to update PercentSetting attribute");
-        return Status::Failure;
-    }
-
-    return Status::Success;
+    return SetPercentSetting(curPercentSetting);
 }
 
 void AppTask::UpdateClusterState(intptr_t arg)
@@ -507,12 +618,19 @@ void AppTask::DMPostAttributeChangeCallback(const ConcreteAttributePath & attrib
         break;
     }
     case Attributes::SpeedSetting::Id: {
-        AppInstance().HandleSpeedSettingChange(*value);
+        if (sSupportsMultiSpeed)
+        {
+            AppInstance().HandleSpeedSettingChange(*value);
+        }
         break;
     }
     case Attributes::FanMode::Id: {
         sFanMode = *reinterpret_cast<FanModeEnum *>(value);
-        AppInstance().HandleFanModeChange(sFanMode);
+        // MultiSpeed: cluster keeps FanMode / PercentSetting / SpeedSetting consistent.
+        if (!sSupportsMultiSpeed)
+        {
+            AppInstance().HandleFanModeChange(sFanMode);
+        }
         PostFanUiUpdateEvent();
         break;
     }


### PR DESCRIPTION


cp #1081

### Summary

This PR fixes the cascading attribute handling in Fan Control app.

The app was remapping FanMode, PercentSetting, and SpeedSetting in ways that fought the cluster’s own cascade logic, causing write/read mismatches and missing subscription reports.

**Problem**

- Writing PercentSetting=1 was read back as 10 because a speed→fan-mode→percent remap overwrote small percent values.
- FanMode descending to Off produced 3 FanMode reports but only 2 PercentSetting reports (3 != 2), failing the report-count check.

**Fix**
Refactor FanControlManager to support feature-gated, directional synchronization between FanMode, SpeedSetting, and PercentSetting.

- MultiSpeed enabled

  - Direct FanMode writes now update SpeedSetting only.
  - The Fan Control cluster derives PercentSetting from SpeedSetting.
  - SpeedSetting changes synchronize only FanMode and SpeedCurrent. They no longer remap values back to other settings, preventing circular updates.
  - Direct PercentSetting writes update only PercentCurrent.

- MultiSpeed disabled

  - Direct FanMode writes map to PercentSetting using percentage bands derived dynamically from the current SpeedMax value via SpeedToPercent().
  - This replaces the previous fixed thresholds (1–33%, 34–66%, and 67–100%), allowing the mapping to adapt to the configured maximum speed.

- Additional changes

  - SetSpeedSetting() now uses the synchronous Attributes::SpeedSetting::Set() API.
  - This ensures the application delegate is invoked before the cluster's FanMode callback, allowing the expected PercentSetting subscription report to be emitted when transitioning to Off.

### Related issues

[MATTER-6315](https://jira.silabs.com/browse/MATTER-6315)

### Testing

Build and flash fan-control app on BRD4338A.
Run TC-FAN-3.1 (TC_FAN_3_1.py) and ensure that the test-case passes.

