### PR TITLE
[SL-ONLY]Add simg301/brd4407a to silabs ci

### DIFF
--- a/.github/silabs-builds-simg301.json
+++ b/.github/silabs-builds-simg301.json
@@ -1,0 +1,12 @@
+{
+    "standard": {
+        "default": [
+            {
+                "boards": [
+                    "BRD4407A"
+                ],
+                "arguments": ["--docker"]
+            }
+        ]
+    }
+}

--- a/.github/workflows/silabs-common-build.yaml
+++ b/.github/workflows/silabs-common-build.yaml
@@ -23,7 +23,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                platform: [mg24, mgm24, mg26, siwx]
+                platform: [mg24, mgm24, mg26, siwx, simg301]
 
         steps:
             - name: Checkout
@@ -42,7 +42,8 @@ jobs:
                       ${{ matrix.platform == 'mg24' && './.github/silabs-builds-mg24.json' ||
                           matrix.platform == 'mgm24' && './.github/silabs-builds-mgm24.json' ||
                           matrix.platform == 'mg26' && './.github/silabs-builds-mg26.json' ||
-                          matrix.platform == 'siwx' && './.github/silabs-builds-siwx.json' }}
+                          matrix.platform == 'siwx' && './.github/silabs-builds-siwx.json' ||
+                          matrix.platform == 'simg301' && './.github/silabs-builds-simg301.json' }}
                   example-app: ${{ inputs.example-app }}
                   path-to-example-app: examples/${{ inputs.example-app }}/silabs
                   build-script: "./scripts/examples/gn_silabs_example.sh"

--- a/.github/workflows/silabs-common-build.yaml
+++ b/.github/workflows/silabs-common-build.yaml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-efr32:206
+            image: ghcr.io/project-chip/chip-build-efr32:208
 
         strategy:
             fail-fast: false

--- a/.github/workflows/silabs-custom-thread-build.yaml
+++ b/.github/workflows/silabs-custom-thread-build.yaml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-efr32:206
+            image: ghcr.io/project-chip/chip-build-efr32:208
         steps:
             - name: Checkout
               uses: actions/checkout@v7


### PR DESCRIPTION
### Summary
A Simg301 board is now supported with GN build.
We can now  add it to the CI in this repo to validate CSA/matter sdk changes are not breaking series3 platform.

### Related issues
n/a

### Testing
CI will try to build apps for brd4407a
