### PR TITLE
[SL-UP] MATTER-5896 : Translate common bootloader errors to human readable strings

### DIFF
--- a/src/platform/silabs/BootloaderError.cpp
+++ b/src/platform/silabs/BootloaderError.cpp
@@ -1,0 +1,69 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <platform/silabs/BootloaderError.h>
+
+#include <lib/support/logging/CHIPLogging.h>
+
+extern "C" {
+#include "btl_errorcode.h"
+}
+
+namespace chip {
+namespace DeviceLayer {
+namespace Silabs {
+
+const char * BootloaderErrorCodeName(int32_t errorCode)
+{
+    switch (errorCode)
+    {
+    case BOOTLOADER_ERROR_STORAGE_INVALID_SLOT:
+        return "BOOTLOADER_ERROR_STORAGE_INVALID_SLOT";
+    case BOOTLOADER_ERROR_STORAGE_INVALID_ADDRESS:
+        return "BOOTLOADER_ERROR_STORAGE_INVALID_ADDRESS";
+    case BOOTLOADER_ERROR_STORAGE_NEEDS_ALIGN:
+        return "BOOTLOADER_ERROR_STORAGE_NEEDS_ALIGN";
+    case BOOTLOADER_ERROR_PARSER_UNEXPECTED:
+        return "BOOTLOADER_ERROR_PARSER_UNEXPECTED";
+    case BOOTLOADER_ERROR_PARSER_UNKNOWN_TAG:
+        return "BOOTLOADER_ERROR_PARSER_UNKNOWN_TAG";
+    case BOOTLOADER_ERROR_PARSER_VERSION:
+        return "BOOTLOADER_ERROR_PARSER_VERSION";
+    case BOOTLOADER_ERROR_PARSER_FILETYPE:
+        return "BOOTLOADER_ERROR_PARSER_FILETYPE";
+    default:
+        return nullptr;
+    }
+}
+
+void LogBootloaderApiError(const char * apiName, int32_t errorCode)
+{
+    const char * errorName = BootloaderErrorCodeName(errorCode);
+    if (errorName != nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "%s() error: %ld (%s)", apiName, errorCode, errorName);
+    }
+    else
+    {
+        ChipLogError(SoftwareUpdate, "%s() error: %ld", apiName, errorCode);
+    }
+}
+
+} // namespace Silabs
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/BootloaderError.cpp
+++ b/src/platform/silabs/BootloaderError.cpp
@@ -20,13 +20,12 @@
 
 #include <lib/support/logging/CHIPLogging.h>
 
+#if CHIP_ERROR_LOGGING
 extern "C" {
 #include "btl_errorcode.h"
 }
 
-namespace chip {
-namespace DeviceLayer {
-namespace Silabs {
+namespace {
 
 const char * BootloaderErrorCodeName(int32_t errorCode)
 {
@@ -51,8 +50,16 @@ const char * BootloaderErrorCodeName(int32_t errorCode)
     }
 }
 
-void LogBootloaderApiError(const char * apiName, int32_t errorCode)
+} // namespace
+#endif // CHIP_ERROR_LOGGING
+
+namespace chip {
+namespace DeviceLayer {
+namespace Silabs {
+
+void LogBootloaderApiError([[maybe_unused]] const char * apiName, [[maybe_unused]] int32_t errorCode)
 {
+#if CHIP_ERROR_LOGGING
     const char * errorName = BootloaderErrorCodeName(errorCode);
     if (errorName != nullptr)
     {
@@ -62,6 +69,7 @@ void LogBootloaderApiError(const char * apiName, int32_t errorCode)
     {
         ChipLogError(SoftwareUpdate, "%s() error: %ld", apiName, errorCode);
     }
+#endif // CHIP_ERROR_LOGGING
 }
 
 } // namespace Silabs

--- a/src/platform/silabs/BootloaderError.h
+++ b/src/platform/silabs/BootloaderError.h
@@ -1,0 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Silabs {
+
+const char * BootloaderErrorCodeName(int32_t errorCode);
+
+void LogBootloaderApiError(const char * apiName, int32_t errorCode);
+
+} // namespace Silabs
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/BootloaderError.h
+++ b/src/platform/silabs/BootloaderError.h
@@ -24,8 +24,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Silabs {
 
-const char * BootloaderErrorCodeName(int32_t errorCode);
-
 void LogBootloaderApiError(const char * apiName, int32_t errorCode);
 
 } // namespace Silabs

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -174,6 +174,7 @@ static_library("efr32") {
     public_deps += [ "${silabs_platform_dir}/multi-ota:multi-ota-efr32" ]
   } else if (chip_enable_ota_requestor) {
     sources += [
+      "${silabs_platform_dir}/BootloaderError.cpp",
       "${silabs_platform_dir}/OTAImageProcessorImpl.h",
       "OTAImageProcessorImpl.cpp",
     ]

--- a/src/platform/silabs/efr32/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/efr32/OTAImageProcessorImpl.cpp
@@ -57,6 +57,7 @@ static chip::OTAImageProcessorImpl gImageProcessor;
 
 using namespace chip::DeviceLayer;
 using namespace chip::DeviceLayer::Internal;
+using chip::DeviceLayer::Silabs::LogBootloaderApiError;
 
 namespace chip {
 

--- a/src/platform/silabs/efr32/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/efr32/OTAImageProcessorImpl.cpp
@@ -21,6 +21,7 @@
 #include <cinttypes>
 #include <platform/silabs/OTAImageProcessorImpl.h>
 #include <platform/silabs/SilabsConfig.h>
+#include <platform/silabs/BootloaderError.h>
 
 #if defined(SL_WIFI) && SL_WIFI
 #include <platform/silabs/wifi/ncp/spi_multiplex.h>
@@ -172,7 +173,7 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
     WRAP_BL_DFU_CALL(err = bootloader_init())
     if (err != SL_BOOTLOADER_OK)
     {
-        ChipLogError(SoftwareUpdate, "bootloader_init Failed error: %" PRId32, err);
+        LogBootloaderApiError("bootloader_init", static_cast<int32_t>(err));
         SILABS_TRACE_END_ERROR(TimeTraceOperation::kImageUpload, CHIP_ERROR_INTERNAL);
     }
 
@@ -232,7 +233,7 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
 #endif // SL_BTLCTRL_MUX
         if (err)
         {
-            ChipLogError(SoftwareUpdate, "bootloader_eraseWriteStorage() error: %" PRIu32, err);
+            LogBootloaderApiError("bootloader_eraseWriteStorage", static_cast<int32_t>(err));
             imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
             SILABS_TRACE_END_ERROR(TimeTraceOperation::kImageUpload, CHIP_ERROR_WRITE_FAILED);
             return;
@@ -293,7 +294,7 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
 
     if (err != SL_BOOTLOADER_OK)
     {
-        ChipLogError(SoftwareUpdate, "bootloader_verifyImage() error: %" PRIu32, err);
+        LogBootloaderApiError("bootloader_verifyImage", static_cast<int32_t>(err));
         // Call the OTARequestor API to reset the state
         GetRequestorInstance()->CancelImageUpdate();
 #if defined(SL_BTLCTRL_MUX) && SL_BTLCTRL_MUX
@@ -312,7 +313,7 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
     UnlockRadioProcessing();
     if (err != SL_BOOTLOADER_OK)
     {
-        ChipLogError(SoftwareUpdate, "bootloader_setImageToBootload() error: %" PRIu32, err);
+        LogBootloaderApiError("bootloader_setImageToBootload", static_cast<int32_t>(err));
         // Call the OTARequestor API to reset the state
         GetRequestorInstance()->CancelImageUpdate();
 #if defined(SL_BTLCTRL_MUX) && SL_BTLCTRL_MUX
@@ -419,7 +420,7 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
 #endif // SL_BTLCTRL_MUX
             if (err)
             {
-                ChipLogError(SoftwareUpdate, "bootloader_eraseWriteStorage() error: %" PRIu32, err);
+                LogBootloaderApiError("bootloader_eraseWriteStorage", static_cast<int32_t>(err));
                 imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
                 return;
             }

--- a/src/platform/silabs/multi-ota/BUILD.gn
+++ b/src/platform/silabs/multi-ota/BUILD.gn
@@ -63,7 +63,10 @@ source_set("multi-ota-common") {
 }
 
 source_set("multi-ota-efr32") {
-  sources = [ "OTAFirmwareProcessor.cpp" ]
+  sources = [
+    "${silabs_platform_dir}/BootloaderError.cpp",
+    "OTAFirmwareProcessor.cpp",
+  ]
   deps = [ "${chip_root}/src/app/clusters/ota-requestor:interface" ]
   public_deps = [
     ":multi-ota-common",

--- a/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFirmwareProcessor.cpp
@@ -18,6 +18,7 @@
 
 #include <platform/silabs/multi-ota/OTAFirmwareProcessor.h>
 #include <platform/silabs/multi-ota/OTAMultiImageProcessorImpl.h>
+#include <platform/silabs/BootloaderError.h>
 
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 
@@ -112,7 +113,7 @@ CHIP_ERROR OTAFirmwareProcessor::ProcessInternal(ByteSpan & block)
 #endif // SL_BTLCTRL_MUX
             if (err)
             {
-                ChipLogError(SoftwareUpdate, "bootloader_eraseWriteStorage() error: %ld", err);
+                LogBootloaderApiError("bootloader_eraseWriteStorage", static_cast<int32_t>(err));
                 return CHIP_ERROR_CANCELLED;
             }
             mWriteOffset += kAlignmentBytes;
@@ -148,7 +149,7 @@ CHIP_ERROR OTAFirmwareProcessor::ApplyAction()
     CORE_CRITICAL_SECTION(err = bootloader_verifyImage(mSlotId, NULL);)
     if (err != SL_BOOTLOADER_OK)
     {
-        ChipLogError(SoftwareUpdate, "bootloader_verifyImage() error: %ld", err);
+        LogBootloaderApiError("bootloader_verifyImage", static_cast<int32_t>(err));
         // Call the OTARequestor API to reset the state
         GetRequestorInstance()->CancelImageUpdate();
 #if SL_BTLCTRL_MUX
@@ -165,7 +166,7 @@ CHIP_ERROR OTAFirmwareProcessor::ApplyAction()
     CORE_CRITICAL_SECTION(err = bootloader_setImageToBootload(mSlotId);)
     if (err != SL_BOOTLOADER_OK)
     {
-        ChipLogError(SoftwareUpdate, "bootloader_setImageToBootload() error: %ld", err);
+        LogBootloaderApiError("bootloader_setImageToBootload", static_cast<int32_t>(err));
         // Call the OTARequestor API to reset the state
         GetRequestorInstance()->CancelImageUpdate();
 #if SL_BTLCTRL_MUX


### PR DESCRIPTION
### Summary
Added a better way to dereference the bootloader failures, making it easier to debug, 

Bootloader error codes are already provided in the btl_errorcode.h, so they can be used to translate the error codes to user-readable strings. 


Maybe a better way is to get it in CSA master, v1.6 and v1.6.1. 

### Related issues
[MATTER-5896](https://jira.silabs.com/browse/MATTER-5896)

### Testing

OTA test with CMP app ( failing intentionally as the LZMA compression is not done)
`[0000:07:05.635][error][SWU] bootloader_eraseWriteStorage() error: 1026 (BOOTLOADER_ERROR_STORAGE_INVALID_ADDRESS)`
